### PR TITLE
Fix flaky test_task_counter

### DIFF
--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -1748,8 +1748,9 @@ def test_task_counter(ws):
         # timer accuracy in Windows can be very poor;
         # see awful hack in distributed.metrics
         margin_lo = 0.099 if WINDOWS else 0
-        # sleep() has been observed to have up to 450ms lag on MacOSX GitHub CI
-        margin_hi = 0.6 if MACOS else 0.1
+        # sleep() has been observed to have up to 450ms lag on both
+        # MacOSX and Windows GitHub CI
+        margin_hi = 0.6 if MACOS or WINDOWS else 0.1
         assert expect - margin_lo <= actual < expect + margin_hi
 
     sleep(0.1)


### PR DESCRIPTION
https://github.com/dask/distributed/actions/runs/5966044981/job/16184860068?pr=8127

On Windows CI:
```
>       assert_time(elapsed["x", "flight"], 0.2)

    def assert_time(actual, expect):
        # timer accuracy in Windows can be very poor;
        # see awful hack in distributed.metrics
        margin_lo = 0.099 if WINDOWS else 0
        # sleep() has been observed to have up to 450ms lag on MacOSX GitHub CI
        margin_hi = 0.6 if MACOS else 0.1
>       assert expect - margin_lo <= actual < expect + margin_hi
E       assert 0.355125300000509 < (0.2 + 0.1)
```