### PR TITLE
Offload deeply nested objects

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -178,7 +178,7 @@ def process(
         # sometimes need to be recursed into as well, e.g. for serialization
         # which can cause recursion errors later on since this can generate
         # deeply nested dictionaries
-        depth = min(250, sys.getrecursionlimit() // 4)
+        depth = min(100, sys.getrecursionlimit() // 4)
 
     if any(frame.f_code.co_filename.endswith(o) for o in omit):
         return None

--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -178,7 +178,7 @@ def process(
         # sometimes need to be recursed into as well, e.g. for serialization
         # which can cause recursion errors later on since this can generate
         # deeply nested dictionaries
-        depth = min(100, sys.getrecursionlimit() // 4)
+        depth = min(250, sys.getrecursionlimit() // 4)
 
     if any(frame.f_code.co_filename.endswith(o) for o in omit):
         return None

--- a/distributed/protocol/tests/test_serialize.py
+++ b/distributed/protocol/tests/test_serialize.py
@@ -445,21 +445,6 @@ def test_serialize_raises():
     assert "Hello-123" in str(info.value)
 
 
-@gen_test()
-async def test_profile_nested_sizeof():
-    # https://github.com/dask/distributed/issues/1674
-    n = 500
-    original = outer = {}
-    inner = {}
-
-    for _ in range(n):
-        outer["children"] = inner
-        outer, inner = inner, {}
-
-    msg = {"data": original}
-    frames = await to_frames(msg)
-
-
 def test_different_compression_families():
     """Test serialization of a collection of items that use different compression
 


### PR DESCRIPTION
- Closes #8212
- Supersedes #8213
- Iterates on #3455
- Twin of #8224

This PR fixes an issue in `to_frame()` where an object (not produced by `profile`) is between 140 and 512 recursion depth; such an object would never be offloaded before.

You also need #8224 to fix all CI errors.