### PR TITLE
Allow ``comm`` for ``(un)register_*_plugin``

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7507,7 +7507,7 @@ class Scheduler(SchedulerState, ServerNode):
         return responses
 
     async def unregister_worker_plugin(
-        self, name: str
+        self, name: str, comm: None = None
     ) -> dict[str, ErrorMessage | OKMessage]:
         """Unregisters a worker plugin"""
         try:
@@ -7519,7 +7519,7 @@ class Scheduler(SchedulerState, ServerNode):
         return responses
 
     async def register_nanny_plugin(
-        self, plugin: bytes, name: str, idempotent: bool = False
+        self, plugin: bytes, name: str, idempotent: bool = False, comm: None = None
     ) -> dict[str, OKMessage]:
         """Registers a nanny plugin on all running and future nannies"""
         logger.info("Registering Nanny plugin %s", name)
@@ -7540,7 +7540,7 @@ class Scheduler(SchedulerState, ServerNode):
             return responses
 
     async def unregister_nanny_plugin(
-        self, name: str
+        self, name: str, comm: None = None
     ) -> dict[str, ErrorMessage | OKMessage]:
         """Unregisters a worker plugin"""
         try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7492,7 +7492,7 @@ class Scheduler(SchedulerState, ServerNode):
         return {"metadata": plugin.metadata, "state": plugin.state}
 
     async def register_worker_plugin(
-        self, plugin: bytes, name: str, idempotent: bool = False, comm: None = None
+        self, comm: None, plugin: bytes, name: str, idempotent: bool = False
     ) -> dict[str, OKMessage]:
         """Registers a worker plugin on all running and future workers"""
         logger.info("Registering Worker plugin %s", name)
@@ -7507,7 +7507,7 @@ class Scheduler(SchedulerState, ServerNode):
         return responses
 
     async def unregister_worker_plugin(
-        self, name: str, comm: None = None
+        self, comm: None, name: str
     ) -> dict[str, ErrorMessage | OKMessage]:
         """Unregisters a worker plugin"""
         try:
@@ -7519,7 +7519,7 @@ class Scheduler(SchedulerState, ServerNode):
         return responses
 
     async def register_nanny_plugin(
-        self, plugin: bytes, name: str, idempotent: bool = False, comm: None = None
+        self, comm: None, plugin: bytes, name: str, idempotent: bool = False
     ) -> dict[str, OKMessage]:
         """Registers a nanny plugin on all running and future nannies"""
         logger.info("Registering Nanny plugin %s", name)
@@ -7540,7 +7540,7 @@ class Scheduler(SchedulerState, ServerNode):
             return responses
 
     async def unregister_nanny_plugin(
-        self, name: str, comm: None = None
+        self, comm: None, name: str
     ) -> dict[str, ErrorMessage | OKMessage]:
         """Unregisters a worker plugin"""
         try:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7492,7 +7492,7 @@ class Scheduler(SchedulerState, ServerNode):
         return {"metadata": plugin.metadata, "state": plugin.state}
 
     async def register_worker_plugin(
-        self, plugin: bytes, name: str, idempotent: bool = False
+        self, plugin: bytes, name: str, idempotent: bool = False, comm: None = None
     ) -> dict[str, OKMessage]:
         """Registers a worker plugin on all running and future workers"""
         logger.info("Registering Worker plugin %s", name)

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -66,7 +66,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
     async def start(self, scheduler: Scheduler) -> None:
         worker_plugin = ShuffleWorkerPlugin()
         await self.scheduler.register_worker_plugin(
-            dumps(worker_plugin), name="shuffle"
+            dumps(worker_plugin), name="shuffle", comm=None
         )
 
     def shuffle_ids(self) -> set[ShuffleId]:

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -66,7 +66,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
     async def start(self, scheduler: Scheduler) -> None:
         worker_plugin = ShuffleWorkerPlugin()
         await self.scheduler.register_worker_plugin(
-            dumps(worker_plugin), name="shuffle", comm=None
+            None, dumps(worker_plugin), name="shuffle"
         )
 
     def shuffle_ids(self) -> set[ShuffleId]:


### PR DESCRIPTION
Coiled is calling into this method manually (which we shouldn't do) and this causes some breakage. Let's please add this back until we have a compat layer

Closes https://github.com/coiled/benchmarks/issues/986

cc @jrbourbeau 