### PR TITLE
Ensure stream messages are always ordered

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1006,10 +1006,7 @@ class Server:
                             break
                         handler = self.stream_handlers[op]
                         if iscoroutinefunction(handler):
-                            self._ongoing_background_tasks.call_soon(
-                                handler, **merge(extra, msg)
-                            )
-                            await asyncio.sleep(0)
+                            await handler(**merge(extra, msg))
                         else:
                             handler(**merge(extra, msg))
                     else:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1518,6 +1518,14 @@ class ConnectionPool:
 
         return _().__await__()
 
+    async def __aenter__(self):
+        await self
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()
+        return
+
     async def start(self) -> None:
         # Invariant: semaphore._value == limit - open - _n_connecting
         self.semaphore = asyncio.Semaphore(self.limit)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5650,12 +5650,12 @@ class Scheduler(SchedulerState, ServerNode):
             self.idle_task_count.discard(ws)
             self.saturated.discard(ws)
 
-    async def handle_request_refresh_who_has(
+    def handle_request_refresh_who_has(
         self, keys: Iterable[str], worker: str, stimulus_id: str
     ) -> None:
-        """Asynchronous request (through bulk comms) from a Worker to refresh the
-        who_has for some keys. Not to be confused with scheduler.who_has, which is a
-        synchronous RPC request from a Client.
+        """Request from a Worker to refresh the
+        who_has for some keys. Not to be confused with scheduler.who_has, which
+        is a dedicated comm RPC request from a Client.
         """
         who_has = {}
         free_keys = []

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
+import random
 import socket
 import sys
 import threading
@@ -1388,7 +1389,7 @@ async def test_messages_are_ordered_bsend():
     ledger = []
 
     async def async_handler(val):
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01 * random.random())
         ledger.append(val)
 
     def sync_handler(val):
@@ -1428,7 +1429,7 @@ async def test_messages_are_ordered_raw():
     ledger = []
 
     async def async_handler(val):
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01 * random.random())
         ledger.append(val)
 
     def sync_handler(val):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -1388,7 +1388,7 @@ async def test_messages_are_ordered_bsend():
     ledger = []
 
     async def async_handler(val):
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.01)
         ledger.append(val)
 
     def sync_handler(val):


### PR DESCRIPTION
Some motivation for this over here https://github.com/dask/distributed/pull/8049#issuecomment-1660422106

Essentially this breaks ordering of operations as soon as a handler is async. With this change, we'd ensure ordering within a given BatchedStream regardless of whether the handlers are sync or async.
I think this is a much easier to reason about behavior (but I have no idea where this will blow up... )