### PR TITLE
Reduce memory usage during culling for shuffling and merge

### DIFF
--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -243,15 +243,13 @@ class HashJoinP2PLayer(Layer):
         all input partitions. This method does not require graph
         materialization.
         """
-        deps = defaultdict(set)
+        deps = defaultdict(frozenset)
         parts_out = parts_out or self._keys_to_parts(keys)
+        keys = {(self.name_input_left, i) for i in range(self.npartitions)}
+        keys |= {(self.name_input_right, i) for i in range(self.npartitions)}
+        keys = frozenset(keys)
         for part in parts_out:
-            deps[(self.name, part)] |= {
-                (self.name_input_left, i) for i in range(self.npartitions)
-            }
-            deps[(self.name, part)] |= {
-                (self.name_input_right, i) for i in range(self.npartitions)
-            }
+            deps[(self.name, part)] = keys
         return deps
 
     def _keys_to_parts(self, keys: Iterable[str]) -> set[str]:

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -243,7 +243,7 @@ class HashJoinP2PLayer(Layer):
         all input partitions. This method does not require graph
         materialization.
         """
-        deps = defaultdict(frozenset)
+        deps = {}
         parts_out = parts_out or self._keys_to_parts(keys)
         keys = {(self.name_input_left, i) for i in range(self.npartitions)}
         keys |= {(self.name_input_right, i) for i in range(self.npartitions)}

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -1,7 +1,6 @@
 # mypy: ignore-errors
 from __future__ import annotations
 
-from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -247,6 +247,7 @@ class HashJoinP2PLayer(Layer):
         parts_out = parts_out or self._keys_to_parts(keys)
         keys = {(self.name_input_left, i) for i in range(self.npartitions)}
         keys |= {(self.name_input_right, i) for i in range(self.npartitions)}
+        # Protect against mutations later on with frozenset
         keys = frozenset(keys)
         for part in parts_out:
             deps[(self.name, part)] = keys

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -227,6 +227,7 @@ class P2PShuffleLayer(Layer):
         parameter.
         """
         parts_out = self._keys_to_parts(keys)
+        # Protect against mutations later on with frozenset
         input_parts = frozenset(
             {(self.name_input, i) for i in range(self.npartitions_input)}
         )

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -227,8 +227,10 @@ class P2PShuffleLayer(Layer):
         parameter.
         """
         parts_out = self._keys_to_parts(keys)
-        input_parts = {(self.name_input, i) for i in range(self.npartitions_input)}
-        culled_deps = {(self.name, part): input_parts.copy() for part in parts_out}
+        input_parts = frozenset(
+            {(self.name_input, i) for i in range(self.npartitions_input)}
+        )
+        culled_deps = {(self.name, part): input_parts for part in parts_out}
 
         if parts_out != set(self.parts_out):
             culled_layer = self._cull(parts_out)


### PR DESCRIPTION
Closes #8196

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Not sure if we can add tests here that would actually help. memory spike is gone on this branch