### PR TITLE
Fix flaky test_adapt_then_manual

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -203,9 +203,8 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          # DNM
-          pytest distributed/deploy/tests/test_local.py::test_adapt_then_manual \
-            --runslow \
+          pytest distributed \
+            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -203,8 +203,9 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pytest distributed \
-            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
+          # DNM
+          pytest distributed/deploy/tests/test_local.py::test_adapt_then_manual \
+            --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -747,7 +747,6 @@ def test_adapt(loop):
             assert time() < start + 5
 
 
-@pytest.mark.repeat(100)  # DNM
 @gen_test()
 async def test_adapt_then_manual():
     """We can revert from adaptive, back to manual"""
@@ -782,8 +781,6 @@ async def test_adapt_then_manual():
             tasks = {t for t in asyncio.all_tasks() if "PeriodicCallback" in str(t)}
             if tasks:
                 await asyncio.wait(tasks)
-
-            print(asyncio.all_tasks())  # DNM
 
             cluster.scale(2)
             await wait_workers(2)


### PR DESCRIPTION
This was straightforward to reproduce locally, both with and without scheduler-side queuing. Unsure why on CI it seems to only fail without queuing.

![image](https://github.com/dask/distributed/assets/6213168/ae93bdb1-0624-4543-8b0d-cd003e0570f1)

Now the test is rock solid (ran 200 times per CI environment).