### PR TITLE
Rebalance ci1 markers

### DIFF
--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -13,6 +13,8 @@ from dask.dataframe._compat import PANDAS_GE_200, tm
 from dask.dataframe.utils import assert_eq
 from dask.utils_test import hlg_layer_topological
 
+pytestmark = pytest.mark.ci1
+
 
 @pytest.fixture(params=[0, 0.3, 1], ids=["none", "some", "all"])
 def lose_annotations(request):

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -29,6 +29,8 @@ from distributed.utils_test import (
     slowsum,
 )
 
+pytestmark = pytest.mark.ci1
+
 # All tests here are slow in some way
 setup_module = nodebug_setup_module
 teardown_module = nodebug_teardown_module


### PR DESCRIPTION
This should move about ~5min of runtime from non-ci1 to ci1 which should roughly make both runs the same length