### PR TITLE
Make P2P shuffle extensible

### DIFF
--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -238,12 +238,12 @@ def get_worker_plugin() -> ShuffleWorkerPlugin:
             "`shuffle='p2p'` requires Dask's distributed scheduler. This task is not running on a Worker; "
             "please confirm that you've created a distributed Client and are submitting this computation through it."
         ) from e
-    plugin: ShuffleWorkerPlugin | None = worker.plugins.get("shuffle")  # type: ignore
-    if plugin is None:
+    try:
+        plugin: ShuffleWorkerPlugin = worker.plugins["shuffle"]  # type: ignore
+    except KeyError as e:
         raise RuntimeError(
-            f"The worker {worker.address} does not have a ShuffleExtension. "
-            "Is pandas installed on the worker?"
-        )
+            f"The worker {worker.address} does not have a P2P shuffle plugin."
+        ) from e
     return plugin
 
 

--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -49,7 +49,6 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
         self,
         id: ShuffleId,
         run_id: int,
-        output_workers: set[str],
         local_address: str,
         directory: str,
         executor: ThreadPoolExecutor,
@@ -60,7 +59,6 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
     ):
         self.id = id
         self.run_id = run_id
-        self.output_workers = output_workers
         self.local_address = local_address
         self.executor = executor
         self.rpc = rpc
@@ -269,7 +267,6 @@ class ShuffleState(abc.ABC):
 
     id: ShuffleId
     run_id: int
-    output_workers: set[str]
     participating_workers: set[str]
     _archived_by: str | None = field(default=None, init=False)
 
@@ -294,7 +291,6 @@ class ShuffleRunSpec(Generic[_T_partition_id]):
     id: ShuffleId
     run_id: int
     worker_for: dict[_T_partition_id, str]
-    output_workers: set[str]  # TODO: Is this necessary?
 
 
 @dataclass(eq=False)
@@ -303,7 +299,6 @@ class SchedulerShuffleState:
 
     id: ShuffleId
     run_id: int
-    output_workers: set[str]
     participating_workers: set[str]
     _archived_by: str | None = field(default=None, init=False)
 

--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -285,16 +285,16 @@ class ShuffleSpec(abc.ABC, Generic[_T_partition_id]):
     def _pin_output_workers(
         self, plugin: ShuffleSchedulerPlugin
     ) -> dict[_T_partition_id, str]:
-        """TODO"""
+        """Pin output tasks to workers and return the mapping of partition ID to worker."""
 
     @abc.abstractmethod
-    def initialize_run_on_worker(
+    def create_run_on_worker(
         self,
         run_id: int,
         worker_for: dict[_T_partition_id, str],
         plugin: ShuffleWorkerPlugin,
     ) -> ShuffleRun:
-        """TODO"""
+        """Create the new shuffle run on the worker."""
 
 
 @dataclass(eq=False)

--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -239,12 +239,11 @@ def get_worker_plugin() -> ShuffleWorkerPlugin:
             "please confirm that you've created a distributed Client and are submitting this computation through it."
         ) from e
     try:
-        plugin: ShuffleWorkerPlugin = worker.plugins["shuffle"]  # type: ignore
+        return worker.plugins["shuffle"]  # type: ignore
     except KeyError as e:
         raise RuntimeError(
             f"The worker {worker.address} does not have a P2P shuffle plugin."
         ) from e
-    return plugin
 
 
 _BARRIER_PREFIX = "shuffle-barrier-"

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -293,15 +293,14 @@ class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
     This object is responsible for splitting, sending, receiving and combining
     data shards.
 
