### PR TITLE
Do not reset CUDA context after UCX tests

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -40,8 +40,6 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate dask
 
-mamba install -y 'aws-sdk-cpp<1.11'
-
 gpuci_logger "Install distributed"
 python -m pip install -e .
 

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -40,6 +40,8 @@ gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate dask
 
+mamba install -y 'aws-sdk-cpp<1.11'
+
 gpuci_logger "Install distributed"
 python -m pip install -e .
 

--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -179,7 +179,7 @@ async def test_ucx_deserialize(ucx_loop):
     "g",
     [
         lambda cudf: cudf.Series([1, 2, 3]),
-        lambda cudf: cudf.Series([]),
+        lambda cudf: cudf.Series([], dtype=object),
         lambda cudf: cudf.DataFrame([]),
         lambda cudf: cudf.DataFrame([1]).head(0),
         lambda cudf: cudf.DataFrame([1.0]).head(0),

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -2156,17 +2156,6 @@ def ucx_loop():
     import distributed.comm.ucx
 
     distributed.comm.ucx.ucp = None
-    # If the test created a context, clean it up.
-    # TODO: should we check if there's already a context _before_ the test runs?
-    # I think that would be useful.
-    from distributed.diagnostics.nvml import has_cuda_context
-
-    ctx = has_cuda_context()
-    if ctx.has_context:
-        import numba.cuda
-
-        ctx = numba.cuda.current_context()
-        ctx.device.reset()
 
 
 def wait_for_log_line(


### PR DESCRIPTION
Resetting CUDA contexts during a running process may have unintended consequences on third-party libraries -- e.g., CuPy -- that store state based on the context. Therefore, prevent destroying CUDA context for now.

Additionally fix cuDF failure due to a `FutureWarning`.

Closes #8194 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
