### PR TITLE
Don't capture functools frames in code

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -275,14 +275,15 @@ distributed:
       nframes: 0
       ignore-modules:
         - asyncio
-        - distributed
+        - functools
         - dask
-        - xarray
+        - distributed
+        - coiled
         - cudf
         - cuml
         - prefect
+        - xarray
         - xgboost
-        - coiled
     erred-tasks:
       max-history: 100
 


### PR DESCRIPTION
Suppress functools frames in `distributed.spans.Span.code`