### PR TITLE
Immediately remove worker from scheduler on `Worker.close`

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1537,6 +1537,8 @@ class Worker(BaseWorker, ServerNode):
             logger.info("Not waiting on executor to close")
         self.status = Status.closing
         self.batched_send({"op": "close-stream"})
+        if self.batched_stream:
+            await self.batched_stream.close()
 
         # Stop callbacks before giving up control in any `await`.
         # We don't want to heartbeat while closing.
@@ -1608,9 +1610,6 @@ class Worker(BaseWorker, ServerNode):
             await asyncio.sleep(0.2)
 
  
-        if self.batched_stream:
-            with suppress(TimeoutError):
-                await self.batched_stream.close(timedelta(seconds=timeout))
 
         for executor in self.executors.values():
             if executor is utils._offload_executor:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -26,8 +26,6 @@ from collections.abc import (
     MutableMapping,
 )
 from concurrent.futures import Executor
-from contextlib import suppress
-from datetime import timedelta
 from functools import wraps
 from inspect import isawaitable
 from typing import (
@@ -1608,8 +1606,6 @@ class Worker(BaseWorker, ServerNode):
         # trying to send closing message.
         if self._protocol == "ucx":  # pragma: no cover
             await asyncio.sleep(0.2)
-
- 
 
         for executor in self.executors.values():
             if executor is utils._offload_executor:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1600,13 +1600,6 @@ class Worker(BaseWorker, ServerNode):
 
         self.stop_services()
 
-        # Give some time for a UCX scheduler to complete closing endpoints
-        # before closing self.batched_stream, otherwise the local endpoint
-        # may be closed too early and errors be raised on the scheduler when
-        # trying to send closing message.
-        if self._protocol == "ucx":  # pragma: no cover
-            await asyncio.sleep(0.2)
-
         for executor in self.executors.values():
             if executor is utils._offload_executor:
                 continue  # Never shutdown the offload executor

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1536,6 +1536,7 @@ class Worker(BaseWorker, ServerNode):
         if not executor_wait:
             logger.info("Not waiting on executor to close")
         self.status = Status.closing
+        self.batched_send({"op": "close-stream"})
 
         # Stop callbacks before giving up control in any `await`.
         # We don't want to heartbeat while closing.
@@ -1606,8 +1607,7 @@ class Worker(BaseWorker, ServerNode):
         if self._protocol == "ucx":  # pragma: no cover
             await asyncio.sleep(0.2)
 
-        self.batched_send({"op": "close-stream"})
-
+ 
         if self.batched_stream:
             with suppress(TimeoutError):
                 await self.batched_stream.close(timedelta(seconds=timeout))


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
