### PR TITLE
Better logging for anomalous task termination

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5165,17 +5165,19 @@ def test_quiet_client_close(loop):
             sleep(0.200)  # stop part-way
         sleep(0.1)  # let things settle
 
-        out = logger.getvalue()
-        lines = out.strip().split("\n")
-        assert len(lines) <= 2
-        for line in lines:
-            assert (
-                not line
-                or "heartbeat from unregistered worker" in line
-                or "unaware of this worker" in line
-                or "garbage" in line
-                or set(line) == {"-"}
-            ), line
+    out = logger.getvalue()
+    lines = out.strip().split("\n")
+    unexpected_lines = [
+        line
+        for line in lines
+        if line
+        and "heartbeat from unregistered worker" not in line
+        and "unaware of this worker" not in line
+        and "garbage" not in line
+        and "ended with CancelledError" not in line
+        and set(line) != {"-"}
+    ]
+    assert not unexpected_lines, lines
 
 
 @pytest.mark.slow

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3656,9 +3656,11 @@ class BaseWorker(abc.ABC):
             stim = task.result()
         except asyncio.CancelledError:
             # This should exclusively happen in Worker.close()
+            logger.warning(f"Async instruction for {task} ended with CancelledError")
             return
         except BaseException:  # pragma: nocover
-            logger.exception("async instruction handlers should never raise!")
+            # This should never happen
+            logger.exception(f"Unhandled exception in async instruction for {task}")
             raise
 
         # Capture metric events in _transition_to_memory()


### PR DESCRIPTION
Follow-up to #8006
In #8006, CancelledError not only caused the worker state machine to deadlock, but it also left no trace in the log.
While #8013 prevents this specific issue, it's wise to ensure that CancelledError is never silently ignored.