### PR TITLE
Remove `dumps_task`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -126,7 +126,7 @@ from distributed.utils_comm import (
 )
 from distributed.utils_perf import disable_gc_diagnosis, enable_gc_diagnosis
 from distributed.variable import VariableExtension
-from distributed.worker import dumps_task
+from distributed.worker import _normalize_task
 
 if TYPE_CHECKING:
     # TODO import from typing (requires Python >=3.10)
@@ -155,6 +155,8 @@ Recs: TypeAlias = dict[str, TaskStateState]
 Msgs: TypeAlias = dict[str, list[dict[str, Any]]]
 # (recommendations, client messages, worker messages)
 RecsMsgs: TypeAlias = tuple[Recs, Msgs, Msgs]
+
+T_runspec: TypeAlias = tuple[Callable, tuple, dict[str, Any]]
 
 logger = logging.getLogger(__name__)
 LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
@@ -1176,7 +1178,7 @@ class TaskState:
     #: "pure data" (such as, for example, a piece of data loaded in the scheduler using
     #: :meth:`Client.scatter`).  A "pure data" task cannot be computed again if its
     #: value is lost.
-    run_spec: object
+    run_spec: T_runspec | None
 
     #: The priority provides each task with a relative ranking which is used to break
     #: ties when many tasks are being considered for execution.
@@ -1375,7 +1377,7 @@ class TaskState:
     def __init__(
         self,
         key: str,
-        run_spec: object,
+        run_spec: T_runspec | None,
         state: TaskStateState,
     ):
         self.key = key
@@ -1787,7 +1789,7 @@ class SchedulerState:
     def new_task(
         self,
         key: str,
-        spec: object,
+        spec: T_runspec | None,
         state: TaskStateState,
         computation: Computation | None = None,
     ) -> TaskState:
@@ -3343,10 +3345,7 @@ class SchedulerState:
                 dts.key: [ws.address for ws in dts.who_has] for dts in ts.dependencies
             },
             "nbytes": {dts.key: dts.nbytes for dts in ts.dependencies},
-            "run_spec": None,
-            "function": None,
-            "args": None,
-            "kwargs": None,
+            "run_spec": ToPickle(ts.run_spec),
             "resource_restrictions": ts.resource_restrictions,
             "actor": ts.actor,
             "annotations": ts.annotations,
@@ -3354,11 +3353,6 @@ class SchedulerState:
         }
         if self.validate:
             assert all(msg["who_has"].values())
-
-        if isinstance(ts.run_spec, dict):
-            msg.update(ts.run_spec)
-        else:
-            msg["run_spec"] = ts.run_spec
 
         return msg
 
@@ -4606,7 +4600,11 @@ class Scheduler(SchedulerState, ServerNode):
         self.digest_metric("update-graph-duration", end - start)
 
     def _generate_taskstates(
-        self, keys: set[str], dsk: dict, dependencies: dict, computation: Computation
+        self,
+        keys: set[str],
+        dsk: dict[str, T_runspec],
+        dependencies: dict[str, set[str]],
+        computation: Computation,
     ) -> tuple:
         # Get or create task states
         runnable = []
@@ -8479,8 +8477,8 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
 
 
 def _materialize_graph(
-    graph: HighLevelGraph, global_annotations: dict
-) -> tuple[dict, dict, dict]:
+    graph: HighLevelGraph, global_annotations: dict[str, Any]
+) -> tuple[dict[str, T_runspec], dict[str, set[str]], dict[str, Any]]:
     dsk = dask.utils.ensure_dict(graph)
     annotations_by_type: defaultdict[str, dict[str, Any]] = defaultdict(dict)
     for annotations_type, value in global_annotations.items():
