### PR TITLE
Simplify boilerplate for P2P shuffles

### DIFF
--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -236,7 +236,7 @@ async def test_rechunk_with_single_output_chunk_raises(c, s, *ws):
     assert x2.chunks == new
     # FIXME: distributed#7816
     with raises_with_cause(
-        RuntimeError, "rechunk_transfer failed", RuntimeError, "Barrier task"
+        RuntimeError, "failed during transfer", RuntimeError, "Barrier task"
     ):
         await c.compute(x2)
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -222,7 +222,7 @@ async def test_shuffle_with_array_conversion(c, s, a, b, lose_annotations, npart
     if npartitions == 1:
         # FIXME: distributed#7816
         with raises_with_cause(
-            RuntimeError, "shuffle_transfer failed", RuntimeError, "Barrier task"
+            RuntimeError, "failed during transfer", RuntimeError, "Barrier task"
         ):
             await c.compute(out)
     else:
@@ -285,7 +285,7 @@ async def test_bad_disk(c, s, a, b):
     while not b.plugins["shuffle"].shuffles:
         await asyncio.sleep(0.01)
     shutil.rmtree(b.local_directory)
-    with pytest.raises(RuntimeError, match=f"shuffle_transfer failed .* {shuffle_id}"):
+    with pytest.raises(RuntimeError, match=f"{shuffle_id} failed during transfer"):
         out = await c.compute(out)
 
     await c.close()
@@ -2143,7 +2143,7 @@ async def test_raise_on_incompatible_partitions_p2p_shuffling(c, s, a, b):
     ddf = dd.from_map(make_partition, range(50))
     out = ddf.shuffle(on="a", shuffle="p2p", ignore_index=True)
     with raises_with_cause(
-        RuntimeError, "shuffle_transfer", ValueError, "could not convert"
+        RuntimeError, "failed during transfer", ValueError, "could not convert"
     ):
         await c.compute(out)
 


### PR DESCRIPTION
Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
