### PR TITLE
Deprecate duck-typed plugins

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4906,8 +4906,22 @@ class Client(SyncMethodMixin):
 
     async def _register_worker_plugin(self, plugin=None, name=None, nanny=None):
         if nanny or nanny is None and isinstance(plugin, NannyPlugin):
+            if not isinstance(plugin, NannyPlugin):
+                warnings.warn(
+                    "Registering duck-typed plugins has been deprecated. "
+                    "Please make sure your plugin subclasses `NannyPlugin`.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             method = self.scheduler.register_nanny_plugin
         else:
+            if not isinstance(plugin, WorkerPlugin):
+                warnings.warn(
+                    "Registering duck-typed plugins has been deprecated. "
+                    "Please make sure your plugin subclasses `WorkerPlugin`.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             method = self.scheduler.register_worker_plugin
 
         responses = await method(plugin=dumps(plugin), name=name)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -24,7 +24,7 @@ from collections.abc import (
 )
 from enum import Enum
 from functools import wraps
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, TypeVar, final
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, TypeVar, final
 
 import tblib
 from tlz import merge
@@ -1727,6 +1727,10 @@ class ErrorMessage(TypedDict):
     traceback: protocol.Serialize | None
     exception_text: str
     traceback_text: str
+
+
+class OKMessage(TypedDict):
+    status: Literal["OK"]
 
 
 def error_message(e: BaseException, status: str = "error") -> ErrorMessage:

--- a/distributed/diagnostics/tests/test_nanny_plugin.py
+++ b/distributed/diagnostics/tests/test_nanny_plugin.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from distributed import Nanny
+from distributed.utils_test import gen_cluster
+
+
+@gen_cluster(client=True, nthreads=[("", 1)], Worker=Nanny)
+async def test_duck_typed_nanny_plugin_is_deprecated(c, s, a):
+    class DuckPlugin:
+        def setup(self, nanny):
+            pass
+
+        def teardown(self, nanny):
+            pass
+
+    n_existing_plugins = len(a.plugins)
+    with pytest.warns(DeprecationWarning, match="duck-typed"):
+        await c.register_worker_plugin(DuckPlugin(), nanny=True)
+    assert len(a.plugins) == n_existing_plugins + 1

--- a/distributed/diagnostics/tests/test_nanny_plugin.py
+++ b/distributed/diagnostics/tests/test_nanny_plugin.py
@@ -16,6 +16,6 @@ async def test_duck_typed_nanny_plugin_is_deprecated(c, s, a):
             pass
 
     n_existing_plugins = len(a.plugins)
-    with pytest.warns(DeprecationWarning, match="duck-typed"):
+    with pytest.warns(DeprecationWarning, match="duck-typed.*NannyPlugin"):
         await c.register_worker_plugin(DuckPlugin(), nanny=True)
     assert len(a.plugins) == n_existing_plugins + 1

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -268,3 +268,18 @@ async def test_WorkerPlugin_overwrite(c, s, w):
 
     await c.submit(inc, 0)
     assert w.bar == 456
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_duck_typed_worker_plugin_is_deprecated(c, s, a):
+    class DuckPlugin:
+        def setup(self, worker):
+            pass
+
+        def teardown(self, worker):
+            pass
+
+    n_existing_plugins = len(a.plugins)
+    with pytest.warns(DeprecationWarning, match="duck-typed"):
+        await c.register_worker_plugin(DuckPlugin())
+    assert len(a.plugins) == n_existing_plugins + 1

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -280,6 +280,6 @@ async def test_duck_typed_worker_plugin_is_deprecated(c, s, a):
             pass
 
     n_existing_plugins = len(a.plugins)
-    with pytest.warns(DeprecationWarning, match="duck-typed"):
+    with pytest.warns(DeprecationWarning, match="duck-typed.*WorkerPlugin"):
         await c.register_worker_plugin(DuckPlugin())
     assert len(a.plugins) == n_existing_plugins + 1

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -188,7 +188,7 @@ async def test_dependent_tasks(c, s, w):
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
 async def test_empty_plugin(c, s, w):
-    class EmptyPlugin:
+    class EmptyPlugin(WorkerPlugin):
         pass
 
     await c.register_worker_plugin(EmptyPlugin())

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -15,7 +15,7 @@ import weakref
 from collections.abc import Callable, Collection
 from inspect import isawaitable
 from queue import Empty
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from toolz import merge
 from tornado.ioloop import IOLoop
@@ -437,9 +437,19 @@ class Nanny(ServerNode):
         return result
 
     @log_errors
-    async def plugin_add(self, plugin=None, name=None):
+    async def plugin_add(
+        self, plugin: NannyPlugin | bytes, name: str | None = None
+    ) -> dict[str, Any]:
         if isinstance(plugin, bytes):
             plugin = pickle.loads(plugin)
+        if not isinstance(plugin, NannyPlugin):
+            warnings.warn(
+                "Registering duck-typed plugins has been deprecated. "
+                "Please make sure your plugin subclasses `NannyPlugin`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        plugin = cast(NannyPlugin, plugin)
 
         if name is None:
             name = _get_plugin_name(plugin)
@@ -456,7 +466,7 @@ class Nanny(ServerNode):
                     result = await result
             except Exception as e:
                 msg = error_message(e)
-                return msg
+                return cast(dict[str, Any], msg)
         if getattr(plugin, "restart", False):
             await self.restart(reason=f"nanny-plugin-{name}-restart")
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -15,7 +15,7 @@ import weakref
 from collections.abc import Callable, Collection
 from inspect import isawaitable
 from queue import Empty
-from typing import Any, ClassVar, Literal, cast
+from typing import ClassVar, Literal, cast
 
 from toolz import merge
 from tornado.ioloop import IOLoop
@@ -33,6 +33,7 @@ from distributed.core import (
     AsyncTaskGroupClosedError,
     CommClosedError,
     ErrorMessage,
+    OKMessage,
     RPCClosed,
     Status,
     coerce_to_address,
@@ -436,7 +437,7 @@ class Nanny(ServerNode):
     @log_errors
     async def plugin_add(
         self, plugin: NannyPlugin | bytes, name: str | None = None
-    ) -> dict[str, Any]:
+    ) -> ErrorMessage | OKMessage:
         if isinstance(plugin, bytes):
             plugin = pickle.loads(plugin)
         if not isinstance(plugin, NannyPlugin):
@@ -462,8 +463,7 @@ class Nanny(ServerNode):
                 if isawaitable(result):
                     result = await result
             except Exception as e:
-                msg = error_message(e)
-                return cast(dict[str, Any], msg)
+                return error_message(e)
         if getattr(plugin, "restart", False):
             await self.restart(reason=f"nanny-plugin-{name}-restart")
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -15,7 +15,7 @@ import weakref
 from collections.abc import Callable, Collection
 from inspect import isawaitable
 from queue import Empty
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 from toolz import merge
 from tornado.ioloop import IOLoop
@@ -38,7 +38,7 @@ from distributed.core import (
     coerce_to_address,
     error_message,
 )
-from distributed.diagnostics.plugin import _get_plugin_name
+from distributed.diagnostics.plugin import NannyPlugin, _get_plugin_name
 from distributed.metrics import time
 from distributed.node import ServerNode
 from distributed.process import AsyncProcess
@@ -61,9 +61,6 @@ from distributed.worker_memory import (
     DeprecatedMemoryMonitor,
     NannyMemoryManager,
 )
-
-if TYPE_CHECKING:
-    from distributed.diagnostics.plugin import NannyPlugin
 
 logger = logging.getLogger(__name__)
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6953,7 +6953,7 @@ async def test_get_task_metadata_multiple(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_register_worker_plugin_exception(c, s, a, b):
-    class MyPlugin:
+    class MyPlugin(WorkerPlugin):
         def setup(self, worker=None):
             raise ValueError("Setup failed")
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -464,7 +464,7 @@ async def test_base_exception_in_task(c, s, a, sync, exc_type):
 
 @gen_test()
 async def test_plugin_exception():
-    class MyPlugin:
+    class MyPlugin(WorkerPlugin):
         def setup(self, worker=None):
             raise ValueError("Setup failed")
 
@@ -478,11 +478,11 @@ async def test_plugin_exception():
 
 @gen_test()
 async def test_plugin_multiple_exceptions():
-    class MyPlugin1:
+    class MyPlugin1(WorkerPlugin):
         def setup(self, worker=None):
             raise ValueError("MyPlugin1 Error")
 
-    class MyPlugin2:
+    class MyPlugin2(WorkerPlugin):
         def setup(self, worker=None):
             raise RuntimeError("MyPlugin2 Error")
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -67,6 +67,8 @@ from distributed.comm.addressing import address_from_user_args
 from distributed.compatibility import PeriodicCallback
 from distributed.core import (
     ConnectionPool,
+    ErrorMessage,
+    OKMessage,
     PooledRPCCall,
     Status,
     coerce_to_address,
@@ -1847,7 +1849,7 @@ class Worker(BaseWorker, ServerNode):
         plugin: WorkerPlugin | bytes,
         name: str | None = None,
         catch_errors: bool = True,
-    ) -> dict[str, Any]:
+    ) -> ErrorMessage | OKMessage:
         if isinstance(plugin, bytes):
             plugin = pickle.loads(plugin)
         if not isinstance(plugin, WorkerPlugin):
@@ -1878,8 +1880,7 @@ class Worker(BaseWorker, ServerNode):
             except Exception as e:
                 if not catch_errors:
                     raise
-                msg = error_message(e)
-                return cast("dict[str, Any]", msg)
+                return error_message(e)
 
         return {"status": "OK"}
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -77,7 +77,7 @@ from distributed.core import (
 from distributed.core import rpc as RPCType
 from distributed.core import send_recv
 from distributed.diagnostics import nvml, rmm
-from distributed.diagnostics.plugin import _get_plugin_name
+from distributed.diagnostics.plugin import WorkerPlugin, _get_plugin_name
 from distributed.diskutils import WorkSpace
 from distributed.exceptions import Reschedule
 from distributed.http import get_handlers
@@ -155,7 +155,6 @@ if TYPE_CHECKING:
 
     # Circular imports
     from distributed.client import Client
-    from distributed.diagnostics.plugin import WorkerPlugin
     from distributed.nanny import Nanny
     from distributed.scheduler import T_runspec
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1850,9 +1850,15 @@ class Worker(BaseWorker, ServerNode):
         catch_errors: bool = True,
     ) -> dict[str, Any]:
         if isinstance(plugin, bytes):
-            # Note: historically we have accepted duck-typed classes that don't
-            # inherit from WorkerPlugin. Don't do `assert isinstance`.
-            plugin = cast("WorkerPlugin", pickle.loads(plugin))
+            plugin = pickle.loads(plugin)
+        if not isinstance(plugin, WorkerPlugin):
+            warnings.warn(
+                "Registering duck-typed plugins has been deprecated. "
+                "Please make sure your plugin subclasses `WorkerPlugin`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        plugin = cast(WorkerPlugin, plugin)
 
         if name is None:
             name = _get_plugin_name(plugin)


### PR DESCRIPTION
Allowing duck-typed plugins makes it hard for us to validate user inputs and for users to unintentionally register the wrong type of plugin. Deprecating duck-typed plugins is the first step to cleaning this up.

Precursor to #8149 

Note that duck-typed scheduler plugins are already not allowed.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