@@ -8536,6 +8534,6 @@ def _materialize_graph(
     for k in list(dsk):
         if dsk[k] is k:
             del dsk[k]
-    dsk = valmap(dumps_task, dsk)
+    dsk = valmap(_normalize_task, dsk)
 
     return dsk, dependencies, annotations_by_type

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -518,14 +518,12 @@ async def test_worker_metrics(c, s, a, b):
 
     # metrics for foo include self and its child bar
     assert list(foo_metrics) == [
-        ("execute", "x", "deserialize", "seconds"),
         ("execute", "x", "thread-cpu", "seconds"),
         ("execute", "x", "thread-noncpu", "seconds"),
         ("execute", "x", "executor", "seconds"),
         ("execute", "x", "other", "seconds"),
         ("execute", "x", "memory-read", "count"),
         ("execute", "x", "memory-read", "bytes"),
-        ("execute", "y", "deserialize", "seconds"),
         ("execute", "y", "thread-cpu", "seconds"),
         ("execute", "y", "thread-noncpu", "seconds"),
         ("execute", "y", "executor", "seconds"),
@@ -536,7 +534,6 @@ async def test_worker_metrics(c, s, a, b):
         list(bar0_metrics)
         == list(bar1_metrics)
         == [
-            ("execute", "y", "deserialize", "seconds"),
             ("execute", "y", "thread-cpu", "seconds"),
             ("execute", "y", "thread-noncpu", "seconds"),
             ("execute", "y", "executor", "seconds"),

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -95,7 +95,6 @@ from distributed.worker_state_machine import (
     ExecuteFailureEvent,
     ExecuteSuccessEvent,
     RemoveReplicasEvent,
-    SerializedTask,
     StealRequestEvent,
 )
 
@@ -2090,7 +2089,7 @@ async def test_stimulus_story(c, s, a):
 
     assert isinstance(story[0], ComputeTaskEvent)
     assert story[0].key == "f1"
-    assert story[0].run_spec == SerializedTask(task=None)  # Not logged
+    assert story[0].run_spec is None  # Not logged
 
     assert isinstance(story[1], ExecuteSuccessEvent)
     assert story[1].key == "f1"
@@ -2100,7 +2099,7 @@ async def test_stimulus_story(c, s, a):
     assert isinstance(story[2], ComputeTaskEvent)
     assert story[2].key == "f2"
     assert story[2].who_has == {"f1": (a.address,)}
-    assert story[2].run_spec == SerializedTask(task=None)  # Not logged
+    assert story[2].run_spec is None  # Not logged
     assert story[2].handled >= story[1].handled
 
     assert isinstance(story[3], ExecuteFailureEvent)

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3617,7 +3617,6 @@ async def test_execute_preamble_abort_retirement(c, s):
     """
     async with BlockedExecute(s.address) as a:
         await c.wait_for_workers(1)
-        a.block_deserialize_task.set()  # Uninteresting in this test
 
         x = await c.scatter({"x": 1}, workers=[a.address])
         y = c.submit(inc, 1, key="y", workers=[a.address])

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -390,6 +390,7 @@ def test_computetask_to_dict():
         annotations={},
         span_id=None,
         stimulus_id="test",
+        run_id=5,
     )
     assert ev.run_spec is not None
     ev2 = ev.to_loggable(handled=11.22)
@@ -402,7 +403,7 @@ def test_computetask_to_dict():
         "who_has": {"y": ["w1"]},
         "nbytes": {"y": 123},
         "priority": [0],
-        "run_spec": [None, None, None],
+        "run_spec": None,
         "duration": 123.45,
         "resource_restrictions": {},
         "actor": False,

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -426,15 +426,12 @@ def test_computetask_dummy():
         nbytes={},
         priority=(0,),
         duration=1.0,
-        run_spec=None,
+        run_spec=ComputeTaskEvent.dummy_runspec(),
         resource_restrictions={},
         actor=False,
         annotations={},
         span_id=None,
         stimulus_id="s",
-        function=None,
-        args=None,
-        kwargs=None,
         run_id=0,
     )
 

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -57,7 +57,6 @@ from distributed.worker_state_machine import (
     RetryBusyWorkerEvent,
     RetryBusyWorkerLater,
     SecedeEvent,
-    SerializedTask,
     StateMachineEvent,
     TaskErredMsg,
     TaskState,
@@ -375,28 +374,27 @@ def test_event_to_dict_without_annotations():
 
 def test_computetask_to_dict():
     """The potentially very large ComputeTaskEvent.run_spec is not stored in the log"""
+
+    def f(arg):
+        pass
+
     ev = ComputeTaskEvent(
         key="x",
         who_has={"y": ["w1"]},
         nbytes={"y": 123},
         priority=(0,),
         duration=123.45,
-        run_spec=None,
+        run_spec=(f, "arg", {}),
         resource_restrictions={},
         actor=False,
         annotations={},
         span_id=None,
         stimulus_id="test",
-        function=b"blob",
-        args=b"blob",
-        kwargs=None,
-        run_id=5,
     )
-    assert ev.run_spec == SerializedTask(function=b"blob", args=b"blob")
+    assert ev.run_spec is not None
     ev2 = ev.to_loggable(handled=11.22)
     assert ev2.handled == 11.22
-    assert ev2.run_spec == SerializedTask(task=None)
-    assert ev.run_spec == SerializedTask(function=b"blob", args=b"blob")
+    assert ev2.run_spec is None
     d = recursive_to_dict(ev2)
     assert d == {
         "cls": "ComputeTaskEvent",
@@ -404,7 +402,7 @@ def test_computetask_to_dict():
         "who_has": {"y": ["w1"]},
         "nbytes": {"y": 123},
         "priority": [0],
-        "run_spec": [None, None, None, None],
+        "run_spec": [None, None, None],
         "duration": 123.45,
         "resource_restrictions": {},
         "actor": False,
@@ -412,14 +410,11 @@ def test_computetask_to_dict():
         "span_id": None,
         "stimulus_id": "test",
         "handled": 11.22,
-        "function": None,
-        "args": None,
-        "kwargs": None,
         "run_id": 5,
     }
     ev3 = StateMachineEvent.from_dict(d)
     assert isinstance(ev3, ComputeTaskEvent)
-    assert ev3.run_spec == SerializedTask(task=None)
+    assert ev3.run_spec is None
     assert ev3.priority == (0,)  # List is automatically converted back to tuple
 
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2303,13 +2303,6 @@ class BlockedExecute(Worker):
             self.in_execute_exit.set()
             await self.block_execute_exit.wait()
 
-    async def _maybe_deserialize_task(
-        self, ts: WorkerTaskState
-    ) -> tuple[Callable, tuple, dict[str, Any]]:
-        self.in_deserialize_task.set()
-        await self.block_deserialize_task.wait()
-        return await super()._maybe_deserialize_task(ts)
-
 
 @contextmanager
 def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[None]:

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2253,10 +2253,6 @@ class BlockedExecute(Worker):
     method and then does not proceed, thus leaving the task in executing state
     indefinitely, until the test sets `block_execute`.
 
-    After that, the worker sets `in_deserialize_task` to simulate the moment when a
-    large run_spec is being deserialized in a separate thread. The worker will block
-    again until the test sets `block_deserialize_task`.
-
     Finally, the worker sets `in_execute_exit` when execute() terminates, but before the
     worker state has processed its exit callback. The worker will block one last time
     until the test sets `block_execute_exit`.

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2287,8 +2287,6 @@ class BlockedExecute(Worker):
     def __init__(self, *args, **kwargs):
         self.in_execute = asyncio.Event()
         self.block_execute = asyncio.Event()
-        self.in_deserialize_task = asyncio.Event()
-        self.block_deserialize_task = asyncio.Event()
         self.in_execute_exit = asyncio.Event()
         self.block_execute_exit = asyncio.Event()
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -66,7 +66,6 @@ from distributed.collections import LRU
 from distributed.comm import Comm, connect, get_address_host, parse_address
 from distributed.comm import resolve_address as comm_resolve_address
 from distributed.comm.addressing import address_from_user_args
-from distributed.comm.utils import OFFLOAD_THRESHOLD
 from distributed.compatibility import PeriodicCallback
 from distributed.core import (
     ConnectionPool,
@@ -75,7 +74,6 @@ from distributed.core import (
     coerce_to_address,
     context_meter_to_server_digest,
     error_message,
-    loads_function,
     pingpong,
 )
 from distributed.core import rpc as RPCType
@@ -125,7 +123,6 @@ from distributed.worker_memory import (
     WorkerMemoryManager,
 )
 from distributed.worker_state_machine import (
-    NO_VALUE,
     AcquireReplicasEvent,
     BaseWorker,
     CancelComputeEvent,
@@ -162,6 +159,7 @@ if TYPE_CHECKING:
     from distributed.client import Client
     from distributed.diagnostics.plugin import WorkerPlugin
     from distributed.nanny import Nanny
+    from distributed.scheduler import T_runspec
 
     P = ParamSpec("P")
     T = TypeVar("T")
@@ -2226,24 +2224,6 @@ class Worker(BaseWorker, ServerNode):
         except Exception as ex:
             return {"status": "error", "exception": to_serialize(ex)}
 
-    async def _maybe_deserialize_task(
-        self, ts: TaskState
-    ) -> tuple[Callable, tuple, dict[str, Any]]:
-        assert ts.run_spec is not None
-        start = time()
-        # Offload deserializing large tasks
-        if sizeof(ts.run_spec) > OFFLOAD_THRESHOLD:
-            function, args, kwargs = await offload(_deserialize, *ts.run_spec)
-        else:
-            function, args, kwargs = _deserialize(*ts.run_spec)
-        stop = time()
-
-        if stop - start > 0.010:
-            ts.startstops.append(
-                {"action": "deserialize", "start": start, "stop": stop}
-            )
-        return function, args, kwargs
-
     @fail_hard
     async def execute(self, key: str, *, stimulus_id: str) -> StateMachineEvent:
         """Execute a task. Implements BaseWorker abstract method.
@@ -2263,22 +2243,12 @@ class Worker(BaseWorker, ServerNode):
         run_id = ts.run_id
 
         try:
-            function, args, kwargs = await self._maybe_deserialize_task(ts)
-        except Exception as exc:
-            logger.error("Could not deserialize task %s", key, exc_info=True)
-            return ExecuteFailureEvent.from_exception(
-                exc,
-                key=key,
-                run_id=run_id,
-                stimulus_id=f"run-spec-deserialize-failed-{time()}",
-            )
-
-        try:
             if self.state.validate:
                 assert not ts.waiting_for_data
                 assert ts.state in ("executing", "cancelled", "resumed"), ts
-                assert ts.run_spec is not None
+            assert ts.run_spec is not None
 
+            function, args, kwargs = ts.run_spec
             args2, kwargs2 = self._prepare_args_for_execution(ts, args, kwargs)
 
             assert ts.annotations is not None
@@ -2947,27 +2917,14 @@ async def get_data_from_worker(
         rpc.reuse(worker, comm)
 
 
-job_counter = [0]
+def _normalize_task(task: Any) -> T_runspec:
+    if istask(task):
+        if task[0] is apply and not any(map(_maybe_complex, task[2:])):
+            return task[1], task[2], task[3] if len(task) == 4 else {}
+        elif not any(map(_maybe_complex, task[1:])):
+            return task[0], task[1:], {}
 
-
-@context_meter.meter("deserialize")
-def _deserialize(function=None, args=None, kwargs=None, task=NO_VALUE):
-    """Deserialize task inputs and regularize to func, args, kwargs"""
-    # Some objects require threadlocal state during deserialization, e.g. to
-    # detect the current worker
-    if function is not None:
-        function = loads_function(function)
-    if args and isinstance(args, bytes):
-        args = pickle.loads(args)
-    if kwargs and isinstance(kwargs, bytes):
-        kwargs = pickle.loads(kwargs)
-
-    if task is not NO_VALUE:
-        assert not function and not args and not kwargs
-        function = execute_task
-        args = (task,)
-
-    return function, args or (), kwargs or {}
+    return execute_task, (task,), {}
 
 
 def execute_task(task):
@@ -3006,62 +2963,6 @@ def dumps_function(func) -> bytes:
     except TypeError:  # Unhashable function
         result = pickle.dumps(func)
     return result
-
-
-def dumps_task(task):
-    """Serialize a dask task
-
-    Returns a dict of bytestrings that can each be loaded with ``loads``
-
-    Examples
-    --------
-    Either returns a task as a function, args, kwargs dict
-
-    >>> from operator import add
-    >>> dumps_task((add, 1))  # doctest: +SKIP
-    {'function': b'\x80\x04\x95\x00\x8c\t_operator\x94\x8c\x03add\x94\x93\x94.'
-     'args': b'\x80\x04\x95\x07\x00\x00\x00K\x01K\x02\x86\x94.'}
-
-    Or as a single task blob if it can't easily decompose the result.  This
-    happens either if the task is highly nested, or if it isn't a task at all
-
-    >>> dumps_task(1)  # doctest: +SKIP
-    {'task': b'\x80\x04\x95\x03\x00\x00\x00\x00\x00\x00\x00K\x01.'}
-    """
-    if istask(task):
-        if task[0] is apply and not any(map(_maybe_complex, task[2:])):
-            d = {"function": dumps_function(task[1]), "args": warn_dumps(task[2])}
-            if len(task) == 4:
-                d["kwargs"] = warn_dumps(task[3])
-            return d
-        elif not any(map(_maybe_complex, task[1:])):
-            return {"function": dumps_function(task[0]), "args": warn_dumps(task[1:])}
-    return to_serialize(task)
-
-
-_warn_dumps_warned = [False]
-
-
-def warn_dumps(obj, dumps=pickle.dumps, limit=1e6):
-    """Dump an object to bytes, warn if those bytes are large"""
-    b = dumps(obj)
-    if not _warn_dumps_warned[0] and len(b) > limit:
-        _warn_dumps_warned[0] = True
-        s = str(obj)
-        if len(s) > 70:
-            s = s[:50] + " ... " + s[-15:]
-        warnings.warn(
-            "Large object of size %s detected in task graph: \n"
-            "  %s\n"
-            "Consider scattering large objects ahead of time\n"
-            "with client.scatter to reduce scheduler burden and \n"
-            "keep data on workers\n\n"
-            "    future = client.submit(func, big_data)    # bad\n\n"
-            "    big_future = client.scatter(big_data)     # good\n"
-            "    future = client.submit(func, big_future)  # good"
-            % (format_bytes(len(b)), s)
-        )
-    return b
 
 
 def apply_function(

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -777,7 +777,7 @@ class ComputeTaskEvent(StateMachineEvent):
 
     @classmethod
     def _f(cls) -> None:
-        return
+        return  # pragma: nocover
 
     @classmethod
     def dummy_runspec(cls) -> tuple[Callable, tuple, dict]:

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -27,16 +27,7 @@ from copy import copy
 from dataclasses import dataclass, field
 from functools import lru_cache, partial, singledispatchmethod, wraps
 from itertools import chain
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Literal,
-    NamedTuple,
-    TypedDict,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, Union, cast
 
 from tlz import peekn
 
@@ -49,7 +40,7 @@ from distributed.comm import get_address_host
 from distributed.core import ErrorMessage, error_message
 from distributed.metrics import DelayedMetricsLedger, monotonic, time
 from distributed.protocol import pickle
-from distributed.protocol.serialize import Serialize
+from distributed.protocol.serialize import Serialize, ToPickle
 from distributed.sizeof import safe_sizeof as sizeof
 from distributed.utils import recursive_to_dict
 
@@ -64,6 +55,7 @@ if TYPE_CHECKING:
 
     # Circular imports
     from distributed.diagnostics.plugin import WorkerPlugin
+    from distributed.scheduler import T_runspec
     from distributed.worker import Worker
 
 # Not to be confused with distributed.scheduler.TaskStateState
@@ -110,19 +102,6 @@ WAITING_FOR_DATA: Set[TaskStateState] = {
 NO_VALUE = "--no-value-sentinel--"
 
 RUN_ID_SENTINEL = -1
-
-
-class SerializedTask(NamedTuple):
-    """Info from distributed.scheduler.TaskState.run_spec
-    Input to distributed.worker._deserialize
-
-    (function, args kwargs) and task are mutually exclusive
-    """
-
-    function: bytes | None = None
-    args: bytes | tuple | list | None = None
-    kwargs: bytes | dict[str, Any] | None = None
-    task: object = NO_VALUE
 
 
 class StartStop(TypedDict):
@@ -239,11 +218,11 @@ class TaskState:
     prefix: str = field(init=False)
     #: Task run ID.
     run_id: int = RUN_ID_SENTINEL
-    #: A named tuple containing the ``function``, ``args``, ``kwargs`` and ``task``
+    #: A tuple containing the ``function``, ``args``, ``kwargs`` and ``task``
     #: associated with this `TaskState` instance. This defaults to ``None`` and can
     #: remain empty if it is a dependency that this worker will receive from another
     #: worker.
-    run_spec: SerializedTask | None = None
+    run_spec: T_runspec | None = None
 
     #: The data needed by this key to run
     dependencies: set[TaskState] = field(default_factory=set)
@@ -763,10 +742,7 @@ class ComputeTaskEvent(StateMachineEvent):
     nbytes: dict[str, int]
     priority: tuple[int, ...]
     duration: float
-    run_spec: SerializedTask | None
-    function: bytes | None
-    args: bytes | tuple | list | None | None
-    kwargs: bytes | dict[str, Any] | None
+    run_spec: T_runspec | None
     resource_restrictions: dict[str, float]
     actor: bool
     annotations: dict
@@ -778,24 +754,17 @@ class ComputeTaskEvent(StateMachineEvent):
         # Fixes after msgpack decode
         if isinstance(self.priority, list):  # type: ignore[unreachable]
             self.priority = tuple(self.priority)  # type: ignore[unreachable]
-
-        if self.function is not None:
-            assert self.run_spec is None
-            self.run_spec = SerializedTask(
-                function=self.function, args=self.args, kwargs=self.kwargs
-            )
-        elif not isinstance(self.run_spec, SerializedTask):
-            self.run_spec = SerializedTask(task=self.run_spec)
+        if isinstance(self.run_spec, ToPickle):
+            # FIXME Sometimes the protocol is not unpacking this
+            # E.g. distributed/tests/test_client.py::test_async_with
+            self.run_spec = self.run_spec.data  # type: ignore[unreachable]
 
     def _to_dict(self, *, exclude: Container[str] = ()) -> dict:
         return StateMachineEvent._to_dict(self._clean(), exclude=exclude)
 
     def _clean(self) -> StateMachineEvent:
         out = copy(self)
-        out.function = None
-        out.kwargs = None
-        out.args = None
-        out.run_spec = SerializedTask(task=None, function=None, args=None, kwargs=None)
+        out.run_spec = None
         return out
 
     def to_loggable(self, *, handled: float) -> StateMachineEvent:
@@ -804,7 +773,7 @@ class ComputeTaskEvent(StateMachineEvent):
         return out
 
     def _after_from_dict(self) -> None:
-        self.run_spec = SerializedTask(task=None, function=None, args=None, kwargs=None)
+        self.run_spec = None
 
     @staticmethod
     def dummy(
@@ -831,9 +800,6 @@ class ComputeTaskEvent(StateMachineEvent):
             priority=priority,
             duration=duration,
             run_spec=None,
-            function=None,
-            args=None,
-            kwargs=None,
             resource_restrictions=resource_restrictions or {},
             actor=actor,
             annotations=annotations or {},

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -775,6 +775,14 @@ class ComputeTaskEvent(StateMachineEvent):
     def _after_from_dict(self) -> None:
         self.run_spec = None
 
+    @classmethod
+    def _f(cls) -> None:
+        return
+
+    @classmethod
+    def dummy_runspec(cls) -> tuple[Callable, tuple, dict]:
+        return (cls._f, (), {})
+
     @staticmethod
     def dummy(
         key: str,
@@ -799,7 +807,7 @@ class ComputeTaskEvent(StateMachineEvent):
             nbytes=nbytes or {k: 1 for k in who_has or ()},
             priority=priority,
             duration=duration,
-            run_spec=None,
+            run_spec=ComputeTaskEvent.dummy_runspec(),
             resource_restrictions=resource_restrictions or {},
             actor=actor,
             annotations=annotations or {},


### PR DESCRIPTION
This is a tangent to https://github.com/dask/distributed/pull/8049

I noticed that the `dumps_task` is a surprisingly expensive operation (about 12% in https://github.com/dask/distributed/issues/7998)

It is also a rather significant complexity driver and I believe it is no longer necessary now that pickle is used on the scheduler. 

This PR explores what actually relies on this behavior and how much complexity we can remove with the removal of dumps_task