### PR TITLE
Fix race condition between MemorySampler and scheduler shutdown

### DIFF
--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -217,6 +217,7 @@ class MemorySamplerExtension:
 
     def stop(self, key: str) -> list[tuple[float, int]]:
         """Stop sampling and return the samples"""
-        pc = self.scheduler.periodic_callbacks.pop("MemorySampler-" + key)
-        pc.stop()
+        pc = self.scheduler.periodic_callbacks.pop("MemorySampler-" + key, None)
+        if pc is not None:  # Race condition with scheduler shutdown
+            pc.stop()
         return self.samples.pop(key)


### PR DESCRIPTION
Closes https://github.com/coiled/benchmarks/issues/979

Fix rare race condition where the client exits the MemorySampler context manager while the scheduler is shutting down, but the RPC channel with the scheduler has not been collapsed yet

https://github.com/coiled/benchmarks/actions/runs/6103738223/job/16564669719
```

tests/stability/test_deadlock.py:52: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../miniconda3/envs/test/lib/python3.9/contextlib.py:137: in __exit__
    self.gen.throw(typ, value, traceback)
tests/conftest.py:377: in _benchmark_all
    yield
../../../miniconda3/envs/test/lib/python3.9/contextlib.py:137: in __exit__
    self.gen.throw(typ, value, traceback)
tests/conftest.py:263: in _benchmark_memory
    yield
../../../miniconda3/envs/test/lib/python3.9/contextlib.py:137: in __exit__
    self.gen.throw(typ, value, traceback)
../../../miniconda3/envs/test/lib/python3.9/site-packages/distributed/diagnostics/memory_sampler.py:109: in _sample_sync
    samples = client.sync(client.scheduler.memory_sampler_stop, key=key)
../../../miniconda3/envs/test/lib/python3.9/site-packages/distributed/utils.py:359: in sync
    return sync(
../../../miniconda3/envs/test/lib/python3.9/site-packages/distributed/utils.py:426: in sync
    raise exc.with_traceback(tb)
../../../miniconda3/envs/test/lib/python3.9/site-packages/distributed/utils.py:399: in f
    result = yield future
../../../miniconda3/envs/test/lib/python3.9/site-packages/tornado/gen.py:769: in run
    value = future.result()
../../../miniconda3/envs/test/lib/python3.9/site-packages/distributed/core.py:1347: in send_recv_from_rpc
    return await send_recv(comm=comm, op=key, **kwargs)
../../../miniconda3/envs/test/lib/python3.9/site-packages/distributed/core.py:1131: in send_recv
    raise exc.with_traceback(tb)
/opt/coiled/env/lib/python3.9/site-packages/distributed/core.py:919: in _handle_comm
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   KeyError: 'MemorySampler-6e8b241e-4d8e-426c-898c-10686be2ee6a'

/opt/coiled/env/lib/python3.9/site-packages/distributed/diagnostics/memory_sampler.py:220: KeyError
```

No unit test as I would have no idea how to write one...