### PR TITLE
#8202 Close gracefully should leave no suspicious tasks

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1576,6 +1576,37 @@ async def test_close_gracefully(c, s, a, b):
         assert_amm_transfer_story(key, b, a)
 
 
+@pytest.mark.slow
+@gen_cluster(client=True, Worker=Nanny)
+async def test_close_gracefully_no_suspicious_tasks(c, s, a, b):
+    workers = {a.worker_address: a, b.worker_address: b}
+    started = Event()
+    block_task = Event()
+
+    def blocking_task():
+        started.set()
+        block_task.wait()
+
+    fut = c.submit(blocking_task)
+    await started.wait()
+
+    to_close = s.tasks[fut.key].processing_on.address
+
+    async def close_gracefully(dask_worker):
+        await asyncio.shield(dask_worker.close_gracefully())
+
+    try:
+        await c.run(close_gracefully, workers=[to_close])
+    except CommClosedError:
+        pass
+    await async_poll_for(lambda: to_close not in s.workers, 5)
+
+    assert b.address not in s.workers
+    assert s.tasks[fut.key].suspicious == 0
+    await block_task.set()
+    await fut
+
+
 @pytest.mark.parametrize("sync", [False, pytest.param(True, marks=[pytest.mark.slow])])
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_close_while_executing(c, s, a, sync):

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1686,7 +1686,7 @@ class Worker(BaseWorker, ServerNode):
         await self.scheduler.retire_workers(
             workers=[self.address],
             close_workers=False,
-            remove=False,
+            remove=True,
             stimulus_id=f"worker-close-gracefully-{time()}",
         )
         if restart is None:


### PR DESCRIPTION
Closes #8202 

the issue in https://github.com/dask/distributed/issues/8202 is triggered by worker.close_gracefully closing the batched_comm https://github.com/dask/distributed/blob/dfc43580f2342ce984cda51fe22a3addb0c0c815/distributed/worker.py#L1619-L1623
which causes the scheduler to call remove_worker with safe=False here: https://github.com/dask/distributed/blob/dfc43580f2342ce984cda51fe22a3addb0c0c815/distributed/scheduler.py#L5753-L5755

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
