### PR TITLE
Fix flaky test_worker_metrics

### DIFF
--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -547,9 +547,8 @@ async def test_send_metrics_to_scheduler(c, s, a, b):
     assert set(s_metrics) == set(expect_scheduler)
 
     for wk, sk in zip(expect_worker, expect_scheduler):
-        if not WINDOWS:
-            assert a_metrics[wk] > 0
-            assert b_metrics[wk] > 0
+        assert a_metrics[wk] >= 0
+        assert b_metrics[wk] >= 0
         assert s_metrics[sk] == pytest.approx(a_metrics[wk] + b_metrics[wk])
 
 
@@ -580,8 +579,7 @@ async def test_no_spans_extension(c, s, a):
     assert list(s_metrics) == expect_scheduler
 
     for wk, sk in zip(expect_worker, expect_scheduler):
-        if not WINDOWS:
-            assert w_metrics[wk] > 0
+        assert w_metrics[wk] >= 0
         assert s_metrics[sk] == pytest.approx(w_metrics[wk])
 
 


### PR DESCRIPTION
The ("execute", <prefix>, "other", "seconds") metric is calculated as a floored difference between the grand total and everything else so it can occasionally be exactly zero.

https://github.com/dask/distributed/actions/runs/6072978417/job/16473987961?pr=8144

