### PR TITLE
Hide pytest from code snippets

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1050,6 +1050,12 @@ properties:
                   A list of modules which are ignored when trying to collect the
                   code context when submitting a computation. Accepts regular
                   expressions.
+              ignore-files:
+                type: array
+                description: |
+                  A list of files and directories which are ignored when trying to
+                  collect the code context when submitting a computation. Accepts
+                  regular expressions.
           erred-tasks:
             type: object
             properties:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -281,10 +281,17 @@ distributed:
         - coiled
         - cudf
         - cuml
+        - pluggy  # part of pytest
         - prefect
         - rechunker
         - xarray
         - xgboost
+      ignore-files:
+        - runpy\.py  # `python -m pytest` shell command
+        - pytest  # `pytest` shell command
+        - py\.test  # `py.test` shell command
+        - _pytest  # pytest implementation
+        - pycharm  # Run pytest from PyCharm GUI
     erred-tasks:
       max-history: 100
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -287,9 +287,10 @@ distributed:
         - xarray
         - xgboost
       ignore-files:
-        - runpy\.py  # `python -m pytest` shell command
+        - runpy\.py  # `python -m pytest` (or other module) shell command
         - pytest  # `pytest` shell command
         - py\.test  # `py.test` shell command
+        - pytest-script\.py  # `pytest` shell command in Windows
         - _pytest  # pytest implementation
         - pycharm  # Run pytest from PyCharm GUI
     erred-tasks:

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -276,7 +276,9 @@ distributed:
       ignore-modules:
         - asyncio
         - functools
+        - datashader
         - dask
+        - debugpy
         - distributed
         - coiled
         - cudf
@@ -293,6 +295,8 @@ distributed:
         - pytest-script\.py  # `pytest` shell command in Windows
         - _pytest  # pytest implementation
         - pycharm  # Run pytest from PyCharm GUI
+        - vscode_pytest
+        - get_output_via_markers\.py
     erred-tasks:
       max-history: 100
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7314,7 +7314,10 @@ def test_computation_code_walk_frames():
             code = Client._get_computation_code()
 
     with dask.config.set(
-        {"distributed.diagnostics.computations.ignore-modules": ["test_client"]}
+        {
+            "distributed.diagnostics.computations.ignore-modules": ["test_client"],
+            "distributed.diagnostics.computations.ignore-files": [],
+        }
     ):
         import sys
 
@@ -7413,10 +7416,8 @@ def test_computation_object_code_dask_compute(client):
         return comp.code[0]
 
     code = client.run_on_scheduler(fetch_comp_code)
-
-    assert len(code) == 2
-    assert code[-1].code == test_function_code
-    assert code[-2].code == inspect.getsource(sys._getframe(1))
+    assert len(code) == 1
+    assert code[0].code == test_function_code
 
 
 def test_computation_object_code_dask_compute_no_frames_default(client):


### PR DESCRIPTION
- xref #8146

Clean up code snippets when pytest starts a cluster, e.g. coiled/benchmarks:

![image](https://github.com/dask/distributed/assets/6213168/99d11258-c0ea-4039-b3f9-3b58f2e0db47)
