### PR TITLE
Fix profile on msgpack 1.0.6/Windows

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -178,7 +178,7 @@ def process(
         # sometimes need to be recursed into as well, e.g. for serialization
         # which can cause recursion errors later on since this can generate
         # deeply nested dictionaries
-        depth = min(250, sys.getrecursionlimit() // 4)
+        depth = min(100, sys.getrecursionlimit() // 4)
 
     if any(frame.f_code.co_filename.endswith(o) for o in omit):
         return None


### PR DESCRIPTION
- Closes #8212
- Iterates on #3455
- Twin of #8214

Make sure that profile doesn't reach the point where sizeof() starts raising (at depth 140).
This is problematic with msgpack 1.0.6 on Windows because its max recursion depth fell from 512 to 256.

The remaining exception in the unit tests is fixed by #8214