### PR TITLE
Shutdown scheduler cleanly on JupyterLab shutdown

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3623,7 +3623,7 @@ class Scheduler(SchedulerState, ServerNode):
                     """Shut down the server."""
                     self.log.info("Shutting down on /api/shutdown request.")
 
-                    await scheduler.close()
+                    await scheduler.close(reason="shutdown requested via Jupyter")
 
             j = ServerApp.instance(
                 config=Config(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -35,6 +35,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, NamedTuple, cast, overload
 
 import psutil
+import tornado.web
 from sortedcontainers import SortedDict, SortedSet
 from tlz import (
     concat,
@@ -3589,6 +3590,7 @@ class Scheduler(SchedulerState, ServerNode):
             distributed.dashboard.scheduler.connect(
                 self.http_application, self.http_server, self, prefix=http_prefix
             )
+        scheduler = self
         if self.jupyter:
             try:
                 from jupyter_server.serverapp import ServerApp
@@ -3598,6 +3600,30 @@ class Scheduler(SchedulerState, ServerNode):
                     "need to have jupyterlab installed"
                 )
             from traitlets.config import Config
+
+            """HTTP handler to shut down the Jupyter server.
+            """
+            try:
+                from jupyter_server.auth import authorized
+            except ImportError:
+
+                def authorized(c):
+                    return c
+
+            from jupyter_server.base.handlers import JupyterHandler
+
+            class ShutdownHandler(JupyterHandler):
+                """A shutdown API handler."""
+
+                auth_resource = "server"
+
+                @tornado.web.authenticated
+                @authorized
+                async def post(self):
+                    """Shut down the server."""
+                    self.log.info("Shutting down on /api/shutdown request.")
+
+                    await scheduler.close()
 
             j = ServerApp.instance(
                 config=Config(
@@ -3620,6 +3646,11 @@ class Scheduler(SchedulerState, ServerNode):
                 argv=[],
             )
             self._jupyter_server_application = j
+            shutdown_app = tornado.web.Application(
+                [(r"/jupyter/api/shutdown", ShutdownHandler)]
+            )
+            shutdown_app.settings = j.web_app.settings
+            self.http_application.add_application(shutdown_app)
             self.http_application.add_application(j.web_app)
 
         # Communication state

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -132,9 +132,13 @@ def test_shutsdown_cleanly(loop):
 
         stderr = subprocess_fut.result().stderr
         assert "Traceback" not in stderr
+        assert (
+            "distributed.scheduler - INFO - Scheduler closing due to shutdown "
+            "requested via Jupyter...\n" in stderr
+        )
         assert "Shutting down on /api/shutdown request.\n" in stderr
         assert (
-            f"distributed.scheduler - INFO - Stopped scheduler at 'tcp://127.0.0.1:{port}'"
-            in stderr
+            "distributed.scheduler - INFO - Stopped scheduler at "
+            f"'tcp://127.0.0.1:{port}'\n" in stderr
         )
         assert stderr.endswith("distributed.scheduler - INFO - End scheduler\n")


### PR DESCRIPTION
Closes #8219

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
