### PR TITLE
MemorySampler: Ensure x axis is uniform when plotting

### DIFF
--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -169,7 +169,7 @@ class MemorySampler:
         =======
         Output of :meth:`pandas.DataFrame.plot`
         """
-        df = self.to_pandas(align=align) / 2**30
+        df = self.to_pandas(align=align).resample("1s").nearest() / 2**30
         return df.plot(
             xlabel="time",
             ylabel="Cluster memory (GiB)",


### PR DESCRIPTION
I haven't investigate this but it appears that when plotting timeseries data with vastly different runtimes, the longer runtimes can be squeezed hard. Resampling before plotting fixes this

main (notice how the last two ticks on the x axis are 6 minutes apart)

![image](https://github.com/dask/distributed/assets/8629629/991041c8-9dab-45ef-9e7d-529530db951c)


this PR

![image](https://github.com/dask/distributed/assets/8629629/f77d98c8-9a3d-4cfd-92d3-8f8ae3f6bd98)


(The x-axis labels are a bit messed up now. If somebody knows why I'd like to fix that before merging)