### PR TITLE
Await async `listener.stop` in `Worker.close`

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1618,9 +1618,7 @@ class Worker(BaseWorker, ServerNode):
                 abort_handshaking_comms()
 
         if _stops:
-
-            async def background_stops():
-                await asyncio.gather(*_stops)
+            await asyncio.gather(*_stops)
 
         # end copy-paste
 


### PR DESCRIPTION
Follow-up to #8076

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
