### PR TITLE
Remove stringification

### DIFF
--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -18,7 +18,7 @@ dependencies:
   - toolz=0.10.0
   - tornado=6.0.4
   - urllib3=1.24.3
-  - zict=2.2.0
+  - zict=3.0.0
   # Distributed depends on the latest version of Dask
   - pip
   - pip:

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - toolz >=0.10.0
     - tornado >=6.0.4
     - urllib3 >=1.24.3
-    - zict >=2.2.0
+    - zict >=3.0.0
   run_constrained:
     - openssl !=1.1.1e
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -28,7 +28,7 @@ from queue import Queue as pyQueue
 from typing import Any, ClassVar, Literal, NamedTuple, TypedDict
 
 from packaging.version import parse as parse_version
-from tlz import first, groupby, keymap, merge, partition_all, valmap
+from tlz import first, groupby, merge, partition_all, valmap
 
 import dask
 from dask.base import collections_to_dsk, normalize_token, tokenize
@@ -41,7 +41,6 @@ from dask.utils import (
     format_bytes,
     funcname,
     parse_timedelta,
-    stringify,
     typename,
 )
 from dask.widgets import get_template
@@ -211,7 +210,6 @@ class Future(WrappedKey):
     def __init__(self, key, client=None, inform=True, state=None):
         self.key = key
         self._cleared = False
-        self._tkey = stringify(key)
         self._client = client
         self._input_state = state
         self._inform = inform
@@ -231,19 +229,19 @@ class Future(WrappedKey):
                 client = None
             self._client = client
         if self._client and not self._state:
-            self._client._inc_ref(self._tkey)
+            self._client._inc_ref(self.key)
             self._generation = self._client.generation
 
-            if self._tkey in self._client.futures:
-                self._state = self._client.futures[self._tkey]
+            if self.key in self._client.futures:
+                self._state = self._client.futures[self.key]
             else:
-                self._state = self._client.futures[self._tkey] = FutureState()
+                self._state = self._client.futures[self.key] = FutureState()
 
             if self._inform:
                 self._client._send_to_scheduler(
                     {
                         "op": "client-desires-keys",
-                        "keys": [self._tkey],
+                        "keys": [self.key],
                         "client": self._client.id,
                     }
                 )
@@ -503,7 +501,7 @@ class Future(WrappedKey):
         if not self._cleared and self.client.generation == self._generation:
             self._cleared = True
             try:
-                self.client.loop.add_callback(self.client._dec_ref, stringify(self.key))
+                self.client.loop.add_callback(self.client._dec_ref, self.key)
             except TypeError:  # pragma: no cover
                 pass  # Shutting down, add_callback may be None
 
@@ -1963,10 +1961,8 @@ class Client(SyncMethodMixin):
             else:
                 key = funcname(func) + "-" + str(uuid.uuid4())
 
-        skey = stringify(key)
-
         with self._refcount_lock:
-            if skey in self.futures:
+            if key in self.futures:
                 return Future(key, self, inform=False)
 
         if allow_other_workers and workers is None:
@@ -1976,16 +1972,16 @@ class Client(SyncMethodMixin):
             workers = [workers]
 
         if kwargs:
-            dsk = {skey: (apply, func, list(args), kwargs)}
+            dsk = {key: (apply, func, list(args), kwargs)}
         else:
-            dsk = {skey: (func,) + tuple(args)}
+            dsk = {key: (func,) + tuple(args)}
 
         futures = self._graph_to_futures(
             dsk,
-            [skey],
+            [key],
             workers=workers,
             allow_other_workers=allow_other_workers,
-            internal_priority={skey: 0},
+            internal_priority={key: 0},
             user_priority=priority,
             resources=resources,
             retries=retries,
@@ -1995,7 +1991,7 @@ class Client(SyncMethodMixin):
 
         logger.debug("Submit %s(...), %s", funcname(func), key)
 
-        return futures[skey]
+        return futures[key]
 
     def map(
         self,
@@ -2200,7 +2196,7 @@ class Client(SyncMethodMixin):
         )
         logger.debug("map(%s, ...)", funcname(func))
 
-        return [futures[stringify(k)] for k in keys]
+        return [futures[k] for k in keys]
 
     async def _gather(self, futures, errors="raise", direct=None, local_worker=None):
         unpacked, future_set = unpack_remotedata(futures, byte_keys=True)
@@ -2212,7 +2208,7 @@ class Client(SyncMethodMixin):
                 f"mismatched Futures and their client IDs (this client is {self.id}): "
                 f"{ {f: f.client.id for f in mismatched_futures} }"
             )
-        keys = [stringify(future.key) for future in future_set]
+        keys = [future.key for future in future_set]
         bad_data = dict()
         data = {}
 
