### PR TITLE
Enforce `dtypes` early in P2P shuffling

### DIFF
--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -52,7 +52,7 @@ def _calculate_partitions(df: pd.DataFrame, index: IndexLabel, npartitions: int)
         meta=df._meta._constructor_sliced([0]),
         transform_divisions=False,
     )
-    df2 = df.assign(**{_HASH_COLUMN_NAME: partitions})
+    df2 = df.assign(**{_HASH_COLUMN_NAME: partitions.values})
     df2._meta.index.name = df._meta.index.name
     return df2
 

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -283,9 +283,7 @@ def split_by_worker(
 
     from dask.dataframe.dispatch import to_pyarrow_table_dispatch
 
-    dtypes = dict(meta.dtypes)
-    dtypes.pop(column)
-    df = df.astype(dtypes, copy=False)
+    df = df.astype(meta.dtypes, copy=False)
 
     # (cudf support) Avoid pd.Series
     constructor = df._constructor_sliced

--- a/distributed/shuffle/tests/test_shuffle_plugins.py
+++ b/distributed/shuffle/tests/test_shuffle_plugins.py
@@ -46,7 +46,7 @@ def test_split_by_worker():
             "_partition": [0, 1, 2, 0, 1],
         }
     )
-
+    meta = df[["x"]].head(0)
     workers = ["alice", "bob"]
     worker_for_mapping = {}
     npartitions = 3
@@ -55,7 +55,7 @@ def test_split_by_worker():
             npartitions, part, workers
         )
     worker_for = pd.Series(worker_for_mapping, name="_workers").astype("category")
-    out = split_by_worker(df, "_partition", worker_for)
+    out = split_by_worker(df, "_partition", meta, worker_for)
     assert set(out) == {"alice", "bob"}
     assert list(out["alice"].to_pandas().columns) == list(df.columns)
 
@@ -71,8 +71,9 @@ def test_split_by_worker_empty():
             "_partition": [0, 1, 2, 0, 1],
         }
     )
+    meta = df[["x"]].head(0)
     worker_for = pd.Series({5: "chuck"}, name="_workers").astype("category")
-    out = split_by_worker(df, "_partition", worker_for)
+    out = split_by_worker(df, "_partition", meta, worker_for)
     assert out == {}
 
 
@@ -85,6 +86,7 @@ def test_split_by_worker_many_workers():
             "_partition": [5, 7, 5, 0, 1],
         }
     )
+    meta = df[["x"]].head(0)
     workers = ["a", "b", "c", "d", "e", "f", "g", "h"]
     npartitions = 10
     worker_for_mapping = {}
@@ -93,7 +95,7 @@ def test_split_by_worker_many_workers():
             npartitions, part, workers
         )
     worker_for = pd.Series(worker_for_mapping, name="_workers").astype("category")
-    out = split_by_worker(df, "_partition", worker_for)
+    out = split_by_worker(df, "_partition", meta, worker_for)
     assert _get_worker_for_range_sharding(npartitions, 5, workers) in out
     assert _get_worker_for_range_sharding(npartitions, 0, workers) in out
     assert _get_worker_for_range_sharding(npartitions, 7, workers) in out


### PR DESCRIPTION
~Blocked by dask/dask#10462~

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
