### PR TITLE
Introduce `PreloadManager` to handle failures in preload setup/teardown

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -843,7 +843,7 @@ class Client(SyncMethodMixin):
 
     _default_event_handlers = {"print": _handle_print, "warn": _handle_warn}
 
-    preloads: list[preloading.Preload]
+    preloads: preloading.PreloadManager
     __loop: IOLoop | None = None
 
     def __init__(
@@ -1313,8 +1313,7 @@ class Client(SyncMethodMixin):
         for topic, handler in Client._default_event_handlers.items():
             self.subscribe_topic(topic, handler)
 
-        for preload in self.preloads:
-            await preload.start()
+        await self.preloads.start()
 
         self._handle_report_task = asyncio.create_task(self._handle_report())
 
@@ -1702,8 +1701,7 @@ class Client(SyncMethodMixin):
 
         self.status = "closing"
 
-        for preload in self.preloads:
-            await preload.teardown()
+        await self.preloads.teardown()
 
         with suppress(AttributeError):
             for pc in self._periodic_callbacks.values():

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -349,8 +349,7 @@ class Nanny(ServerNode):
 
         self.ip = get_address_host(self.address)
 
-        for preload in self.preloads:
-            await preload.start()
+        await self.preloads.start()
 
         msg = await self.scheduler.register_nanny()
         for name, plugin in msg["nanny-plugins"].items():
@@ -582,8 +581,7 @@ class Nanny(ServerNode):
         self.status = Status.closing
         logger.info("Closing Nanny at %r. Reason: %s", self.address_safe, reason)
 
-        for preload in self.preloads:
-            await preload.teardown()
+        await self.preloads.teardown()
 
         teardowns = [
             plugin.teardown(self)

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -236,7 +236,7 @@ class PreloadManager:
                 logger.exception("Failed to start preload: %s", preload.name)
 
     async def teardown(self):
-        for preload in self._preloads:
+        for preload in reversed(self._preloads):
             try:
                 await preload.teardown()
             except Exception:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3963,11 +3963,7 @@ class Scheduler(SchedulerState, ServerNode):
 
             weakref.finalize(self, del_scheduler_file)
 
-        for preload in self.preloads:
-            try:
-                await preload.start()
-            except Exception:
-                logger.exception("Failed to start preload")
+        await self.preloads.start()
 
         if self.jupyter:
             # Allow insecure communications from local users
@@ -4014,11 +4010,7 @@ class Scheduler(SchedulerState, ServerNode):
         logger.info("Scheduler closing due to %s...", reason or "unknown reason")
         setproctitle("dask scheduler [closing]")
 
-        for preload in self.preloads:
-            try:
-                await preload.teardown()
-            except Exception:
-                logger.exception("Failed to tear down preload")
+        await self.preloads.teardown()
 
         await asyncio.gather(
             *[log_errors(plugin.close) for plugin in list(self.plugins.values())]

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -439,7 +439,7 @@ class Worker(BaseWorker, ServerNode):
     _client: Client | None
     bandwidth_workers: defaultdict[str, tuple[float, int]]
     bandwidth_types: defaultdict[type, tuple[float, int]]
-    preloads: list[preloading.Preload]
+    preloads: preloading.PreloadManager
     contact_address: str | None
     _start_port: int | str | Collection[int] | None = None
     _start_host: str | None
@@ -1409,11 +1409,7 @@ class Worker(BaseWorker, ServerNode):
         if self.name is None:
             self.name = self.address
 
-        for preload in self.preloads:
-            try:
-                await preload.start()
-            except Exception:
-                logger.exception("Failed to start preload")
+        await self.preloads.start()
 
         # Services listen on all addresses
         # Note Nanny is not a "real" service, just some metadata
@@ -1563,11 +1559,7 @@ class Worker(BaseWorker, ServerNode):
 
         self.stop_services()
 
-        for preload in self.preloads:
-            try:
-                await preload.teardown()
-            except Exception:
-                logger.exception("Failed to tear down preload")
+        await self.preloads.teardown()
 
         for pc in self.periodic_callbacks.values():
             pc.stop()


### PR DESCRIPTION
This PR introduces a `PreloadManager` which deduplicates preload handling code from the `Client`, `Nanny`, `Scheduler`, and `Worker`. The `PreloadManager` also ensures that errors on `preload.{start|teardown}` don't raise.


- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
