### PR TITLE
Fix flaky test_close_connections

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -203,8 +203,8 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pytest distributed \
-            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
+          pytest distributed/tests/test_stress.py::test_close_connections \
+            --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -203,8 +203,8 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pytest distributed/tests/test_stress.py::test_close_connections \
-            --runslow \
+          pytest distributed \
+            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -229,32 +229,32 @@ async def test_stress_steal(c, s, *workers):
             break
 
 
-@pytest.mark.slow
-@gen_cluster(
-    nthreads=[("", 1)] * 10,
-    client=True,
-    timeout=180,
-    scheduler_kwargs={"transition_counter_max": 500_000},
-    worker_kwargs={"transition_counter_max": 500_000},
-)
+# @pytest.mark.slow
+@pytest.mark.repeat(50)
+@gen_cluster(client=True, nthreads=[("", 1)] * 10)
 async def test_close_connections(c, s, *workers):
+    # Schedule 600 slowinc's interleaved by worker-to-worker data transfers
+    # The minimum time to compute this is (600 * 0.1 / 10 threads) = 6s
     da = pytest.importorskip("dask.array")
-    x = da.random.random(size=(1000, 1000), chunks=(1000, 1))
+    x = da.random.random(size=(100, 100), chunks=(-1, 1))
     for _ in range(3):
-        x = x.rechunk((1, 1000))
-        x = x.rechunk((1000, 1))
+        x = x.rechunk((1, -1))
+        x = x.map_blocks(slowinc, delay=0.1, dtype=x.dtype)
+        x = x.rechunk((-1, 1))
+        x = x.map_blocks(slowinc, delay=0.1, dtype=x.dtype)
+    x = x.sum()
 
-    future = c.compute(x.sum())
-    while any(ws.processing for ws in s.workers.values()):
+    future = c.compute(x)
+    n = 0
+    while not future.done():
+        n += 1
         await asyncio.sleep(0.5)
         worker = random.choice(list(workers))
         for comm in worker._comms:
             comm.abort()
-        # print(frequencies(ts.state for ts in s.tasks.values()))
-        # for w in workers:
-        #     print(w)
 
-    await wait(future)
+    await future
+    assert n > 5
 
 
 @pytest.mark.slow

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -229,8 +229,7 @@ async def test_stress_steal(c, s, *workers):
             break
 
 
-# @pytest.mark.slow
-@pytest.mark.repeat(50)
+@pytest.mark.slow
 @gen_cluster(client=True, nthreads=[("", 1)] * 10)
 async def test_close_connections(c, s, *workers):
     # Schedule 600 slowinc's interleaved by worker-to-worker data transfers


### PR DESCRIPTION
This test was consistently killing off Windows CI.

![image](https://github.com/dask/distributed/assets/6213168/58adaa34-b241-4968-b85e-4c8446fb0f9d)

"Kill off" here means that the test ran for more than 5 minutes, so it was hitting pytest-timeout, all while never releasing the GIL and thus not incurring in the `@gen_cluster` timeout.
When it did work, it took ~170s to complete. It was death by GIL.