### PR TITLE
Avoid schema enforcement from `meta` on Arrow data in P2P shuffling

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -499,8 +499,8 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
     def _get_assigned_worker(self, id: int) -> str:
         return self.worker_for[id]
 
-    def read(self, path: Path) -> tuple[Any, int]:
-        return read_from_disk(path, self.meta)
+    def read(self, path: Path) -> tuple[pa.Table, int]:
+        return read_from_disk(path)
 
 
 @dataclass(frozen=True)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1129,7 +1129,7 @@ def test_processing_chain(tmp_path):
 
     out = {}
     for k in range(npartitions):
-        shards, _ = read_from_disk(tmp_path / str(k), meta)
+        shards, _ = read_from_disk(tmp_path / str(k))
         out[k] = convert_shards(shards, meta)
 
     shuffled_df = pd.concat(df for df in out.values())

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2140,7 +2140,7 @@ async def test_handle_null_partitions_p2p_shuffling_2(c, s, a, b):
 
 
 @gen_cluster(client=True)
-async def test_handle_array_columns_p2p(c, s, a, b):
+async def test_handle_object_columns_p2p(c, s, a, b):
     with dask.config.set({"dataframe.convert-string": False}):
         df = pd.DataFrame(
             {
@@ -2150,6 +2150,7 @@ async def test_handle_array_columns_p2p(c, s, a, b):
                     np.asarray([4, 5, 6]),
                     np.asarray([7, 8, 9]),
                 ],
+                "c": ["foo", "bar", "baz"],
             }
         )
 


### PR DESCRIPTION
Closes #8200

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
