### PR TITLE
Suppress SpillBuffer stack traces for cancelled tasks

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3784,3 +3784,31 @@ async def test_startstops(c, s, a, b):
         < ss[1]["stop"]
         < t1 + b.scheduler_delay
     )
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+@pytest.mark.parametrize("state", ["cancelled", "resumed"])
+async def test_suppress_keyerror_for_cancelled_tasks(c, s, a, state):
+    async with BlockedExecute(s.address) as b:
+        with captured_logger("distributed.worker", level=logging.ERROR) as log:
+            x = (await c.scatter({"x": 1}))["x"]
+            y = c.submit(inc, x, key="y", workers=[b.address])
+            await b.in_execute.wait()
+            del x, y
+            await async_poll_for(lambda: "x" not in b.data, timeout=5)
+
+            if state == "resumed":
+                y = c.submit(inc, 1, key="y", workers=[a.address])
+                z = c.submit(inc, y, key="z", workers=[b.address])
+                await wait_for_state("y", "resumed", b)
+
+            b.block_execute.set()
+            b.block_execute_exit.set()
+
+            if state == "resumed":
+                assert await z == 3
+                del y, z
+
+            await async_poll_for(lambda: not b.state.tasks, timeout=5)
+
+    assert not log.getvalue()


### PR DESCRIPTION
When a task with dependencies is cancelled before execute() can start running and its dependencies are released, do not litter the log with a stack trace that goes deep into the SpillBuffer.
In case of mass cancellation, this can become several pages long.

Example:
https://github.com/dask/distributed/actions/runs/6397938635/job/17367998673?pr=8231

```
2023-10-03 20:54:44,047 - distributed.scheduler - INFO - Close client connection: Client-a57b78cc-622e-11ee-8851-005056b7f6fc
2023-10-03 20:54:44,049 - distributed.worker - ERROR - Exception during execution of task ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 84).
Traceback (most recent call last):
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 180, in __getitem__
    return self.fast[key]
           ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/lru.py", line 117, in __getitem__
    result = self.d[key]
             ~~~~~~^^^^^
KeyError: ('rechunk-merge-1d63cac85c7ef4c51a30f90ab85e8441', 0, 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2383, in _prepare_args_for_execution
    data[k] = self.data[k]
              ~~~~~~~~~^^^
  File "/Users/runner/work/distributed/distributed/distributed/spill.py", line 216, in __getitem__
    return super().__getitem__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 182, in __getitem__
    return self.slow_to_fast(key)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 149, in slow_to_fast
    value = self.slow[key]
            ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/cache.py", line 66, in __getitem__
    gen = self._last_updated[key]
          ~~~~~~~~~~~~~~~~~~^^^^^
KeyError: ('rechunk-merge-1d63cac85c7ef4c51a30f90ab85e8441', 0, 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2235, in execute
    args2, kwargs2 = self._prepare_args_for_execution(ts, args, kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2387, in _prepare_args_for_execution
    data[k] = Actor(type(self.state.actors[k]), self.address, k, self)
                         ~~~~~~~~~~~~~~~~~^^^
KeyError: ('rechunk-merge-1d63cac85c7ef4c51a30f90ab85e8441', 0, 0)
2023-10-03 20:54:44,069 - distributed.worker - ERROR - Exception during execution of task ('sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 80).
Traceback (most recent call last):
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 180, in __getitem__
    return self.fast[key]
           ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/lru.py", line 117, in __getitem__
    result = self.d[key]
             ~~~~~~^^^^^
KeyError: ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 80)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2383, in _prepare_args_for_execution
    data[k] = self.data[k]
              ~~~~~~~~~^^^
  File "/Users/runner/work/distributed/distributed/distributed/spill.py", line 216, in __getitem__
    return super().__getitem__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 182, in __getitem__
    return self.slow_to_fast(key)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 149, in slow_to_fast
    value = self.slow[key]
            ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/cache.py", line 66, in __getitem__
    gen = self._last_updated[key]
          ~~~~~~~~~~~~~~~~~~^^^^^
KeyError: ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 80)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2235, in execute
    args2, kwargs2 = self._prepare_args_for_execution(ts, args, kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2387, in _prepare_args_for_execution
    data[k] = Actor(type(self.state.actors[k]), self.address, k, self)
                         ~~~~~~~~~~~~~~~~~^^^
KeyError: ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 80)
2023-10-03 20:54:44,072 - distributed.worker - ERROR - Exception during execution of task ('sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 75).
Traceback (most recent call last):
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 180, in __getitem__
    return self.fast[key]
           ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/lru.py", line 117, in __getitem__
    result = self.d[key]
             ~~~~~~^^^^^
KeyError: ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 75)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2383, in _prepare_args_for_execution
    data[k] = self.data[k]
              ~~~~~~~~~^^^
  File "/Users/runner/work/distributed/distributed/distributed/spill.py", line 216, in __getitem__
    return super().__getitem__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 182, in __getitem__
    return self.slow_to_fast(key)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 149, in slow_to_fast
    value = self.slow[key]
            ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/cache.py", line 66, in __getitem__
    gen = self._last_updated[key]
          ~~~~~~~~~~~~~~~~~~^^^^^
KeyError: ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 75)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2235, in execute
    args2, kwargs2 = self._prepare_args_for_execution(ts, args, kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2387, in _prepare_args_for_execution
    data[k] = Actor(type(self.state.actors[k]), self.address, k, self)
                         ~~~~~~~~~~~~~~~~~^^^
KeyError: ('rechunk-merge-rechunk-split-sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 75)
2023-10-03 20:54:44,075 - distributed.worker - ERROR - Exception during execution of task ('sum-partial-34393eb7249af7b1b88b3dd0d17a3f49', 0, 34).
Traceback (most recent call last):
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 180, in __getitem__
    return self.fast[key]
           ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/lru.py", line 117, in __getitem__
    result = self.d[key]
             ~~~~~~^^^^^
KeyError: ('sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 69)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2383, in _prepare_args_for_execution
    data[k] = self.data[k]
              ~~~~~~~~~^^^
  File "/Users/runner/work/distributed/distributed/distributed/spill.py", line 216, in __getitem__
    return super().__getitem__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 182, in __getitem__
    return self.slow_to_fast(key)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/buffer.py", line 149, in slow_to_fast
    value = self.slow[key]
            ~~~~~~~~~^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/common.py", line 126, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/miniconda3/envs/dask-distributed/lib/python3.11/site-packages/zict/cache.py", line 66, in __getitem__
    gen = self._last_updated[key]
          ~~~~~~~~~~~~~~~~~~^^^^^
KeyError: ('sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 69)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2235, in execute
    args2, kwargs2 = self._prepare_args_for_execution(ts, args, kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/distributed/distributed/distributed/worker.py", line 2387, in _prepare_args_for_execution
    data[k] = Actor(type(self.state.actors[k]), self.address, k, self)
                         ~~~~~~~~~~~~~~~~~^^^
KeyError: ('sum-1ae5d08f4dfa23ef4ebff004b96c2cc7', 0, 69)
```