### PR TITLE
Use `task.uncancel` when suppressing cancellation in ConnectionPool

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1544,6 +1544,8 @@ class ConnectionPool:
                 self._connecting_count -= 1
         except asyncio.CancelledError:
             current_task = asyncio.current_task()
+            if sys.version_info >= (3, 11):
+                current_task.uncancel()
             assert current_task
             reason = self._reasons.pop(current_task, "ConnectionPool closing.")
             raise CommClosedError(reason)


### PR DESCRIPTION
This is possibly why we've seen spurious CancelledErrors popping up recently.

Python 3.11 changes semantics around cancellation. The docs explicitly state that when we want to suppress cancellation we have to uncancel the task, see https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.uncancel

Some background about this cancellation suppression [over here](https://github.com/dask/distributed/pull/6005)

I don't really know how to test this...