### PR TITLE
Ensure `NannyPlugin`s are always installed

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -366,7 +366,12 @@ class Nanny(ServerNode):
                 if response != Status.running:
                     raise RuntimeError("Nanny failed to start worker process")
             except Exception:
-                await comm.write({"status": "error"})
+                try:
+                    await comm.write({"status": "error"})
+
+                # If self.instantiate() failed, the comm will already be closed.
+                except CommClosedError:
+                    pass
                 await self.close(reason="nanny-start-failed")
                 raise
             else:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3624,6 +3624,8 @@ class Scheduler(SchedulerState, ServerNode):
         self.event_subscriber = defaultdict(set)
         self.worker_plugins = {}
         self.nanny_plugins = {}
+        self._starting_nannies = set()
+        self._starting_nannies_cond = asyncio.Condition()
 
         worker_handlers = {
             "task-finished": self.handle_task_finished,
@@ -3656,6 +3658,7 @@ class Scheduler(SchedulerState, ServerNode):
             "scatter": self.scatter,
             "register-worker": self.add_worker,
             "register_nanny": self.add_nanny,
+            "deregister_nanny": self.remove_nanny,
             "unregister": self.remove_worker,
             "gather": self.gather,
             "retry": self.stimulus_retry,
@@ -4206,6 +4209,11 @@ class Scheduler(SchedulerState, ServerNode):
         self.log_event(address, {"action": "add-worker"})
         self.log_event("all", {"action": "add-worker", "worker": address})
 
+        if nanny and nanny in self._starting_nannies:
+            async with self._starting_nannies_cond:
+                self._starting_nannies.remove(nanny)
+                self._starting_nannies_cond.notify_all()
+
         self.workers[address] = ws = WorkerState(
             address=address,
             status=Status.lookup[status],  # type: ignore
@@ -4296,12 +4304,19 @@ class Scheduler(SchedulerState, ServerNode):
         # This will keep running until the worker is removed
         await self.handle_worker(comm, address)
 
-    async def add_nanny(self) -> dict[str, Any]:
-        msg = {
-            "status": "OK",
-            "nanny-plugins": self.nanny_plugins,
-        }
-        return msg
+    async def add_nanny(self, address: str) -> dict[str, Any]:
+        async with self._starting_nannies_cond:
+            self._starting_nannies.add(address)
+            msg = {
+                "status": "OK",
+                "nanny-plugins": self.nanny_plugins,
+            }
+            return msg
+
+    async def remove_nanny(self, address: str) -> None:
+        async with self._starting_nannies_cond:
+            self._starting_nannies.discard(address)
+            self._starting_nannies_cond.notify_all()
 
     def _match_graph_with_tasks(
         self, dsk: dict[str, Any], dependencies: dict[str, set[str]], keys: set[str]
@@ -7459,15 +7474,21 @@ class Scheduler(SchedulerState, ServerNode):
         responses = await self.broadcast(msg=dict(op="plugin-remove", name=name))
         return responses
 
-    async def register_nanny_plugin(self, comm, plugin, name=None):
+    async def register_nanny_plugin(self, comm, plugin, name):
         """Registers a setup function, and call it on every worker"""
+        logger.info("Registering Nanny plugin %s", name)
         self.nanny_plugins[name] = plugin
-
-        responses = await self.broadcast(
-            msg=dict(op="plugin_add", plugin=plugin, name=name),
-            nanny=True,
-        )
-        return responses
+        async with self._starting_nannies_cond:
+            if self._starting_nannies:
+                logger.info("Waiting for Nannies to start %s", self._starting_nannies)
+            await self._starting_nannies_cond.wait_for(
+                lambda: not self._starting_nannies
+            )
+            responses = await self.broadcast(
+                msg=dict(op="plugin_add", plugin=plugin, name=name),
+                nanny=True,
+            )
+            return responses
 
     async def unregister_nanny_plugin(self, comm, name):
         """Unregisters a worker plugin"""

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7457,6 +7457,7 @@ class Scheduler(SchedulerState, ServerNode):
 
     async def register_worker_plugin(self, comm, plugin, name=None):
         """Registers a worker plugin on all running and future workers"""
+        logger.info("Registering Worker plugin %s", name)
         self.worker_plugins[name] = plugin
 
         responses = await self.broadcast(

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -661,7 +661,6 @@ async def test_close_joins(s):
         assert not p.process
 
 
-# FIXME
 @gen_cluster(Worker=Nanny, nthreads=[("", 1)])
 async def test_scheduler_crash_doesnt_restart(s, a):
     # Simulate a scheduler crash by disconnecting it first


### PR DESCRIPTION
There is a race condition that allows to ignore and not setup a `NannyPlugin` on a `Nanny` if said `Nanny` is _starting_ while the registration is happening. This Nanny would never receive the plugin and we'd end up in an inconsistent state.

Closes https://github.com/dask/distributed/issues/8100

This implementation guarantees strong consistency such that once `client.register_worker_plugin` is called, all present and future Nannies are guaranteed to have the plugin setup. If a Nanny is current starting while this API is called, it is blocking until all intermediate state Nannies are up. Subsequently, all Nannies that want to start after `register_worker_plugin` has been called but not completed, have to wait.
This strong guarantee requires a mutex which makes the implementation a little more complex but I believe this is the right choice for UX. Inconsistencies that arise from these races are very difficult to debug for end users and I believe this complexity if warranted for such a common situation.

If we imposed only eventual consistency, i.e. we allowed for a brief period after `register_worker_plugin` to be inconsistent, we could instead get away with installing the plugin on the inconsistent `Nanny` after it is properly started and restarting the worker afterwards. I chose to not go for this approach since we would have to keep state about currently starting Nannies as well (`Scheduler.add/remove_nanny`). While the concurrency control would be simpler, the UX would be much worse.