@@ -2423,11 +2419,6 @@ class Client(SyncMethodMixin):
             timeout = self._timeout
         if isinstance(workers, (str, Number)):
             workers = [workers]
-        if isinstance(data, dict) and not all(
-            isinstance(k, (bytes, str)) for k in data
-        ):
-            d = await self._scatter(keymap(stringify, data), workers, broadcast)
-            return {k: d[stringify(k)] for k in data}
 
         if isinstance(data, type(range(0))):
             data = list(data)
@@ -2639,7 +2630,7 @@ class Client(SyncMethodMixin):
 
     async def _cancel(self, futures, force=False):
         # FIXME: This method is asynchronous since interacting with the FutureState below requires an event loop.
-        keys = list({stringify(f.key) for f in futures_of(futures)})
+        keys = list({f.key for f in futures_of(futures)})
         self._send_to_scheduler({"op": "cancel-keys", "keys": keys, "force": force})
         for k in keys:
             st = self.futures.pop(k, None)
@@ -2665,7 +2656,7 @@ class Client(SyncMethodMixin):
         return self.sync(self._cancel, futures, asynchronous=asynchronous, force=force)
 
     async def _retry(self, futures):
-        keys = list({stringify(f.key) for f in futures_of(futures)})
+        keys = list({f.key for f in futures_of(futures)})
         response = await self.scheduler.retry(keys=keys, client=self.id)
         for key in response:
             st = self.futures[key]
@@ -2689,7 +2680,7 @@ class Client(SyncMethodMixin):
         coroutines = []
 
         def add_coro(name, data):
