### PR TITLE
Handle `CancelledError` properly in `ConnectionPool`

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1599,9 +1599,7 @@ class ConnectionPool:
         try:
             return connect_attempt.result()
         except asyncio.CancelledError:
-            current_task = asyncio.current_task()
-            assert current_task
-            reason = self._reasons.pop(current_task, "ConnectionPool closing.")
+            reason = self._reasons.pop(connect_attempt, "ConnectionPool closing.")
             raise CommClosedError(reason)
 
     def reuse(self, addr: str, comm: Comm) -> None:

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1542,11 +1542,6 @@ class ConnectionPool:
                 raise
             finally:
                 self._connecting_count -= 1
-        except asyncio.CancelledError:
-            current_task = asyncio.current_task()
-            assert current_task
-            reason = self._reasons.pop(current_task, "ConnectionPool closing.")
-            raise CommClosedError(reason)
         finally:
             self._pending_count -= 1
 
@@ -1599,12 +1594,15 @@ class ConnectionPool:
         except asyncio.CancelledError:
             # This is an outside cancel attempt
             connect_attempt.cancel()
-            try:
-                await connect_attempt
-            except CommClosedError:
-                pass
+            await connect_attempt
             raise
-        return await connect_attempt
+        try:
+            return connect_attempt.result()
+        except asyncio.CancelledError:
+            current_task = asyncio.current_task()
+            assert current_task
+            reason = self._reasons.pop(current_task, "ConnectionPool closing.")
+            raise CommClosedError(reason)
 
     def reuse(self, addr: str, comm: Comm) -> None:
         """

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3326,44 +3326,6 @@ async def test_gather_dep_no_longer_in_flight_tasks(c, s, a):
         assert not any("missing-dep" in msg for msg in f2_story)
 
 
-@gen_cluster(client=True, nthreads=[("", 1)])
-async def test_gather_dep_cancelled_error(c, s, a):
-    """Something somewhere in the networking stack raises CancelledError while
-    gather_dep is running
-
-    See Also
-    --------
-    test_get_data_cancelled_error
-    https://github.com/dask/distributed/issues/8006
-    """
-    async with BlockedGetData(s.address) as b:
-        x = c.submit(inc, 1, key="x", workers=[b.address])
-        y = c.submit(inc, x, key="y", workers=[a.address])
-        await b.in_get_data.wait()
-        tasks = {
-            task for task in asyncio.all_tasks() if "gather_dep" in task.get_name()
-        }
-        assert tasks
-        # There should be only one task but cope with finding more just in case a
-        # previous test didn't properly clean up
-        for task in tasks:
-            task.cancel()
-
-        b.block_get_data.set()
-        assert await y == 3
-
-    assert_story(
-        a.state.story("x"),
-        [
-            ("x", "fetch", "flight", "flight", {}),
-            ("x", "flight", "missing", "missing", {}),
-            ("x", "missing", "fetch", "fetch", {}),
-            ("x", "fetch", "flight", "flight", {}),
-            ("x", "flight", "memory", "memory", {"y": "ready"}),
-        ],
-    )
-
-
 @gen_cluster(client=True, nthreads=[("", 1)], timeout=5)
 async def test_get_data_cancelled_error(c, s, a):
     """Something somewhere in the networking stack raises CancelledError while

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3333,7 +3333,6 @@ async def test_get_data_cancelled_error(c, s, a):
 
     See Also
     --------
-    test_gather_dep_cancelled_error
     https://github.com/dask/distributed/issues/8006
     """
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2112,11 +2112,7 @@ class Worker(BaseWorker, ServerNode):
                 data=response["data"],
                 stimulus_id=f"gather-dep-success-{time()}",
             )
-
-        # Note: CancelledError and asyncio.TimeoutError are rare conditions
-        # that can be raised by the network stack.
-        # See https://github.com/dask/distributed/issues/8006
-        except (OSError, asyncio.CancelledError, asyncio.TimeoutError):
+        except OSError:
             logger.exception("Worker stream died during communication: %s", worker)
             self.state.log.append(
                 ("gather-dep-failed", worker, to_gather, stimulus_id, time())


### PR DESCRIPTION
This reverts https://github.com/dask/distributed/pull/8013 and changes the way how we're handling cancellations in the connection pool.

~I haven't figured out quite how we end up in this situation but somehow the `connect_attempt` task is raising a `CancelledError` even though the task itself is catching `CancelledError`s and is supposed to reraise as `CommClosed`. For whatever reason this is not happening and is therefore raising the `CancelledError`~

If the task is cancelled before the task is actually scheduled, awaiting it can still cause a `CancelledError` to be raised even if the body handles this and reraises as `CommClosed`. I don't know why this issue hasn't affected us before.

Catching the CancelledError in `gather_dep` is causing other tests to flake. Explicitly, I found that `distributed.tests.test_scheduler.test_tell_workers_when_peers_have_left` is affected by this change in gather_dep. If #8013 is reverted, that test is rock solid.

Generally, these two tests have been sensitive to changes around this cancellation
- `distributed/tests/test_worker_metrics.py::test_gather_dep_network_error`
- `distributed/tests/test_scheduler.py::test_tell_workers_when_peers_have_left`

and with this PR, both tests are rock solid on my machine.


This may collide / supersede / be superseded by https://github.com/dask/distributed/pull/8109
Related https://github.com/dask/distributed/pull/8108