### PR TITLE
Propagate CancelledError in gather_from_workers

### DIFF
--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -96,10 +96,7 @@ async def gather_from_workers(
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for address, r in zip(d, results):
-            # Note: CancelledError and asyncio.TimeoutError are rare conditions
-            # that can be raised by the network stack.
-            # See https://github.com/dask/distributed/issues/8006
-            if isinstance(r, (OSError, asyncio.CancelledError, asyncio.TimeoutError)):
+            if isinstance(r, OSError):
                 missing_workers.add(address)
             elif isinstance(r, Exception):
                 # For example, deserialization error

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -109,6 +109,9 @@ async def gather_from_workers(
                 for key in d[address]:
                     failed_keys.append(key)
                     del to_gather[key]
+            elif isinstance(r, BaseException):  # pragma: nocover
+                # for example, asyncio.CancelledError
+                raise r
             else:
                 assert isinstance(r, dict), r
                 if r["status"] == "busy":

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -103,10 +103,11 @@ async def gather_from_workers(
                 missing_workers.add(address)
             elif isinstance(r, Exception):
                 # For example, deserialization error
-                logger.exception(
+                logger.error(
                     "Unexpected error while collecting tasks %s from %s",
                     d[address],
                     address,
+                    exc_info=r,
                 )
                 for key in d[address]:
                     failed_keys.append(key)

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -96,7 +96,10 @@ async def gather_from_workers(
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for address, r in zip(d, results):
-            if isinstance(r, OSError):
+            # Note: CancelledError and asyncio.TimeoutError are rare conditions
+            # that can be raised by the network stack.
+            # See https://github.com/dask/distributed/issues/8006
+            if isinstance(r, (OSError, asyncio.CancelledError, asyncio.TimeoutError)):
                 missing_workers.add(address)
             elif isinstance(r, Exception):
                 # For example, deserialization error

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -76,8 +76,8 @@ async def gather_from_workers(
 
             return data, list(to_gather), failed_keys, list(missing_workers)
 
-        tasks = {
-            address: asyncio.create_task(
+        tasks = [
+            asyncio.create_task(
                 retry_operation(
                     partial(
                         get_data_from_worker,
@@ -92,13 +92,13 @@ async def gather_from_workers(
                 name=f"get-data-from-{address}",
             )
             for address, keys in d.items()
-        }
-        for address, task in tasks.items():
-            try:
-                r = await task
-            except OSError:
+        ]
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for address, r in zip(d, results):
+            if isinstance(r, OSError):
                 missing_workers.add(address)
-            except Exception:
+            elif isinstance(r, Exception):
                 # For example, deserialization error
                 logger.exception(
                     "Unexpected error while collecting tasks %s from %s",
@@ -109,6 +109,7 @@ async def gather_from_workers(
                     failed_keys.append(key)
                     del to_gather[key]
             else:
+                assert isinstance(r, dict), r
                 if r["status"] == "busy":
                     busy_workers.add(address)
                     continue


### PR DESCRIPTION
Follow-up from https://github.com/dask/distributed/pull/7997#discussion_r1288630555

Propagate task cancellation downwards from `gather_from_workers` to the `get-data-from-*` tasks. This should hopefully get rid of some of our "task was never awaited" errors.