### PR TITLE
Ignore asyncio when scraping code

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -274,6 +274,7 @@ distributed:
       max-history: 100
       nframes: 0
       ignore-modules:
+        - asyncio
         - distributed
         - dask
         - xarray

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7514,7 +7514,6 @@ async def test_computation_object_code_client_submit_dict_comp(c, s, a, b):
 
     assert len(comp.code[0]) == 2
     assert comp.code[0][-1].code == test_function_code
-    assert comp.code[0][-2].code == inspect.getsource(sys._getframe(1))
 
 
 @gen_cluster(client=True, config={"distributed.diagnostics.computations.nframes": 2})

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7446,7 +7446,6 @@ async def test_computation_object_code_dask_persist(c, s, a, b):
 
     assert len(comp.code[0]) == 2
     assert comp.code[0][-1].code == test_function_code
-    assert comp.code[0][-2].code == inspect.getsource(sys._getframe(1))
 
 
 @gen_cluster(client=True, config={"distributed.diagnostics.computations.nframes": 2})
@@ -7469,7 +7468,6 @@ async def test_computation_object_code_client_submit_simple(c, s, a, b):
 
     assert len(comp.code[0]) == 2
     assert comp.code[0][-1].code == test_function_code
-    assert comp.code[0][-2].code == inspect.getsource(sys._getframe(1))
 
 
 @gen_cluster(client=True, config={"distributed.diagnostics.computations.nframes": 2})
@@ -7493,7 +7491,6 @@ async def test_computation_object_code_client_submit_list_comp(c, s, a, b):
 
     assert len(comp.code[0]) == 2
     assert comp.code[0][-1].code == test_function_code
-    assert comp.code[0][-2].code == inspect.getsource(sys._getframe(1))
 
 
 @gen_cluster(client=True, config={"distributed.diagnostics.computations.nframes": 2})
@@ -7538,7 +7535,6 @@ async def test_computation_object_code_client_map(c, s, a, b):
 
     assert len(comp.code[0]) == 2
     assert comp.code[0][-1].code == test_function_code
-    assert comp.code[0][-2].code == inspect.getsource(sys._getframe(1))
 
 
 @gen_cluster(client=True, config={"distributed.diagnostics.computations.nframes": 2})
@@ -7558,7 +7554,6 @@ async def test_computation_object_code_client_compute(c, s, a, b):
 
     assert len(comp.code[0]) == 2
     assert comp.code[0][-1].code == test_function_code
-    assert comp.code[0][-2].code == inspect.getsource(sys._getframe(1))
 
 
 @pytest.mark.slow

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -635,7 +635,6 @@ async def test_code(c, s, a, b):
 
     # Identical code stacks have been deduplicated
     assert len(code) == 3
-    assert "def _run(self)" in code[0][-2].code
     assert "inc, 1" in code[0][-1].code
     assert code[0][-1].lineno_relative == 10
     assert code[1][-1].lineno_relative == 11


### PR DESCRIPTION
Sometimes code is triggered from here, but it's not particularly informative.  Let's add it to the ignore list.