### PR TITLE
Fix validation in unpack phase of P2P shuffle

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -453,16 +453,12 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         del data
         return {(k,): serialize_table(v) for k, v in groups.items()}
 
-    async def add_partition(
+    async def _add_partition(
         self,
         data: pd.DataFrame,
         partition_id: int,
         **kwargs: Any,
     ) -> int:
-        self.raise_if_closed()
-        if self.transferred:
-            raise RuntimeError(f"Cannot add more partitions to {self}")
-
         def _() -> dict[str, tuple[int, bytes]]:
             out = split_by_worker(
                 data,
@@ -477,19 +473,12 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         await self._write_to_comm(out)
         return self.run_id
 
-    async def get_output_partition(
+    async def _get_output_partition(
         self,
         partition_id: int,
         key: str,
         **kwargs: Any,
     ) -> pd.DataFrame:
-        self.raise_if_closed()
-        if not self.transferred:
-            raise RuntimeError("`get_output_partition` called before barrier task")
-
-        await self._ensure_output_worker(partition_id, key)
-
-        await self.flush_receive()
         try:
             data = self._read_from_disk((partition_id,))
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2214,18 +2214,11 @@ class BlockedBarrierShuffleRun(DataFrameShuffleRun):
         super().__init__(*args, **kwargs)
         self.in_barrier = asyncio.Event()
         self.block_barrier = asyncio.Event()
-        self.in_get_output_partition = asyncio.Event()
-        self.block_get_output_partition = asyncio.Event()
 
     async def barrier(self):
         self.in_barrier.set()
         await self.block_barrier.wait()
         return await super().barrier()
-
-    async def get_output_partition(self, *args, **kwargs):
-        # self.in_get_output_partition.set()
-        # await self.block_get_output_partition.wait()
-        return await super().get_output_partition(*args, **kwargs)
 
 
 @mock.patch(


### PR DESCRIPTION
This PR fixes the validation logic and canonicalizes some code.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
