### PR TITLE
use asyncio.timeout() in ConnectionPool where available

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import math
 import os
 import sys
 import tempfile
@@ -1450,13 +1451,12 @@ class ConnectionPool:
         # _connecting contains futures actively trying to establish a connection
         # while the _n_connecting also accounts for connection attempts which
         # are waiting due to the connection limit
-        self._connecting: defaultdict[str, set[asyncio.Task[Comm]]] = defaultdict(set)
+        self._connecting: defaultdict[str, set[Callable[[str], None]]] = defaultdict(
+            set
+        )
         self._pending_count = 0
         self._connecting_count = 0
         self.status = Status.init
-        self._reasons: weakref.WeakKeyDictionary[
-            asyncio.Task[Any], str
-        ] = weakref.WeakKeyDictionary()
 
     def _validate(self) -> None:
         """
@@ -1564,43 +1564,75 @@ class ConnectionPool:
         if self.semaphore.locked():
             self.collect()
 
-        # This construction is there to ensure that cancellation requests from
-        # the outside can be distinguished from cancellations of our own.
-        # Once the CommPool closes, we'll cancel the connect_attempt which will
-        # raise an OSError
-        # If the ``connect`` is cancelled from the outside, the Event.wait will
-        # be cancelled instead which we'll reraise as a CancelledError and allow
-        # it to propagate
-        connect_attempt = asyncio.create_task(self._connect(addr, timeout))
-        done = asyncio.Event()
-        connecting = self._connecting[addr]
-        connecting.add(connect_attempt)
+        if sys.version_info >= (3, 11):
+            reason: str | None = None
+            try:
+                async with asyncio.timeout(math.inf) as scope:
 
-        def callback(task: asyncio.Task[Comm]) -> None:
-            done.set()
+                    def cancel_timeout_cb(reason_: str) -> None:
+                        nonlocal reason
+                        reason = reason_
+                        scope.reschedule(-1)
+
+                    self._connecting[addr].add(cancel_timeout_cb)
+                    try:
+                        return await self._connect(addr=addr, timeout=timeout)
+                    finally:
+                        connecting = self._connecting[addr]
+                        connecting.discard(cancel_timeout_cb)
+                        if not connecting:
+                            try:
+                                del self._connecting[addr]
+                            except KeyError:
+                                pass
+            except TimeoutError:
+                if reason is None:
+                    raise
+                raise CommClosedError(reason)
+        else:
+            # This construction is there to ensure that cancellation requests from
+            # the outside can be distinguished from cancellations of our own.
+            # Once the CommPool closes, we'll cancel the connect_attempt which will
+            # raise an OSError
+            # If the ``connect`` is cancelled from the outside, the Event.wait will
+            # be cancelled instead which we'll reraise as a CancelledError and allow
+            # it to propagate
+            connect_attempt = asyncio.create_task(self._connect(addr, timeout))
+            done = asyncio.Event()
+            reason = "ConnectionPool closing."
+
+            def cancel_task_cb(reason_: str) -> None:
+                nonlocal reason
+                reason = reason_
+                connect_attempt.cancel()
+
             connecting = self._connecting[addr]
-            connecting.discard(task)
+            connecting.add(cancel_task_cb)
 
-            if not connecting:
-                try:
-                    del self._connecting[addr]
-                except KeyError:  # pragma: no cover
-                    pass
+            def callback(task: asyncio.Task[Comm]) -> None:
+                done.set()
+                connecting = self._connecting[addr]
+                connecting.discard(cancel_task_cb)
 
-        connect_attempt.add_done_callback(callback)
+                if not connecting:
+                    try:
+                        del self._connecting[addr]
+                    except KeyError:  # pragma: no cover
+                        pass
 
-        try:
-            await done.wait()
-        except asyncio.CancelledError:
-            # This is an outside cancel attempt
-            connect_attempt.cancel()
-            await connect_attempt
-            raise
-        try:
-            return connect_attempt.result()
-        except asyncio.CancelledError:
-            reason = self._reasons.pop(connect_attempt, "ConnectionPool closing.")
-            raise CommClosedError(reason)
+            connect_attempt.add_done_callback(callback)
+
+            try:
+                await done.wait()
+            except asyncio.CancelledError:
+                # This is an outside cancel attempt
+                connect_attempt.cancel()
+                await connect_attempt
+                raise
+            try:
+                return connect_attempt.result()
+            except asyncio.CancelledError:
+                raise CommClosedError(reason)
 
     def reuse(self, addr: str, comm: Comm) -> None:
         """
@@ -1654,19 +1686,18 @@ class ConnectionPool:
                 self.semaphore.release()
 
         if addr in self._connecting:
-            tasks = self._connecting[addr]
-            for task in tasks:
-                self._reasons[task] = reason
-                task.cancel()
+            cbs = self._connecting[addr]
+            for cb in cbs:
+                cb(reason)
 
     async def close(self) -> None:
         """
         Close all communications
         """
         self.status = Status.closed
-        for tasks in self._connecting.values():
-            for task in tasks:
-                task.cancel()
+        for cbs in self._connecting.values():
+            for cb in cbs:
+                cb("ConnectionPool closing.")
         for d in [self.available, self.occupied]:
             comms = set()
             while d:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1564,6 +1564,9 @@ class ConnectionPool:
         if self.semaphore.locked():
             self.collect()
 
+        # on 3.11 this uses asyncio.timeout as a cancel scope to avoid having
+        # to track inner and outer CancelledError exceptions and correctly
+        # call .uncancel() when a CancelledError is caught.
         if sys.version_info >= (3, 11):
             reason: str | None = None
             try:

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -599,7 +599,7 @@ async def test_new_metrics_during_heartbeat(c, s, a):
         a.digest_metric(("execute", span.id, "x", "test", "test"), 1)
         await asyncio.sleep(0)
     await hb_task
-    assert n > 10
+    assert n > 9
     await a.heartbeat()
 
     assert a.digests_total["execute", span.id, "x", "test", "test"] == n


### PR DESCRIPTION
alternative to https://github.com/dask/distributed/pull/8108

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
