### PR TITLE
Remove duplicated teardown logic in Server.close, Nanny.close and Server.stop

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -566,7 +566,7 @@ class Nanny(ServerNode):
             "Closing Nanny gracefully at %r. Reason: %s", self.address_safe, reason
         )
 
-    async def close(
+    async def close(  # type:ignore[override]
         self, timeout: float = 5, reason: str = "nanny-close"
     ) -> Literal["OK"]:
         """

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -6,7 +6,6 @@ import builtins
 import contextlib
 import contextvars
 import errno
-import inspect
 import logging
 import math
 import os
@@ -1614,26 +1613,7 @@ class Worker(BaseWorker, ServerNode):
                         # otherwise
                         c.close()
 
-        # FIXME: Copy-paste from `Server.stop`. See dask/distributed#8077
-        _stops = set()
-        for listener in self.listeners:
-            future = listener.stop()
-            if inspect.isawaitable(future):
-                _stops.add(future)
-            try:
-                abort_handshaking_comms = listener.abort_handshaking_comms
-            except AttributeError:
-                pass
-            else:
-                abort_handshaking_comms()
-
-        if _stops:
-
-            async def background_stops():
-                await asyncio.gather(*_stops)
-
-        # end copy-paste
-
+        await self._stop_listeners()
         await self.rpc.close()
 
         # Give some time for a UCX scheduler to complete closing endpoints


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8077

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

### Overview
The PR moves duplicated logic to stop listeners into a new private method called `_stop_listeners`.

The only logical change here is that the warning "Support for asynchronous `Listener.stop` will be removed in a future version" is now raised by `Server.stop` and `Nanny.close` rather than just `Server.close`.

This PR also adds type hinting to the method signature of `Server.close`.