### PR TITLE
Fix P2P shuffle with `LocalCluster(..., processes=False)`

### DIFF
--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -120,6 +120,9 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         worker: str,
     ) -> ToPickle[ShuffleRunSpec]:
         try:
+            # FIXME: Sometimes, this doesn't actually get pickled
+            if isinstance(spec, ToPickle):
+                spec = spec.data
             return self.get(spec.id, worker)
         except KeyError:
             # FIXME: The current implementation relies on the barrier task to be

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -262,10 +262,6 @@ class ShuffleWorkerPlugin(WorkerPlugin):
                 key=key,
                 worker=self.worker.address,
             )
-        # if result["status"] == "error":
-        # raise RuntimeError(result["message"])
-        # assert result["status"] == "OK"
-
         if self.closed:
             raise ShuffleClosedError(f"{self} has already been closed")
         if shuffle_id in self.shuffles:
@@ -288,6 +284,9 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
                 self.worker._ongoing_background_tasks.call_soon(_, self, existing)
 
+        # FIXME: Sometimes, this doesn't actually get pickled
+        if isinstance(result, ToPickle):
+            result = result.data
         shuffle: ShuffleRun = result.spec.create_run_on_worker(
             result.run_id, result.worker_for, self
         )

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -23,7 +23,7 @@ pd = pytest.importorskip("pandas")
 dd = pytest.importorskip("dask.dataframe")
 
 import dask
-from dask.distributed import Event, Nanny, Worker
+from dask.distributed import Event, LocalCluster, Nanny, Worker
 from dask.utils import stringify
 
 from distributed.client import Client
@@ -185,6 +185,22 @@ async def test_basic_integration(c, s, a, b, lose_annotations, npartitions):
     await check_worker_cleanup(a)
     await check_worker_cleanup(b)
     await check_scheduler_cleanup(s)
+
+
+@gen_test()
+async def test_basic_integration_local_cluster():
+    async with LocalCluster(n_workers=2, processes=False, asynchronous=True) as cluster:
+        df = dask.datasets.timeseries(
+            start="2000-01-01",
+            end="2000-01-10",
+            dtypes={"x": float, "y": float},
+            freq="10 s",
+        )
+        c = cluster.get_client()
+        out = dd.shuffle.shuffle(df, "x", shuffle="p2p")
+        x, y = c.compute([df, out])
+        x, y = await c.gather([x, y])
+        dd.assert_eq(x, y)
 
 
 @pytest.mark.parametrize("npartitions", [None, 1, 20])

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -189,7 +189,12 @@ async def test_basic_integration(c, s, a, b, lose_annotations, npartitions):
 
 @gen_test()
 async def test_basic_integration_local_cluster():
-    async with LocalCluster(n_workers=2, processes=False, asynchronous=True) as cluster:
+    async with LocalCluster(
+        n_workers=2,
+        processes=False,
+        asynchronous=True,
+        dashboard_address=":0",
+    ) as cluster:
         df = dask.datasets.timeseries(
             start="2000-01-01",
             end="2000-01-10",


### PR DESCRIPTION
Closes dask/dask#10455

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
