### PR TITLE
Raise in P2P if `column` `dtype` is wrong 

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -104,9 +104,15 @@ def rearrange_by_column_p2p(
     column: str,
     npartitions: int | None = None,
 ) -> DataFrame:
+    import pandas as pd
+
     from dask.dataframe.core import new_dd_object
 
     meta = df._meta
+    if not pd.api.types.is_integer_dtype(meta[column]):
+        raise TypeError(
+            f"Expected meta {column=} to be an integer column, is {meta[column].dtype}."
+        )
     check_dtype_support(meta)
     npartitions = npartitions or df.npartitions
     token = tokenize(df, column, npartitions)

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -109,7 +109,7 @@ def rearrange_by_column_p2p(
     from dask.dataframe.core import new_dd_object
 
     meta = df._meta
-    if not pd.api.types.is_integer_dtype(meta[column]):
+    if not pd.api.types.is_integer_dtype(meta[column].dtype):
         raise TypeError(
             f"Expected meta {column=} to be an integer column, is {meta[column].dtype}."
         )

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2190,8 +2190,9 @@ def test_set_index_p2p_with_existing_index(loop):
     with LocalCluster(
         n_workers=2, dashboard_address=":0", loop=loop
     ) as cluster, Client(cluster) as c:
-        with pytest.raises(TypeError, match="_partitions.*integer"):
-            ddf.set_index("a", shuffle="p2p")
+        ddf.set_index("a", shuffle="p2p")
+        result = c.compute(ddf, sync=True)
+        dd.assert_eq(result, df)
 
 
 def test_sort_values_p2p_with_existing_divisions(loop):
@@ -2207,5 +2208,11 @@ def test_sort_values_p2p_with_existing_divisions(loop):
         n_workers=2, dashboard_address=":0", loop=loop
     ) as cluster, Client(cluster) as c:
         with dask.config.set({"dataframe.shuffle.method": "p2p"}):
-            with pytest.raises(TypeError, match="_partitions.*integer"):
-                ddf = ddf.set_index("a").sort_values("b")
+            ddf = ddf.set_index("a").sort_values("b")
+            result = c.compute(ddf, sync=True)
+            dd.assert_eq(
+                result,
+                df.set_index("a").sort_values("b"),
+                check_index=False,
+                sort_results=False,
+            )

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2190,9 +2190,9 @@ def test_set_index_p2p_with_existing_index(loop):
     with LocalCluster(
         n_workers=2, dashboard_address=":0", loop=loop
     ) as cluster, Client(cluster) as c:
-        ddf.set_index("a", shuffle="p2p")
+        ddf = ddf.set_index("a", shuffle="p2p")
         result = c.compute(ddf, sync=True)
-        dd.assert_eq(result, df)
+        dd.assert_eq(result, df.set_index("a"))
 
 
 def test_sort_values_p2p_with_existing_divisions(loop):

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2186,9 +2186,8 @@ def test_set_index_p2p_with_existing_index():
         npartitions=4,
     )
     with Client() as c:
-        ddf = ddf.set_index("a", shuffle="p2p")
-        result = c.compute(ddf, sync=True)
-        dd.assert_eq(result, df.set_index("a"))
+        with pytest.raises(TypeError, match="_partitions.*integer"):
+            ddf.set_index("a", shuffle="p2p")
 
 
 def test_sort_values_p2p_with_existing_divisions():
@@ -2202,11 +2201,5 @@ def test_sort_values_p2p_with_existing_divisions():
     )
     with Client() as c:
         with dask.config.set({"dataframe.shuffle.method": "p2p"}):
-            ddf = ddf.set_index("a").sort_values("b")
-            result = c.compute(ddf, sync=True)
-        dd.assert_eq(
-            result,
-            df.set_index("a").sort_values("b"),
-            check_index=False,
-            sort_results=False,
-        )
+            with pytest.raises(TypeError, match="_partitions.*integer"):
+                ddf = ddf.set_index("a").sort_values("b")


### PR DESCRIPTION
* Prevents further issues like #8165 
* Supersedes #8166 
* Extracted from #8157 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
