### PR TITLE
Deprecate asynchronous `Listener.stop()`

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -656,8 +656,9 @@ class Server:
             if inspect.isawaitable(future):
                 warnings.warn(
                     f"{type(listener)} is using an asynchronous `stop` method. "
-                    "Support for asynchronous `Listener.stop` will be removed in a future version",
-                    PendingDeprecationWarning,
+                    "Support for asynchronous `Listener.stop` has been deprecated and "
+                    "will be removed in a future version",
+                    DeprecationWarning,
                 )
                 listeners_to_stop.add(future)
             elif hasattr(listener, "abort_handshaking_comms"):

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -1402,7 +1402,7 @@ class TCPAsyncListenerBackend(TCPBackend):
 @gen_test()
 async def test_async_listener_stop(monkeypatch):
     monkeypatch.setitem(backends, "tcp", TCPAsyncListenerBackend())
-    with pytest.warns(PendingDeprecationWarning):
+    with pytest.warns(DeprecationWarning):
         async with Server({}) as s:
             await s.listen(0)
             assert s.listeners


### PR DESCRIPTION
Asynchronous `Listener.stop()` has been deprecated for over a year now (#6633). We should make another step toward getting rid of it.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
