### PR TITLE
Warn for deprecations on ``dask.config.set()``

### DIFF
--- a/distributed/config.py
+++ b/distributed/config.py
@@ -22,7 +22,7 @@ with open(fn) as f:
 
 dask.config.update_defaults(defaults)
 
-aliases = {
+deprecations = {
     "allowed-failures": "distributed.scheduler.allowed-failures",
     "bandwidth": "distributed.scheduler.bandwidth",
     "default-data-size": "distributed.scheduler.default-data-size",
@@ -55,7 +55,11 @@ aliases = {
     "rmm": "distributed.rmm",
 }
 
-dask.config.rename(aliases)
+# Affects yaml and env variables configs, as well as calls tgo dask.config.set()
+# before importing distributed
+dask.config.rename(deprecations)
+# Affects dask.config.set() from now on
+dask.config.deprecations.update(deprecations)
 
 
 #########################

--- a/distributed/config.py
+++ b/distributed/config.py
@@ -55,7 +55,7 @@ deprecations = {
     "rmm": "distributed.rmm",
 }
 
-# Affects yaml and env variables configs, as well as calls tgo dask.config.set()
+# Affects yaml and env variables configs, as well as calls to dask.config.set()
 # before importing distributed
 dask.config.rename(deprecations)
 # Affects dask.config.set() from now on

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -1051,7 +1051,7 @@ async def test_tick_logging(s, a, b):
 @pytest.mark.parametrize("serialize", [echo_serialize, echo_no_serialize])
 @gen_test()
 async def test_compression(compression, serialize):
-    with dask.config.set(compression=compression):
+    with dask.config.set({"distributed.comm.compression": compression}):
         async with Server({"echo": serialize}) as server:
             await server.listen("tcp://")
 


### PR DESCRIPTION
`dask.config.set` on distributed-specific deprecated keys will now log a warning.

- New tests need https://github.com/dask/dask/pull/10499 to pass
- Also fixes failure in already existing test introduced by the above PR
