### PR TITLE
Fix code capture inside pytest-xdist

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3091,11 +3091,15 @@ class Client(SyncMethodMixin):
 
                 break
 
-            # Ignore IPython related wrapping functions to user code
             if hasattr(fr.f_back, "f_globals"):
-                module_name = sys.modules[fr.f_back.f_globals["__name__"]].__name__  # type: ignore
+                module_name = fr.f_back.f_globals["__name__"]  # type: ignore
+                if module_name == "__channelexec__":
+                    break  # execnet; pytest-xdist  # pragma: nocover
+                # Ignore IPython related wrapping functions to user code
+                module_name = sys.modules[module_name].__name__
                 if module_name.endswith("interactiveshell"):
                     break
+
         return tuple(reversed(code))
 
     def _graph_to_futures(


### PR DESCRIPTION
Fix breakage in coiled/benchmarks caused by #8198.

This is due to a regression that causes a crash whenever you run a Client with code capture enabled from a unit test using `pytest-xdist` (which in turn is based on `execnet`)

```python
/usr/share/miniconda3/envs/test/lib/python3.9/site-packages/distributed/client.py:3163: in _graph_to_futures
    computations = self._get_computation_code(
[...]
>               module_name = sys.modules[fr.f_back.f_globals["__name__"]].__name__  # type: ignore
E               KeyError: '__channelexec__'
```

I manually tested this in coiled/benchmarks.
No unit test included as it's impossible to test without execnet and I'm uneager to add it to the environment just for this.

Output of coiled/benchmarks on the Coiled dashboard:
![image](https://github.com/dask/distributed/assets/6213168/17addad9-0beb-4b72-b6cf-05a456a58807)
