### PR TITLE
Fix warnings from ``pandas=2.1.0``

### DIFF
--- a/distributed/protocol/tests/test_pandas.py
+++ b/distributed/protocol/tests/test_pandas.py
@@ -58,7 +58,7 @@ dfs = [
     pd.DataFrame(
         np.random.randn(10, 5),
         columns=list("ABCDE"),
-        index=pd.period_range("2000", periods=10, freq="B"),
+        index=pd.period_range("2000", periods=10, freq="D"),
     ),
     pd.DataFrame(
         np.random.randn(10, 5),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ filterwarnings = [
     '''ignore:notifyAll\(\) is deprecated, use notify_all\(\) instead:DeprecationWarning:paramiko''',
     '''ignore:setDaemon\(\) is deprecated, set the daemon attribute instead:DeprecationWarning:paramiko''',
     '''ignore:`np.bool8` is a deprecated alias for `np.bool_`''',
+    '''ignore:is_sparse is deprecated and will:FutureWarning''',
 ]
 minversion = "6"
 markers = [


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

The sparse warning comes from arrow, but as far as I can see we are not using from_pandas anywhere outside of tests, so we should be good