-            keys = [stringify(f.key) for f in futures_of(data)]
+            keys = [f.key for f in futures_of(data)]
             coroutines.append(
                 self.scheduler.publish_put(
                     keys=keys,
@@ -3171,7 +3162,7 @@ class Client(SyncMethodMixin):
                     "op": "update-graph",
                     "graph_header": header,
                     "graph_frames": frames,
-                    "keys": list(map(stringify, keys)),
+                    "keys": list(keys),
                     "internal_priority": internal_priority,
                     "submitting_task": getattr(thread_state, "key", None),
                     "fifo_timeout": fifo_timeout,
@@ -3297,7 +3288,7 @@ class Client(SyncMethodMixin):
         with self._refcount_lock:
             changed = False
             for key in list(dsk):
-                if stringify(key) in self.futures:
+                if key in self.futures:
                     if not changed:
                         changed = True
                         dsk = ensure_dict(dsk)
@@ -3805,7 +3796,7 @@ class Client(SyncMethodMixin):
     async def _rebalance(self, futures=None, workers=None):
         if futures is not None:
             await _wait(futures)
-            keys = list({stringify(f.key) for f in self.futures_of(futures)})
+            keys = list({f.key for f in self.futures_of(futures)})
         else:
             keys = None
         result = await self.scheduler.rebalance(keys=keys, workers=workers)
@@ -3841,7 +3832,7 @@ class Client(SyncMethodMixin):
     async def _replicate(self, futures, n=None, workers=None, branching_factor=2):
         futures = self.futures_of(futures)
         await _wait(futures)
-        keys = {stringify(f.key) for f in futures}
+        keys = {f.key for f in futures}
         await self.scheduler.replicate(
             keys=list(keys), n=n, workers=workers, branching_factor=branching_factor
         )
@@ -3962,7 +3953,7 @@ class Client(SyncMethodMixin):
         """
         if futures is not None:
             futures = self.futures_of(futures)
-            keys = list(map(stringify, {f.key for f in futures}))
+            keys = list({f.key for f in futures})
         else:
             keys = None
 
@@ -4098,7 +4089,7 @@ class Client(SyncMethodMixin):
         keys = keys or []
         if futures is not None:
             futures = self.futures_of(futures)
-            keys += list(map(stringify, {f.key for f in futures}))
+            keys += list({f.key for f in futures})
         return self.sync(self.scheduler.call_stack, keys=keys or None)
 
     def profile(
@@ -4682,10 +4673,9 @@ class Client(SyncMethodMixin):
             k = (k,)
         for kk in k:
             if dask.is_dask_collection(kk):
-                for kkk in kk.__dask_keys__():
-                    yield stringify(kkk)
+                yield from kk.__dask_keys__()
             else:
-                yield stringify(kk)
+                yield kk
 
     @staticmethod
     def collections_to_dsk(collections, *args, **kwargs):
@@ -5732,7 +5722,7 @@ def fire_and_forget(obj):
         future.client._send_to_scheduler(
             {
                 "op": "client-desires-keys",
-                "keys": [stringify(future.key)],
+                "keys": [future.key],
                 "client": "fire-and-forget",
             }
         )

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -47,7 +47,7 @@ from dask.widgets import get_template
 
 from distributed.core import ErrorMessage
 from distributed.protocol.serialize import _is_dumpable
-from distributed.utils import Deadline, wait_for
+from distributed.utils import Deadline, validate_key, wait_for
 
 try:
     from dask.delayed import single_key
@@ -3138,6 +3138,10 @@ class Client(SyncMethodMixin):
 
             # Pack the high level graph before sending it to the scheduler
             keyset = set(keys)
+
+            # Validate keys
+            for key in keyset:
+                validate_key(key)
 
             # Create futures before sending graph (helps avoid contention)
             futures = {key: Future(key, self, inform=False) for key in keyset}

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2371,7 +2371,7 @@ class TaskGraph(DashboardComponent):
                     continue
                 xx = x[key]
                 yy = y[key]
-                node_key.append(escape.url_escape(key))
+                node_key.append(escape.url_escape(str(key)))
                 node_x.append(xx)
                 node_y.append(yy)
                 node_state.append(task.state)

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -15,7 +15,6 @@ from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 import dask
 from dask.core import flatten
-from dask.utils import stringify
 
 from distributed import Event
 from distributed.client import wait
@@ -910,7 +909,7 @@ async def test_TaskGraph_complex(c, s, a, b):
     gp.update()
     assert set(gp.layout.index.values()) == set(range(len(gp.layout.index)))
     visible = gp.node_source.data["visible"]
-    keys = list(map(stringify, flatten(y.__dask_keys__())))
+    keys = list(flatten(y.__dask_keys__()))
     assert all(visible[gp.layout.index[key]] == "True" for key in keys)
 
 

--- a/distributed/diagnostics/progress.py
+++ b/distributed/diagnostics/progress.py
@@ -10,7 +10,7 @@ from typing import ClassVar
 from tlz import groupby, valmap
 
 from dask.base import tokenize
-from dask.utils import key_split, stringify
+from dask.utils import key_split
 
 from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.metrics import time
@@ -68,7 +68,7 @@ class Progress(SchedulerPlugin):
     def __init__(self, keys, scheduler, minimum=0, dt=0.1, complete=False, name=None):
         self.name = name or f"progress-{tokenize(keys, minimum, dt, complete)}"
         self.keys = {k.key if hasattr(k, "key") else k for k in keys}
-        self.keys = {stringify(k) for k in self.keys}
+        self.keys = {k for k in self.keys}
         self.scheduler = scheduler
         self.complete = complete
         self._minimum = minimum

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -137,14 +137,13 @@ def deserialize_numpy_ndarray(header, frames):
     elif not x.flags.writeable:
         # This should exclusively happen when the underlying buffer is read-only, e.g.
         # a read-only mmap.mmap or a bytes object.
-        # Specifically, these are the known use cases:
-        # 1. decompression with a library that does not support output to bytearray
-        #    (lz4 does; snappy, zlib, and zstd don't).
-        #    Note that this only applies to buffers whose uncompressed size was small
-        #    enough that they weren't sharded (distributed.comm.shard); for larger
-        #    buffers the decompressed output is deep-copied beforehand into a bytearray
-        #    in order to merge it.
-        # 2. unspill with zict <2.3.0 (https://github.com/dask/zict/pull/74)
+        # The only known case is:
+        #    decompression with a library that does not support output to
+        #    bytearray (lz4 does; snappy, zlib, and zstd don't). Note that this
+        #    only applies to buffers whose uncompressed size was small enough
+        #    that they weren't sharded (distributed.comm.shard); for larger
+        #    buffers the decompressed output is deep-copied beforehand into a
+        #    bytearray in order to merge it.
         x = np.require(x, requirements=["W"])
 
     return x

--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import ast
-
 import pytest
 
 np = pytest.importorskip("numpy")
@@ -110,8 +108,7 @@ class ExampleAnnotationPlugin(SchedulerPlugin):
 
         if "priority" in annots:
             self.priority_matches = sum(
-                int(self.priority_fn(ast.literal_eval(k)) == p)
-                for k, p in annots["priority"].items()
+                int(self.priority_fn(k) == p) for k, p in annots["priority"].items()
             )
 
         if "qux" in annots:

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -5,7 +5,7 @@ import logging
 import uuid
 from collections import defaultdict
 
-from dask.utils import parse_timedelta, stringify
+from dask.utils import parse_timedelta
 
 from distributed.client import Future
 from distributed.utils import wait_for
@@ -214,7 +214,7 @@ class Queue:
     async def _put(self, value, timeout=None):
         if isinstance(value, Future):
             await self.client.scheduler.queue_put(
-                key=stringify(value.key), timeout=timeout, name=self.name
+                key=value.key, timeout=timeout, name=self.name
             )
         else:
             await self.client.scheduler.queue_put(

--- a/distributed/recreate_tasks.py
+++ b/distributed/recreate_tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from distributed.client import futures_of, wait
+from distributed.client import Future, futures_of, wait
 from distributed.protocol.serialize import ToPickle
 from distributed.utils import sync, validate_key
 from distributed.utils_comm import pack_data

--- a/distributed/recreate_tasks.py
+++ b/distributed/recreate_tasks.py
@@ -4,7 +4,7 @@ import logging
 
 from distributed.client import futures_of, wait
 from distributed.protocol.serialize import ToPickle
-from distributed.utils import sync
+from distributed.utils import sync, validate_key
 from distributed.utils_comm import pack_data
 
 logger = logging.getLogger(__name__)
@@ -83,6 +83,7 @@ class ReplayTaskClient:
             await wait(future)
             key = future.key
         else:
+            validate_key(future)
             key = future
         spec = await self.scheduler.get_runspec(key=key)
         return (*spec["task"], spec["deps"])

--- a/distributed/recreate_tasks.py
+++ b/distributed/recreate_tasks.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import logging
 
-from dask.utils import stringify
-
 from distributed.client import futures_of, wait
 from distributed.protocol.serialize import ToPickle
 from distributed.utils import sync
@@ -29,7 +27,6 @@ class ReplayTaskScheduler:
     def _process_key(self, key):
         if isinstance(key, list):
             key = tuple(key)  # ensure not a list from msgpack
-        key = stringify(key)
         return key
 
     def get_error_cause(self, *args, keys=(), **kwargs):
@@ -80,11 +77,13 @@ class ReplayTaskClient:
         For a given future return the func, args and kwargs and future
         deps that would be executed remotely.
         """
-        if isinstance(future, str):
-            key = future
-        else:
+        from distributed.client import Future
+
+        if isinstance(future, Future):
             await wait(future)
             key = future.key
+        else:
+            key = future
         spec = await self.scheduler.get_runspec(key=key)
         return (*spec["task"], spec["deps"])
 

--- a/distributed/recreate_tasks.py
+++ b/distributed/recreate_tasks.py
@@ -77,8 +77,6 @@ class ReplayTaskClient:
         For a given future return the func, args and kwargs and future
         deps that would be executed remotely.
         """
-        from distributed.client import Future
-
         if isinstance(future, Future):
             await wait(future)
             key = future.key

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -60,7 +60,6 @@ from dask.utils import (
     key_split,
     parse_bytes,
     parse_timedelta,
-    stringify,
     tmpfile,
 )
 from dask.widgets import get_template
@@ -115,7 +114,6 @@ from distributed.utils import (
     no_default,
     offload,
     recursive_to_dict,
-    validate_key,
     wait_for,
 )
 from distributed.utils_comm import (
@@ -5513,7 +5511,7 @@ class Scheduler(SchedulerState, ServerNode):
     ) -> None:
         if worker not in self.workers:
             return
-        validate_key(key)
+        self.validate_key(key)
 
         r: tuple = self.stimulus_task_finished(
             key=key, worker=worker, stimulus_id=stimulus_id, **msg
@@ -8464,7 +8462,7 @@ def _materialize_graph(
     annotations_by_type: defaultdict[str, dict[str, Any]] = defaultdict(dict)
     for annotations_type, value in global_annotations.items():
         annotations_by_type[annotations_type].update(
-            {stringify(k): (value(k) if callable(value) else value) for k in dsk}
+            {k: (value(k) if callable(value) else value) for k in dsk}
         )
 
     for layer in graph.layers.values():
@@ -8472,10 +8470,7 @@ def _materialize_graph(
             annot = layer.annotations
             for annot_type, value in annot.items():
                 annotations_by_type[annot_type].update(
-                    {
-                        stringify(k): (value(k) if callable(value) else value)
-                        for k in layer
-                    }
+                    {k: (value(k) if callable(value) else value) for k in layer}
                 )
     dependencies, _ = get_deps(dsk)
 
@@ -8491,18 +8486,6 @@ def _materialize_graph(
     # - Add in deps for any tasks that depend on futures
     for k, futures in fut_deps.items():
         dependencies[k].update(f.key for f in futures)
-    new_dsk = {}
-    # Annotation callables are evaluated on the non-stringified version of
-    # the keys
-    exclusive = set(graph)
-    for k, v in dsk.items():
-        new_k = stringify(k)
-        new_dsk[new_k] = stringify(v, exclusive=exclusive)
-    dsk = new_dsk
-    dependencies = {
-        stringify(k): {stringify(dep) for dep in deps}
-        for k, deps in dependencies.items()
-    }
 
     # Remove any self-dependencies (happens on test_publish_bag() and others)
     for k, v in dependencies.items():

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -114,6 +114,7 @@ from distributed.utils import (
     no_default,
     offload,
     recursive_to_dict,
+    validate_key,
     wait_for,
 )
 from distributed.utils_comm import (
@@ -8459,6 +8460,8 @@ def _materialize_graph(
     graph: HighLevelGraph, global_annotations: dict[str, Any]
 ) -> tuple[dict[str, T_runspec], dict[str, set[str]], dict[str, Any]]:
     dsk = dask.utils.ensure_dict(graph)
+    for k in dsk:
+        validate_key(k)
     annotations_by_type: defaultdict[str, dict[str, Any]] = defaultdict(dict)
     for annotations_type, value in global_annotations.items():
         annotations_by_type[annotations_type].update(

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -344,7 +344,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         """Clean up scheduler and worker state once a shuffle becomes inactive."""
         if finish not in ("released", "forgotten"):
             return
-        if not key.startswith("shuffle-barrier-"):
+        if not isinstance(key, str) or not key.startswith("shuffle-barrier-"):
             return
         shuffle_id = id_from_key(key)
 

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -110,7 +110,7 @@ def rearrange_by_column_p2p(
             f"p2p requires all column names to be str, found: {unsupported}",
         )
 
-    name = f"shuffle-p2p-{token}"
+    name = f"shuffle_p2p-{token}"
     layer = P2PShuffleLayer(
         name,
         column,

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -15,6 +15,8 @@ from unittest import mock
 
 import pytest
 
+from dask.utils import key_split
+
 from distributed.shuffle._core import ShuffleId, ShuffleRun, barrier_key
 from distributed.worker import Status
 
@@ -23,7 +25,6 @@ dd = pytest.importorskip("dask.dataframe")
 
 import dask
 from dask.distributed import Event, Nanny, Worker
-from dask.utils import stringify
 
 from distributed.client import Client
 from distributed.scheduler import KilledWorker, Scheduler
@@ -249,7 +250,9 @@ async def wait_until_worker_has_tasks(
             [
                 key
                 for key, ts in scheduler.tasks.items()
-                if prefix in key and ts.state == "memory" and {ws} == ts.who_has
+                if prefix in key_split(key)
+                and ts.state == "memory"
+                and {ws} == ts.who_has
             ]
         )
         < count
@@ -274,7 +277,13 @@ async def wait_for_tasks_in_state(
         raise TypeError(dask_worker)
 
     while (
-        len([key for key, ts in tasks.items() if prefix in key and ts.state == state])
+        len(
+            [
+                key
+                for key, ts in tasks.items()
+                if prefix in key_split(key) and ts.state == state
+            ]
+        )
         < count
     ):
         await asyncio.sleep(interval)
@@ -791,7 +800,7 @@ async def test_closed_worker_during_unpack(c, s, a, b):
     )
     out = dd.shuffle.shuffle(df, "x", shuffle="p2p")
     x, y = c.compute([df.x.size, out.x.size])
-    await wait_for_tasks_in_state("shuffle-p2p", "memory", 1, b)
+    await wait_for_tasks_in_state("shuffle_p2p", "memory", 1, b)
     await b.close()
 
     x = await x
@@ -818,7 +827,7 @@ async def test_restarting_during_unpack_raises_killed_worker(c, s, a, b):
     )
     out = dd.shuffle.shuffle(df, "x", shuffle="p2p")
     out = c.compute(out.x.size)
-    await wait_for_tasks_in_state("shuffle-p2p", "memory", 1, b)
+    await wait_for_tasks_in_state("shuffle_p2p", "memory", 1, b)
     await b.close()
 
     with pytest.raises(KilledWorker):
@@ -845,7 +854,7 @@ async def test_crashed_worker_during_unpack(c, s, a):
         out = dd.shuffle.shuffle(df, "x", shuffle="p2p")
         y = c.compute(out.x.size)
 
-        await wait_until_worker_has_tasks("shuffle-p2p", killed_worker_address, 1, s)
+        await wait_until_worker_has_tasks("shuffle_p2p", killed_worker_address, 1, s)
         await n.process.process.kill()
 
         y = await y
@@ -1210,7 +1219,7 @@ async def test_crashed_worker_after_shuffle(c, s, a):
             out = block(out, in_event, block_event)
         out = c.compute(out)
 
-        await wait_until_worker_has_tasks("shuffle-p2p", n.worker_address, 1, s)
+        await wait_until_worker_has_tasks("shuffle_p2p", n.worker_address, 1, s)
         await in_event.wait()
         await n.process.process.kill()
         await block_event.set()
@@ -1238,7 +1247,7 @@ async def test_crashed_worker_after_shuffle_persisted(c, s, a):
         out = dd.shuffle.shuffle(df, "x", shuffle="p2p")
         out = out.persist()
 
-        await wait_until_worker_has_tasks("shuffle-p2p", n.worker_address, 1, s)
+        await wait_until_worker_has_tasks("shuffle_p2p", n.worker_address, 1, s)
         await out
 
         await n.process.process.kill()
@@ -1353,10 +1362,10 @@ async def test_restrictions(c, s, a, b):
     y = y.persist(workers=a.address)
 
     await x
-    assert all(stringify(key) in b.data for key in x.__dask_keys__())
+    assert all(key in b.data for key in x.__dask_keys__())
 
     await y
-    assert all(stringify(key) in a.data for key in y.__dask_keys__())
+    assert all(key in a.data for key in y.__dask_keys__())
 
 
 @gen_cluster(client=True)

--- a/distributed/shuffle/tests/utils.py
+++ b/distributed/shuffle/tests/utils.py
@@ -73,7 +73,7 @@ class ShuffleAnnotationChaosPlugin(SchedulerPlugin):
         assert self.scheduler
         if finish != "waiting":
             return
-        if not key.startswith("shuffle-barrier-"):
+        if not isinstance(key, str) or not key.startswith("shuffle-barrier-"):
             return
         if key in self.seen:
             return

--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -274,6 +274,12 @@ class HandledError(Exception):
     pass
 
 
+class CustomFile(zict.File):
+    def _safe_key(self, key):
+        # We don't need _proper_ stringification, just a unique mapping
+        return super()._safe_key(str(key))
+
+
 class Slow(zict.Func[str, object, bytes]):
     max_weight: int | Literal[False]
     weight_by_key: dict[str, SpilledSize]
@@ -293,7 +299,7 @@ class Slow(zict.Func[str, object, bytes]):
             Callable[[object], bytes],
             partial(serialize_bytelist, compression=compression, on_error="raise"),
         )
-        super().__init__(dump, deserialize_bytes, zict.File(spill_directory))
+        super().__init__(dump, deserialize_bytes, CustomFile(spill_directory))
         self.max_weight = max_weight
         self.weight_by_key = {}
         self.total_weight = SpilledSize(0, 0)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4876,7 +4876,6 @@ async def test_recreate_task_futures(c, s, a, b):
     assert function(*args, **kwargs) == 2
 
 
-@pytest.mark.xfail(reason="This is actually using a Series for a key somewhere")
 @gen_cluster(client=True)
 async def test_recreate_task_collection(c, s, a, b):
     b = db.range(10, npartitions=4)
@@ -4913,7 +4912,7 @@ async def test_recreate_task_collection(c, s, a, b):
     # with persist
     df3 = c.persist(df2)
     # recreate_task_locally only works with futures
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError, match="key"):
         function, args, kwargs = await c._get_components_from_future(df3)
 
     f = c.compute(df3)

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -6,7 +6,6 @@ import pytest
 
 import dask
 from dask import delayed
-from dask.utils import stringify
 
 from distributed import Lock, Worker
 from distributed.client import wait
@@ -223,9 +222,9 @@ async def test_resources_str(c, s, a, b):
     yy = y.persist(resources={"MyRes": 1})
     await wait(yy)
 
-    ts_first = s.tasks[stringify(y.__dask_keys__()[0])]
+    ts_first = s.tasks[y.__dask_keys__()[0]]
     assert ts_first.resource_restrictions == {"MyRes": 1}
-    ts_last = s.tasks[stringify(y.__dask_keys__()[-1])]
+    ts_last = s.tasks[y.__dask_keys__()[-1]]
     assert ts_last.resource_restrictions == {"MyRes": 1}
 
 
@@ -415,7 +414,7 @@ async def test_persist_collections(c, s, a, b):
 
     await wait([ww, yy])
 
-    assert all(stringify(key) in a.data for key in y.__dask_keys__())
+    assert all(key in a.data for key in y.__dask_keys__())
 
 
 @pytest.mark.skip(reason="Should protect resource keys from optimization")
@@ -435,7 +434,7 @@ async def test_dont_optimize_out(c, s, a, b):
 
     await c.compute(w, resources={tuple(y.__dask_keys__()): {"A": 1}})
 
-    for key in map(stringify, y.__dask_keys__()):
+    for key in y.__dask_keys__():
         assert "executing" in str(a.state.story(key))
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -223,7 +223,7 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
         secondary_worker_key_fractions = []
         for keys in x.__dask_keys__():
             # Iterate along rows of the array.
-            keys = {k for k in keys}
+            keys = set(keys)
 
             # No more than 2 workers should have any keys
             assert sum(any(k in w.data for k in keys) for w in workers) <= 2

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -363,10 +363,10 @@ async def test_mismatched_span(c, s, a, use_default):
     assert len(sbn[span_name][0].groups) == 1
     assert s.task_groups["x"].span_id == sbn[span_name][0].id
 
-    sts0 = s.tasks[str(x0.key)]
-    sts1 = s.tasks[str(x1.key)]
-    wts0 = a.state.tasks[str(x0.key)]
-    wts1 = a.state.tasks[str(x1.key)]
+    sts0 = s.tasks[x0.key]
+    sts1 = s.tasks[x1.key]
+    wts0 = a.state.tasks[x0.key]
+    wts1 = a.state.tasks[x1.key]
     assert sts0.group is sts1.group
     assert wts0.span_id == wts1.span_id
 
@@ -377,8 +377,8 @@ async def test_mismatched_span(c, s, a, use_default):
     else:
         expect = {"ids": (wts0.span_id,), "name": ("p1",)}
         assert s.plugins["my-plugin"].annotations == [
-            {"span": {"('x', 0)": expect}},
-            {"span": {"('x', 1)": expect}},
+            {"span": {("x", 0): expect}},
+            {"span": {("x", 1): expect}},
         ]
         for ts in (sts0, sts1, wts0, wts1):
             assert ts.annotations["span"] == expect

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -939,13 +939,6 @@ def truncate_exception(e, n=10000):
         return e
 
 
-def validate_key(k):
-    """Validate a key as received on a stream."""
-    typ = type(k)
-    if typ is not str and typ is not bytes:
-        raise TypeError(f"Unexpected key type {typ} (value: {k!r})")
-
-
 def _maybe_complex(task):
     """Possibly contains a nested task"""
     return (

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -27,7 +27,6 @@ from collections.abc import (
     Collection,
     Container,
     Generator,
-    Hashable,
     Iterator,
     KeysView,
     ValuesView,
@@ -942,7 +941,7 @@ def truncate_exception(e, n=10000):
 
 def validate_key(k):
     """Validate a key as received on a stream."""
-    if not isinstance(k, Hashable):
+    if not isinstance(k, (int, float, str, tuple)):
         raise TypeError(f"Unexpected key type {type(k)} (value: {k!r})")
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -942,7 +942,7 @@ def truncate_exception(e, n=10000):
 
 def validate_key(k):
     """Validate a key as received on a stream."""
-    if isinstance(k, Hashable):
+    if not isinstance(k, Hashable):
         raise TypeError(f"Unexpected key type {type(k)} (value: {k!r})")
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -941,7 +941,7 @@ def truncate_exception(e, n=10000):
 
 def validate_key(k):
     """Validate a key as received on a stream."""
-    if not isinstance(k, (int, float, str, tuple)):
+    if not isinstance(k, (bytes, int, float, str, tuple)):
         raise TypeError(f"Unexpected key type {type(k)} (value: {k!r})")
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -941,7 +941,10 @@ def truncate_exception(e, n=10000):
 
 def validate_key(k):
     """Validate a key as received on a stream."""
-    if not isinstance(k, (bytes, int, float, str, tuple)):
+    if isinstance(k, tuple):
+        for e in k:
+            validate_key(e)
+    elif not isinstance(k, (bytes, int, float, str)):
         raise TypeError(f"Unexpected key type {type(k)} (value: {k!r})")
 
 

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -939,6 +939,15 @@ def truncate_exception(e, n=10000):
         return e
 
 
+def validate_key(k):
+    """Validate a key as received on a stream."""
+    typ = type(k)
+    if typ is not str and typ is not tuple:
+        raise TypeError(
+            f"Unexpected key type {typ} (value: {k!r}). Expected str or tuple."
+        )
+
+
 def _maybe_complex(task):
     """Possibly contains a nested task"""
     return (

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -27,6 +27,7 @@ from collections.abc import (
     Collection,
     Container,
     Generator,
+    Hashable,
     Iterator,
     KeysView,
     ValuesView,
@@ -941,11 +942,8 @@ def truncate_exception(e, n=10000):
 
 def validate_key(k):
     """Validate a key as received on a stream."""
-    typ = type(k)
-    if typ is not str and typ is not tuple:
-        raise TypeError(
-            f"Unexpected key type {typ} (value: {k!r}). Expected str or tuple."
-        )
+    if isinstance(k, Hashable):
+        raise TypeError(f"Unexpected key type {type(k)} (value: {k!r})")
 
 
 def _maybe_complex(task):

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 
 from tlz import merge
 
-from dask.utils import parse_timedelta, stringify
+from dask.utils import parse_timedelta
 
 from distributed.client import Future
 from distributed.metrics import time
@@ -184,9 +184,7 @@ class Variable:
 
     async def _set(self, value):
         if isinstance(value, Future):
-            await self.client.scheduler.variable_set(
-                key=stringify(value.key), name=self.name
-            )
+            await self.client.scheduler.variable_set(key=value.key, name=self.name)
         else:
             await self.client.scheduler.variable_set(data=value, name=self.name)
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2400,8 +2400,8 @@ class Worker(BaseWorker, ServerNode):
                 from distributed.actor import Actor  # TODO: create local actor
 
                 data[k] = Actor(type(self.state.actors[k]), self.address, k, self)
-        args2 = pack_data(args, data, key_types=(bytes, str))
-        kwargs2 = pack_data(kwargs, data, key_types=(bytes, str))
+        args2 = pack_data(args, data, key_types=(bytes, str, tuple))
+        kwargs2 = pack_data(kwargs, data, key_types=(bytes, str, tuple))
         stop = time()
         if stop - start > 0.005:
             ts.startstops.append({"action": "disk-read", "start": start, "stop": stop})

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -3591,6 +3591,7 @@ class BaseWorker(abc.ABC):
     def __init__(self, state: WorkerState):
         self.state = state
         self._async_instructions = set()
+        self.debug = dask.config.get("distributed.worker.validate")
 
     def _start_async_instruction(  # type: ignore[valid-type]
         self,
@@ -3716,9 +3717,12 @@ class BaseWorker(abc.ABC):
 
             elif isinstance(inst, GatherDep):
                 assert inst.to_gather
-                keys_str = ", ".join(peekn(27, inst.to_gather)[0])
-                if len(keys_str) > 80:
-                    keys_str = keys_str[:77] + "..."
+                if self.debug:
+                    keys_str = ", ".join(map(str, peekn(27, inst.to_gather)[0]))
+                    if len(keys_str) > 80:
+                        keys_str = keys_str[:77] + "..."
+                else:
+                    keys_str = "..."
 
                 self._start_async_instruction(
                     f"gather_dep({inst.worker}, {{{keys_str}}})",

--- a/docs/source/scheduling-state.rst
+++ b/docs/source/scheduling-state.rst
@@ -105,11 +105,10 @@ not in the "forgotten" state) using several containers:
 
 .. attribute:: tasks: {str: TaskState}
 
-   A dictionary mapping task keys (always strings) to :class:`TaskState`
-   objects.  Task keys are how information about tasks is communicated
-   between the scheduler and clients, or the scheduler and workers; this
-   dictionary is then used to find the corresponding :class:`TaskState`
-   object.
+   A dictionary mapping task keys to :class:`TaskState` objects. Task keys are how
+   information about tasks is communicated between the scheduler and clients, or the
+   scheduler and workers; this dictionary is then used to find the corresponding
+   :class:`TaskState` object.
 
 .. attribute:: unrunnable: {TaskState}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "toolz >= 0.10.0",
     "tornado >= 6.0.4",
     "urllib3 >= 1.24.3",
-    "zict >= 2.2.0",
+    "zict >= 3.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Problem

The distributed scheduler is _stringifying_ keys as a first step when receiving a graph. This is nice because we can rely on keys to be of a single type in the scheduler instead of dealing with a generic `Hashable`.

However, it is also introducing weird artifact of us parsing these str keys again, for example in our P2P extension we have to analyze these strings to infer whether we're dealing with a specific kind (the barrier task)

The stringification is also known to be a performance problem at graph submission time. See https://github.com/dask/distributed/issues/7998 which lists stringify (and subsequent key_splits) to be listed as 12% CPU time each (i.e. in total 24%) of an `update_graph` of a large graph >1-2MM tasks

From a complexity perspective I would love to get rid of stringification (and possible restrict key types to str and tuple, not everything hashable)

## Changes

This PR removes the stringification of keys. Strings will be stored and handled in their raw form on the scheduler. This is a breaking change for plugins with transition hooks.

This PR also restricts keys to the following types: `bytes`, `float`, `int`, `str`, or `tuple`s of these. This is enforced by `validate_key` https://github.com/dask/distributed/blob/75b8055592c64b0e374167da193a6f7c14f06dab/distributed/utils.py#L942-L948 and is a breaking change.

## Migrating

If you run into a `TypeError: TypeError: Unexpected key type...`, please adjust your keys to match the types allowed by `validate_key`. 

If you require strings to be keys, consider whether you achieve your goals by using the raw form of the keys, or to transform the keys to their previous string format using `dask.utils.stringify` as needed.