### PR TITLE
Keep tick durations to not be impacted by prometheus scrape intervals

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -447,9 +447,6 @@ class Server:
         self._tick_counter = 0
         self._last_tick_counter = 0
         self._last_tick_cycle = time()
-        # TODO: Do we care about exact retention as we're calculating below?
-        # Instead we could just approx this by setting
-        # maxlen=retention / interval
         self._tick_retention = parse_timedelta(
             dask.config.get("distributed.admin.tick.retention")
         )
@@ -709,11 +706,10 @@ class Server:
         # TODO: Do we even care that this is accurate? If the event loop is
         # blocked for long, we'd store data for a longer period of time. The
         # stuff below just makes it accurate.
+        threshold = now - self._tick_retention
         while (
             self._observed_tick_durations
-            and now - self._observed_tick_durations[0][0]
-            # called very often!
-            > self._tick_retention
+            and self._observed_tick_durations[0][0] < threshold
         ):
             self._observed_tick_durations.popleft()
 

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -703,9 +703,6 @@ class Server:
             )
         self.digest_metric("tick-duration", tick_duration)
         self._observed_tick_durations.append((now, tick_duration))
-        # TODO: Do we even care that this is accurate? If the event loop is
-        # blocked for long, we'd store data for a longer period of time. The
-        # stuff below just makes it accurate.
         threshold = now - self._tick_retention
         while (
             self._observed_tick_durations

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1106,6 +1106,9 @@ properties:
               cycle :
                 type: string
                 description: The time in between verifying event loop speed
+              retention :
+                type: string
+                description: Store accurate values for this long
 
           max-error-length:
             type: integer

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -305,6 +305,7 @@ distributed:
       interval: 20ms  # time between event loop health checks
       limit: 3s       # time allowed before triggering a warning
       cycle: 1s       # time between checking event loop speed
+      retention: 60s  # Store accurate values for this long
 
     max-error-length: 10000 # Maximum size traceback after error to return
     log-length: 10000  # default length of logs to keep in memory


### PR DESCRIPTION
The tick duration scraping is still returning inaccruate results due to the resetting of the metric. This is an approach that would be more robust to sampling intervals and request timeouts at the cost of accuracy. I suspect the runtime cost to be cheap but I haven't verified

Since we only care aobut worst case, this _should_ be good enough to signal a problem. This would also allow us to expose quantiles.