-    It is entirely agnostic to the distributed system and can perform a shuffle
-    with other `Shuffle` instances using `rpc` and `broadcast`.
+    It is entirely agnostic to the distributed system and can perform a rechunk
+    with other run instances using `rpc``.
 
-    The user of this needs to guarantee that only `Shuffle`s of the same unique
-    `ShuffleID` interact.
+    The user of this needs to guarantee that only `ArrayRechunkRun`s of the same unique
+    `ShuffleID` and `run_id` interact.
 
     Parameters
     ----------
-    # FIXME
     worker_for:
         A mapping partition_id -> worker_address.
     old:
@@ -318,8 +317,6 @@ class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
         The scratch directory to buffer data in.
     executor:
         Thread pool to use for offloading compute.
-    loop:
-        The event loop.
     rpc:
         A callable returning a PooledRPCCall to contact other Shuffle instances.
         Typically a ConnectionPool.

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -463,7 +463,7 @@ class ArrayRechunkSpec(ShuffleSpec[NDIndex]):
             self.id, parts_out, _get_worker_for_hash_sharding
         )
 
-    def initialize_run_on_worker(
+    def create_run_on_worker(
         self,
         run_id: int,
         worker_for: dict[NDIndex, str],

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -308,10 +308,9 @@ class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
 
     Parameters
     ----------
+    # FIXME
     worker_for:
         A mapping partition_id -> worker_address.
-    output_workers:
-        A set of all participating worker (addresses).
     old:
         Existing chunking of the array per dimension.
     new:
@@ -342,7 +341,6 @@ class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
     def __init__(
         self,
         worker_for: dict[NDIndex, str],
-        output_workers: set,
         old: ChunkedAxes,
         new: ChunkedAxes,
         id: ShuffleId,
@@ -358,7 +356,6 @@ class ArrayRechunkRun(ShuffleRun[NDIndex, "np.ndarray"]):
         super().__init__(
             id=id,
             run_id=run_id,
-            output_workers=output_workers,
             local_address=local_address,
             directory=directory,
             executor=executor,
@@ -495,10 +492,9 @@ def _array_rechunk_from_spec(
         id=spec.id,
         run_id=next(SchedulerShuffleState._run_id_iterator),
         worker_for=mapping,
-        output_workers=output_workers,
         old=spec.old,
         new=spec.new,
-        participating_workers=output_workers.copy(),
+        participating_workers=output_workers,
     )
 
 
@@ -508,7 +504,6 @@ def _array_state_to_run_spec(state: ArrayRechunkState) -> ArrayRechunkRunSpec:
         id=state.id,
         run_id=state.run_id,
         worker_for=state.worker_for,
-        output_workers=state.output_workers,
         new=state.new,
         old=state.old,
     )
@@ -520,7 +515,6 @@ def _array_run_spec_to_run(
 ) -> ShuffleRun:
     return ArrayRechunkRun(
         worker_for=spec.worker_for,
-        output_workers=spec.output_workers,
         old=spec.old,
         new=spec.new,
         id=spec.id,

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -4,23 +4,20 @@ import contextlib
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Sequence
-from functools import partial
-from itertools import product
 from typing import TYPE_CHECKING, Any
 
 from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.protocol.pickle import dumps
+from distributed.protocol.serialize import ToPickle
 from distributed.shuffle._core import (
+    SchedulerShuffleState,
     ShuffleId,
-    ShuffleState,
-    ShuffleType,
+    ShuffleRunSpec,
+    ShuffleSpec,
     barrier_key,
     id_from_key,
-)
-from distributed.shuffle._rechunk import ArrayRechunkState, get_worker_for_hash_sharding
-from distributed.shuffle._shuffle import (
-    DataFrameShuffleState,
-    get_worker_for_range_sharding,
+    scheduler_state_to_run_spec,
+    spec_to_scheduler_state,
 )
 from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin
 
@@ -47,10 +44,10 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
     """
 
     scheduler: Scheduler
-    active_shuffles: dict[ShuffleId, ShuffleState]
+    active_shuffles: dict[ShuffleId, SchedulerShuffleState]
     heartbeats: defaultdict[ShuffleId, dict]
-    _shuffles: defaultdict[ShuffleId, set[ShuffleState]]
-    _archived_by_stimulus: defaultdict[str, set[ShuffleState]]
+    _shuffles: defaultdict[ShuffleId, set[SchedulerShuffleState]]
+    _archived_by_stimulus: defaultdict[str, set[SchedulerShuffleState]]
 
     def __init__(self, scheduler: Scheduler):
         self.scheduler = scheduler
@@ -79,7 +76,8 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
 
     async def barrier(self, id: ShuffleId, run_id: int) -> None:
         shuffle = self.active_shuffles[id]
-        assert shuffle.run_id == run_id, f"{run_id=} does not match {shuffle}"
+        if shuffle.run_id != run_id:
+            raise ValueError(f"{run_id=} does not match {shuffle}")
         msg = {"op": "shuffle_inputs_done", "shuffle_id": id, "run_id": run_id}
         await self.scheduler.broadcast(
             msg=msg,
@@ -107,7 +105,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
             if shuffle_id in self.shuffle_ids():
                 self.heartbeats[shuffle_id][ws.address].update(d)
 
-    def get(self, id: ShuffleId, worker: str) -> dict[str, Any]:
+    def get(self, id: ShuffleId, worker: str) -> ToPickle[ShuffleRunSpec]:
         if worker not in self.scheduler.workers:
             # This should never happen
             raise RuntimeError(
@@ -115,36 +113,27 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
             )  # pragma: nocover
         state = self.active_shuffles[id]
         state.participating_workers.add(worker)
-        return state.to_msg()
+        return ToPickle(scheduler_state_to_run_spec(state))
 
     def get_or_create(
         self,
-        id: ShuffleId,
+        spec: ShuffleSpec,
         key: str,
-        type: str,
         worker: str,
-        spec: dict[str, Any],
-    ) -> dict:
+    ) -> ToPickle[ShuffleRunSpec]:
         try:
-            return self.get(id, worker)
+            return self.get(spec.id, worker)
         except KeyError:
             # FIXME: The current implementation relies on the barrier task to be
             # known by its name. If the name has been mangled, we cannot guarantee
             # that the shuffle works as intended and should fail instead.
-            self._raise_if_barrier_unknown(id)
+            self._raise_if_barrier_unknown(spec.id)
             self._raise_if_task_not_processing(key)
-
-            state: ShuffleState
-            if type == ShuffleType.DATAFRAME:
-                state = self._create_dataframe_shuffle_state(id, spec)
-            elif type == ShuffleType.ARRAY_RECHUNK:
-                state = self._create_array_rechunk_state(id, spec)
-            else:  # pragma: no cover
-                raise TypeError(type)
-            self.active_shuffles[id] = state
-            self._shuffles[id].add(state)
+            state: SchedulerShuffleState = spec_to_scheduler_state(spec, self)
+            self.active_shuffles[spec.id] = state
+            self._shuffles[spec.id].add(state)
             state.participating_workers.add(worker)
-            return state.to_msg()
+            return ToPickle(scheduler_state_to_run_spec(state))
 
     def _raise_if_barrier_unknown(self, id: ShuffleId) -> None:
         key = barrier_key(id)
@@ -161,30 +150,6 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         task = self.scheduler.tasks[key]
         if task.state != "processing":
             raise RuntimeError(f"Expected {task} to be processing, is {task.state}.")
-
-    def _create_dataframe_shuffle_state(
-        self, id: ShuffleId, spec: dict[str, Any]
-    ) -> DataFrameShuffleState:
-        column = spec["column"]
-        npartitions = spec["npartitions"]
-        parts_out = spec["parts_out"]
-        assert column is not None
-        assert npartitions is not None
-        assert parts_out is not None
-
-        pick_worker = partial(get_worker_for_range_sharding, npartitions)
-
-        mapping = self._pin_output_workers(id, parts_out, pick_worker)
-        output_workers = set(mapping.values())
-
-        return DataFrameShuffleState(
-            id=id,
-            run_id=next(ShuffleState._run_id_iterator),
-            worker_for=mapping,
-            column=column,
-            output_workers=output_workers,
-            participating_workers=output_workers.copy(),
-        )
 
     def _pin_output_workers(
         self,
@@ -231,28 +196,6 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
             self._set_restriction(dt, worker)
 
         return mapping
-
-    def _create_array_rechunk_state(
-        self, id: ShuffleId, spec: dict[str, Any]
-    ) -> ArrayRechunkState:
-        old = spec["old"]
-        new = spec["new"]
-        assert old is not None
-        assert new is not None
-
-        parts_out = product(*(range(len(c)) for c in new))
-        mapping = self._pin_output_workers(id, parts_out, get_worker_for_hash_sharding)
-        output_workers = set(mapping.values())
-
-        return ArrayRechunkState(
-            id=id,
-            run_id=next(ShuffleState._run_id_iterator),
-            worker_for=mapping,
-            output_workers=output_workers,
-            old=old,
-            new=new,
-            participating_workers=output_workers.copy(),
-        )
 
     def _set_restriction(self, ts: TaskState, worker: str) -> None:
         if "shuffle_original_restrictions" in ts.annotations:
@@ -361,7 +304,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
                     if not archived:
                         del self._archived_by_stimulus[shuffle._archived_by]
 
-    def _fail_on_workers(self, shuffle: ShuffleState, message: str) -> None:
+    def _fail_on_workers(self, shuffle: SchedulerShuffleState, message: str) -> None:
         worker_msgs = {
             worker: [
                 {

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -356,10 +356,9 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
 
     Parameters
     ----------
+    # FIXME
     worker_for:
         A mapping partition_id -> worker_address.
-    output_workers:
-        A set of all participating worker (addresses).
     column:
         The data column we split the input partition by.
     id:
@@ -388,7 +387,6 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
     def __init__(
         self,
         worker_for: dict[int, str],
-        output_workers: set,
         column: str,
         id: ShuffleId,
         run_id: int,
@@ -405,7 +403,6 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         super().__init__(
             id=id,
             run_id=run_id,
-            output_workers=output_workers,
             local_address=local_address,
             directory=directory,
             executor=executor,
@@ -534,8 +531,7 @@ def _dataframe_spec_to_state(
         run_id=next(SchedulerShuffleState._run_id_iterator),
         worker_for=mapping,
         column=spec.column,
-        output_workers=output_workers,
-        participating_workers=output_workers.copy(),
+        participating_workers=output_workers,
     )
 
 
@@ -545,7 +541,6 @@ def _dataframe_state_to_run_spec(state: DataFrameShuffleState) -> ShuffleRunSpec
         id=state.id,
         run_id=state.run_id,
         worker_for=state.worker_for,
-        output_workers=state.output_workers,
         column=state.column,
     )
 
@@ -557,7 +552,6 @@ def _dataframe_run_spec_to_run(
     return DataFrameShuffleRun(
         column=spec.column,
         worker_for=spec.worker_for,
-        output_workers=spec.output_workers,
         id=spec.id,
         run_id=spec.run_id,
         directory=os.path.join(

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -342,14 +342,13 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
     data shards.
 
     It is entirely agnostic to the distributed system and can perform a shuffle
-    with other `Shuffle` instances using `rpc` and `broadcast`.
+    with other run instances using `rpc`.
 
-    The user of this needs to guarantee that only `Shuffle`s of the same unique
-    `ShuffleID` interact.
+    The user of this needs to guarantee that only `DataFrameShuffleRun`s of the
+    same unique `ShuffleID` and `run_id` interact.
 
     Parameters
     ----------
-    # FIXME
     worker_for:
         A mapping partition_id -> worker_address.
     column:
@@ -364,8 +363,6 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         The scratch directory to buffer data in.
     executor:
         Thread pool to use for offloading compute.
-    loop:
-        The event loop.
     rpc:
         A callable returning a PooledRPCCall to contact other Shuffle instances.
         Typically a ConnectionPool.

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -502,7 +502,7 @@ class DataFrameShuffleSpec(ShuffleSpec[int]):
         pick_worker = partial(_get_worker_for_range_sharding, self.npartitions)
         return plugin._pin_output_workers(self.id, self.parts_out, pick_worker)
 
-    def initialize_run_on_worker(
+    def create_run_on_worker(
         self, run_id: int, worker_for: dict[int, str], plugin: ShuffleWorkerPlugin
     ) -> ShuffleRun:
         return DataFrameShuffleRun(

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -288,7 +288,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
                 self.worker._ongoing_background_tasks.call_soon(_, self, existing)
 
-        shuffle: ShuffleRun = result.spec.initialize_run_on_worker(
+        shuffle: ShuffleRun = result.spec.create_run_on_worker(
             result.run_id, result.worker_for, self
         )
         self.shuffles[shuffle_id] = shuffle

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -16,7 +16,6 @@ from distributed.shuffle._core import (
     ShuffleRun,
     ShuffleRunSpec,
     ShuffleSpec,
-    run_spec_to_worker_run,
 )
 from distributed.shuffle._exceptions import ShuffleClosedError
 from distributed.shuffle._limiter import ResourceLimiter
@@ -289,7 +288,9 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
                 self.worker._ongoing_background_tasks.call_soon(_, self, existing)
 
-        shuffle: ShuffleRun = run_spec_to_worker_run(result, self)
+        shuffle: ShuffleRun = result.spec.initialize_run_on_worker(
+            result.run_id, result.worker_for, self
+        )
         self.shuffles[shuffle_id] = shuffle
         self._runs.add(shuffle)
         return shuffle

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, overload
 
@@ -10,11 +9,17 @@ from dask.context import thread_state
 from dask.utils import parse_bytes
 
 from distributed.diagnostics.plugin import WorkerPlugin
-from distributed.shuffle._core import NDIndex, ShuffleId, ShuffleRun, ShuffleType
+from distributed.protocol.serialize import ToPickle
+from distributed.shuffle._core import (
+    NDIndex,
+    ShuffleId,
+    ShuffleRun,
+    ShuffleRunSpec,
+    ShuffleSpec,
+    run_spec_to_worker_run,
+)
 from distributed.shuffle._exceptions import ShuffleClosedError
 from distributed.shuffle._limiter import ResourceLimiter
-from distributed.shuffle._rechunk import ArrayRechunkRun
-from distributed.shuffle._shuffle import DataFrameShuffleRun
 from distributed.utils import log_errors, sync
 
 if TYPE_CHECKING:
@@ -22,6 +27,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from distributed.worker import Worker
+
 
 logger = logging.getLogger(__name__)
 
@@ -127,17 +133,17 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     def add_partition(
         self,
         data: Any,
-        partition_id: int | tuple[int, ...],
-        shuffle_id: ShuffleId,
-        type: ShuffleType,
+        partition_id: int | NDIndex,
+        spec: ShuffleSpec,
         **kwargs: Any,
     ) -> int:
-        shuffle = self.get_or_create_shuffle(shuffle_id, type=type, **kwargs)
+        shuffle = self.get_or_create_shuffle(spec)
         return sync(
             self.worker.loop,
             shuffle.add_partition,
             data=data,
             partition_id=partition_id,
+            **kwargs,
         )
 
     async def _barrier(self, shuffle_id: ShuffleId, run_ids: list[int]) -> int:
@@ -149,7 +155,8 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         """
         run_id = run_ids[0]
         # Assert that all input data has been shuffled using the same run_id
-        assert all(run_id == id for id in run_ids)
+        if any(run_id != id for id in run_ids):
+            raise RuntimeError(f"Expected all run IDs to match: {run_ids=}")
         # Tell all peers that we've reached the barrier
         # Note that this will call `shuffle_inputs_done` on our own worker as well
         shuffle = await self._get_shuffle_run(shuffle_id, run_id)
@@ -194,10 +201,8 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
     async def _get_or_create_shuffle(
         self,
-        shuffle_id: ShuffleId,
-        type: ShuffleType,
+        spec: ShuffleSpec,
         key: str,
-        **kwargs: Any,
     ) -> ShuffleRun:
         """Get or create a shuffle matching the ID and data spec.
 
@@ -210,13 +215,12 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         key:
             Task key triggering the function
         """
-        shuffle = self.shuffles.get(shuffle_id, None)
+        shuffle = self.shuffles.get(spec.id, None)
         if shuffle is None:
             shuffle = await self._refresh_shuffle(
-                shuffle_id=shuffle_id,
-                type=type,
+                shuffle_id=spec.id,
+                spec=ToPickle(spec),
                 key=key,
-                kwargs=kwargs,
             )
 
         if self.closed:
@@ -236,58 +240,38 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     async def _refresh_shuffle(
         self,
         shuffle_id: ShuffleId,
-        type: ShuffleType,
+        spec: ToPickle,
         key: str,
-        kwargs: dict,
     ) -> ShuffleRun:
         ...
 
     async def _refresh_shuffle(
         self,
         shuffle_id: ShuffleId,
-        type: ShuffleType | None = None,
+        spec: ToPickle | None = None,
         key: str | None = None,
-        kwargs: dict | None = None,
     ) -> ShuffleRun:
-        result: dict[str, Any]
-        if type is None:
+        result: ShuffleRunSpec
+        if spec is None:
             result = await self.worker.scheduler.shuffle_get(
                 id=shuffle_id,
                 worker=self.worker.address,
             )
-        elif type == ShuffleType.DATAFRAME:
-            assert kwargs is not None
+        else:
             result = await self.worker.scheduler.shuffle_get_or_create(
-                id=shuffle_id,
+                spec=spec,
                 key=key,
-                type=type,
-                spec={
-                    "npartitions": kwargs["npartitions"],
-                    "column": kwargs["column"],
-                    "parts_out": kwargs["parts_out"],
-                },
                 worker=self.worker.address,
             )
-        elif type == ShuffleType.ARRAY_RECHUNK:
-            assert kwargs is not None
-            result = await self.worker.scheduler.shuffle_get_or_create(
-                id=shuffle_id,
-                key=key,
-                type=type,
-                spec=kwargs,
-                worker=self.worker.address,
-            )
-        else:  # pragma: no cover
-            raise TypeError(type)
-        if result["status"] == "error":
-            raise RuntimeError(result["message"])
-        assert result["status"] == "OK"
+        # if result["status"] == "error":
+        # raise RuntimeError(result["message"])
+        # assert result["status"] == "OK"
 
         if self.closed:
             raise ShuffleClosedError(f"{self} has already been closed")
         if shuffle_id in self.shuffles:
             existing = self.shuffles[shuffle_id]
-            if existing.run_id >= result["run_id"]:
+            if existing.run_id >= result.run_id:
                 return existing
             else:
                 self.shuffles.pop(shuffle_id)
@@ -305,65 +289,10 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
                 self.worker._ongoing_background_tasks.call_soon(_, self, existing)
 
-        shuffle = self._create_shuffle_run(shuffle_id, result)
+        shuffle: ShuffleRun = run_spec_to_worker_run(result, self)
         self.shuffles[shuffle_id] = shuffle
         self._runs.add(shuffle)
         return shuffle
-
-    def _create_shuffle_run(
-        self, shuffle_id: ShuffleId, result: dict[str, Any]
-    ) -> ShuffleRun:
-        shuffle: ShuffleRun
-        if result["type"] == ShuffleType.DATAFRAME:
-            shuffle = self._create_dataframe_shuffle_run(shuffle_id, result)
-        elif result["type"] == ShuffleType.ARRAY_RECHUNK:
-            shuffle = self._create_array_rechunk_run(shuffle_id, result)
-        else:  # pragma: no cover
-            raise TypeError(result["type"])
-        return shuffle
-
-    def _create_dataframe_shuffle_run(
-        self, shuffle_id: ShuffleId, result: dict[str, Any]
-    ) -> DataFrameShuffleRun:
-        return DataFrameShuffleRun(
-            column=result["column"],
-            worker_for=result["worker_for"],
-            output_workers=result["output_workers"],
-            id=shuffle_id,
-            run_id=result["run_id"],
-            directory=os.path.join(
-                self.worker.local_directory,
-                f"shuffle-{shuffle_id}-{result['run_id']}",
-            ),
-            executor=self._executor,
-            local_address=self.worker.address,
-            rpc=self.worker.rpc,
-            scheduler=self.worker.scheduler,
-            memory_limiter_disk=self.memory_limiter_disk,
-            memory_limiter_comms=self.memory_limiter_comms,
-        )
-
-    def _create_array_rechunk_run(
-        self, shuffle_id: ShuffleId, result: dict[str, Any]
-    ) -> ArrayRechunkRun:
-        return ArrayRechunkRun(
-            worker_for=result["worker_for"],
-            output_workers=result["output_workers"],
-            old=result["old"],
-            new=result["new"],
-            id=shuffle_id,
-            run_id=result["run_id"],
-            directory=os.path.join(
-                self.worker.local_directory,
-                f"shuffle-{shuffle_id}-{result['run_id']}",
-            ),
-            executor=self._executor,
-            local_address=self.worker.address,
-            rpc=self.worker.rpc,
-            scheduler=self.worker.scheduler,
-            memory_limiter_disk=self.memory_limiter_disk,
-            memory_limiter_comms=self.memory_limiter_comms,
-        )
 
     async def teardown(self, worker: Worker) -> None:
         assert not self.closed
@@ -406,18 +335,14 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
     def get_or_create_shuffle(
         self,
-        shuffle_id: ShuffleId,
-        type: ShuffleType,
-        **kwargs: Any,
+        spec: ShuffleSpec,
     ) -> ShuffleRun:
         key = thread_state.key
         return sync(
             self.worker.loop,
             self._get_or_create_shuffle,
-            shuffle_id,
-            type,
+            spec,
             key,
-            **kwargs,
         )
 
     def get_output_partition(

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -22,7 +22,7 @@ from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._rechunk import (
     ArrayRechunkRun,
     Split,
-    get_worker_for_hash_sharding,
+    _get_worker_for_hash_sharding,
     split_axes,
 )
 from distributed.shuffle.tests.utils import AbstractShuffleTestPool
@@ -97,7 +97,7 @@ async def test_lowlevel_rechunk(
 
     new_indices = list(product(*(range(len(dim)) for dim in new)))
     for i, idx in enumerate(new_indices):
-        worker_for_mapping[idx] = get_worker_for_hash_sharding(i, workers)
+        worker_for_mapping[idx] = _get_worker_for_hash_sharding(i, workers)
 
     assert len(set(worker_for_mapping.values())) == min(n_workers, len(new_indices))
 

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -55,8 +55,6 @@ class ArrayRechunkTestPool(AbstractShuffleTestPool):
     ):
         s = Shuffle(
             worker_for=worker_for_mapping,
-            # FIXME: Is output_workers redundant with worker_for?
-            output_workers=set(worker_for_mapping.values()),
             old=old,
             new=new,
             directory=directory / name,

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1456,8 +1456,6 @@ class DataFrameShuffleTestPool(AbstractShuffleTestPool):
         s = Shuffle(
             column="_partition",
             worker_for=worker_for_mapping,
-            # FIXME: Is output_workers redundant with worker_for?
-            output_workers=set(worker_for_mapping.values()),
             directory=directory / name,
             id=ShuffleId(name),
             run_id=next(AbstractShuffleTestPool._shuffle_run_id_iterator),

--- a/distributed/shuffle/tests/test_shuffle_plugins.py
+++ b/distributed/shuffle/tests/test_shuffle_plugins.py
@@ -4,18 +4,17 @@ from asyncio import iscoroutinefunction
 
 import pytest
 
+from distributed.shuffle._scheduler_plugin import ShuffleSchedulerPlugin
 from distributed.shuffle._shuffle import (
-    get_worker_for_range_sharding,
+    _get_worker_for_range_sharding,
     split_by_partition,
     split_by_worker,
 )
+from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin
+from distributed.utils_test import gen_cluster
 
 pd = pytest.importorskip("pandas")
 dd = pytest.importorskip("dask.dataframe")
-
-from distributed.shuffle._scheduler_plugin import ShuffleSchedulerPlugin
-from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin
-from distributed.utils_test import gen_cluster
 
 
 @gen_cluster([("", 1)])
@@ -52,7 +51,7 @@ def test_split_by_worker():
     worker_for_mapping = {}
     npartitions = 3
     for part in range(npartitions):
-        worker_for_mapping[part] = get_worker_for_range_sharding(
+        worker_for_mapping[part] = _get_worker_for_range_sharding(
             npartitions, part, workers
         )
     worker_for = pd.Series(worker_for_mapping, name="_workers").astype("category")
@@ -90,15 +89,15 @@ def test_split_by_worker_many_workers():
     npartitions = 10
     worker_for_mapping = {}
     for part in range(npartitions):
-        worker_for_mapping[part] = get_worker_for_range_sharding(
+        worker_for_mapping[part] = _get_worker_for_range_sharding(
             npartitions, part, workers
         )
     worker_for = pd.Series(worker_for_mapping, name="_workers").astype("category")
     out = split_by_worker(df, "_partition", worker_for)
-    assert get_worker_for_range_sharding(npartitions, 5, workers) in out
-    assert get_worker_for_range_sharding(npartitions, 0, workers) in out
-    assert get_worker_for_range_sharding(npartitions, 7, workers) in out
-    assert get_worker_for_range_sharding(npartitions, 1, workers) in out
+    assert _get_worker_for_range_sharding(npartitions, 5, workers) in out
+    assert _get_worker_for_range_sharding(npartitions, 0, workers) in out
+    assert _get_worker_for_range_sharding(npartitions, 7, workers) in out
+    assert _get_worker_for_range_sharding(npartitions, 1, workers) in out
 
     assert sum(map(len, out.values())) == len(df)
 


### PR DESCRIPTION
This PR replaces hard-coded logic for handling dataframe shuffles and array rechunking with a dispatch mechanism. The main goal is to improve the separation of concerns and making the P2P mechanism extensible for other kinds of "shuffle-like" operations.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
