### PR TITLE
Disallow duck-typed plugins

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -79,6 +79,9 @@ from distributed.diagnostics.plugin import (
     UploadFile,
     WorkerPlugin,
     _get_plugin_name,
+    validate_nanny_plugin,
+    validate_scheduler_plugin,
+    validate_worker_plugin,
 )
 from distributed.metrics import time
 from distributed.objects import HasWhat, SchedulerInfo, WhoHas
@@ -4836,6 +4839,7 @@ class Client(SyncMethodMixin):
         idempotent : bool
             Do not re-register if a plugin of the given name already exists.
         """
+        validate_scheduler_plugin(plugin)
         if name is None:
             name = _get_plugin_name(plugin)
 
@@ -4906,8 +4910,10 @@ class Client(SyncMethodMixin):
 
     async def _register_worker_plugin(self, plugin=None, name=None, nanny=None):
         if nanny or nanny is None and isinstance(plugin, NannyPlugin):
+            validate_nanny_plugin(plugin)
             method = self.scheduler.register_nanny_plugin
         else:
+            validate_worker_plugin(plugin)
             method = self.scheduler.register_worker_plugin
 
         responses = await method(plugin=dumps(plugin), name=name)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -314,6 +314,72 @@ def _get_plugin_name(plugin: SchedulerPlugin | WorkerPlugin | NannyPlugin) -> st
         return funcname(type(plugin)) + "-" + str(uuid.uuid4())
 
 
+def validate_nanny_plugin(plugin: Any) -> None:
+    if not isinstance(plugin, NannyPlugin):
+        if isinstance(plugin, WorkerPlugin):
+            raise TypeError(
+                f"Expected {plugin} to be a nanny plugin; "
+                "found it to be a worker plugin instead. "
+                "Consider registering the plugin with "
+                "`Client.register_worker_plugin(..., nanny=False)`."
+            )
+        if isinstance(plugin, SchedulerPlugin):
+            raise TypeError(
+                f"Expected {plugin} to be a nanny plugin; "
+                "found it to be a scheduler plugin instead. "
+                "Consider registering the plugin with "
+                "`Client.register_scheduler_plugin(...)`."
+            )
+        raise TypeError(
+            f"Excepted {plugin} to be a nanny plugin. "
+            "Please make sure to subclass `NannyPlugin` when creating a custom nanny plugin."
+        )
+
+
+def validate_scheduler_plugin(plugin: Any) -> None:
+    if not isinstance(plugin, SchedulerPlugin):
+        if isinstance(plugin, NannyPlugin):
+            raise TypeError(
+                f"Expected {plugin} to be a scheduler plugin; "
+                "found it to be a nanny plugin instead. "
+                "Consider registering the plugin with "
+                "`Client.register_worker_plugin(..., nanny=True)`."
+            )
+        if isinstance(plugin, WorkerPlugin):
+            raise TypeError(
+                f"Expected {plugin} to be a scheduler plugin; "
+                "found it to be a worker plugin instead. "
+                "Consider registering the plugin with "
+                "`Client.register_worker_plugin(..., nanny=False)`."
+            )
+        raise TypeError(
+            f"Excepted {plugin} to be a scheduler plugin. "
+            "Please make sure to subclass `SchedulerPlugin` when creating a custom scheduler plugin."
+        )
+
+
+def validate_worker_plugin(plugin: Any) -> None:
+    if not isinstance(plugin, WorkerPlugin):
+        if isinstance(plugin, NannyPlugin):
+            raise TypeError(
+                f"Expected {plugin} to be a worker plugin; "
+                "found it to be a scheduler plugin instead. "
+                "Consider registering the plugin with "
+                "`Client.register_worker_plugin(..., nanny=True)`."
+            )
+        if isinstance(plugin, SchedulerPlugin):
+            raise TypeError(
+                f"Expected {plugin} to be a worker plugin; "
+                "found it to be a scheduler plugin instead. "
+                "Consider registering the plugin with "
+                "`Client.register_scheduler_plugin`."
+            )
+        raise TypeError(
+            f"Excepted {plugin} to be a worker plugin. "
+            "Please make sure to subclass `WorkerPlugin` when creating a custom worker plugin."
+        )
+
+
 class SchedulerUploadFile(SchedulerPlugin):
     name = "upload_file"
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -83,7 +83,11 @@ from distributed.comm.addressing import addresses_from_user_args
 from distributed.compatibility import PeriodicCallback
 from distributed.core import Status, clean_exception, error_message, rpc, send_recv
 from distributed.diagnostics.memory_sampler import MemorySamplerExtension
-from distributed.diagnostics.plugin import SchedulerPlugin, _get_plugin_name
+from distributed.diagnostics.plugin import (
+    SchedulerPlugin,
+    _get_plugin_name,
+    validate_scheduler_plugin,
+)
 from distributed.event import EventExtension
 from distributed.http import get_handlers
 from distributed.lock import LockExtension
@@ -5740,9 +5744,10 @@ class Scheduler(SchedulerState, ServerNode):
                 "arbitrary bytestrings using pickle via the "
                 "'distributed.scheduler.pickle' configuration setting."
             )
-        if not isinstance(plugin, SchedulerPlugin):
+        if isinstance(plugin, bytes):
             plugin = loads(plugin)
-            assert isinstance(plugin, SchedulerPlugin)
+        validate_scheduler_plugin(plugin)
+        plugin = cast(SchedulerPlugin, plugin)
 
         if name is None:
             name = _get_plugin_name(plugin)


### PR DESCRIPTION
We've historically allowed duck-typed nanny and worker plugins while scheduler plugins were always type-checked. This makes it hard for users to catch situations where they accidentally incorrectly register a plugin (e.g., a nanny plugin as a worker plugin). This becomes even more complicated if plugins change their type (as is necessary in #8142). 

This PR disallows duck-typed plugins as a whole. This is a breaking change, so we should probably introduce a deprecation cycle, though I'd like to rip off the band-aid quickly as the fix is trivial.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
