### PR TITLE
Skip `test_client.py::test_file_descriptors_dont_leak` on Mac OS

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -74,7 +74,7 @@ from distributed.client import (
 )
 from distributed.cluster_dump import load_cluster_dump
 from distributed.comm import CommClosedError
-from distributed.compatibility import LINUX, WINDOWS
+from distributed.compatibility import LINUX, MACOS, WINDOWS
 from distributed.core import Status, error_message
 from distributed.diagnostics.plugin import WorkerPlugin
 from distributed.metrics import time
@@ -6383,6 +6383,7 @@ async def test_wait_for_workers(c, s, a, b):
 
 
 @pytest.mark.skipif(WINDOWS, reason="num_fds not supported on windows")
+@pytest.mark.skipif(MACOS, reason="dask/distributed#8075")
 @pytest.mark.parametrize(
     "Worker", [Worker, pytest.param(Nanny, marks=[pytest.mark.slow])]
 )


### PR DESCRIPTION
Supersedes #8079.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
