### PR TITLE
Move logic keeping shuffle runs consistent and up-to-date from `ShuffleWorkerPlugin` to `ShuffleRunManager`

### DIFF
--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class ShuffleRunManager:
+class _ShuffleRunManager:
     closed: bool
     _active_runs: dict[ShuffleId, ShuffleRun]
     _runs: set[ShuffleRun]
@@ -214,7 +214,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     """
 
     worker: Worker
-    shuffle_runs: ShuffleRunManager
+    shuffle_runs: _ShuffleRunManager
     memory_limiter_comms: ResourceLimiter
     memory_limiter_disk: ResourceLimiter
     closed: bool
@@ -228,7 +228,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
         # Initialize
         self.worker = worker
-        self.shuffle_runs = ShuffleRunManager(self)
+        self.shuffle_runs = _ShuffleRunManager(self)
         self.memory_limiter_comms = ResourceLimiter(parse_bytes("100 MiB"))
         self.memory_limiter_disk = ResourceLimiter(parse_bytes("1 GiB"))
         self.closed = False

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -31,6 +31,176 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ShuffleRunManager:
+    closed: bool
+    _active_runs: dict[ShuffleId, ShuffleRun]
+    _runs: set[ShuffleRun]
+    _runs_cleanup_condition: asyncio.Condition
+    _plugin: ShuffleWorkerPlugin
+
+    def __init__(self, plugin: ShuffleWorkerPlugin) -> None:
+        self.closed = False
+        self._active_runs = {}
+        self._runs = set()
+        self._runs_cleanup_condition = asyncio.Condition()
+        self._plugin = plugin
+
+    def heartbeat(self) -> dict[ShuffleId, Any]:
+        return {
+            id: shuffle_run.heartbeat() for id, shuffle_run in self._active_runs.items()
+        }
+
+    def fail(self, shuffle_id: ShuffleId, run_id: int, message: str) -> None:
+        shuffle_run = self._active_runs.get(shuffle_id, None)
+        if shuffle_run is None or shuffle_run.run_id != run_id:
+            return
+        self._active_runs.pop(shuffle_id)
+        exception = RuntimeError(message)
+        shuffle_run.fail(exception)
+
+        self._plugin.worker._ongoing_background_tasks.call_soon(self.close, shuffle_run)
+
+    async def close(self, shuffle_run: ShuffleRun) -> None:
+        with log_errors():
+            try:
+                await shuffle_run.close()
+            finally:
+                async with self._runs_cleanup_condition:
+                    self._runs.remove(shuffle_run)
+                    self._runs_cleanup_condition.notify_all()
+
+    async def teardown(self) -> None:
+        assert not self.closed
+        self.closed = True
+
+        while self._active_runs:
+            _, shuffle_run = self._active_runs.popitem()
+            self._plugin.worker._ongoing_background_tasks.call_soon(
+                self.close, shuffle_run
+            )
+
+        async with self._runs_cleanup_condition:
+            await self._runs_cleanup_condition.wait_for(lambda: not self._runs)
+
+    async def get_with_run_id(self, shuffle_id: ShuffleId, run_id: int) -> ShuffleRun:
+        """Get the shuffle matching the ID and run ID.
+
+        If necessary, this method fetches the shuffle run from the scheduler plugin.
+
+        Parameters
+        ----------
+        shuffle_id
+            Unique identifier of the shuffle
+        run_id
+            Unique identifier of the shuffle run
+
+        Raises
+        ------
+        KeyError
+            If the shuffle does not exist
+        RuntimeError
+            If the run_id is stale
+        """
+        shuffle_run = self._active_runs.get(shuffle_id, None)
+        if shuffle_run is None or shuffle_run.run_id < run_id:
+            shuffle_run = await self._refresh(
+                shuffle_id=shuffle_id,
+            )
+
+        if shuffle_run.run_id > run_id:
+            raise RuntimeError(f"{run_id=} stale, got {shuffle_run}")
+        elif shuffle_run.run_id < run_id:
+            raise RuntimeError(f"{run_id=} invalid, got {shuffle_run}")
+
+        if self.closed:
+            raise ShuffleClosedError(f"{self} has already been closed")
+        if shuffle_run._exception:
+            raise shuffle_run._exception
+        return shuffle_run
+
+    async def get_or_create(self, spec: ShuffleSpec, key: str) -> ShuffleRun:
+        """Get or create a shuffle matching the ID and data spec.
+
+        Parameters
+        ----------
+        shuffle_id
+            Unique identifier of the shuffle
+        type:
+            Type of the shuffle operation
+        key:
+            Task key triggering the function
+        """
+        shuffle_run = self._active_runs.get(spec.id, None)
+        if shuffle_run is None:
+            shuffle_run = await self._refresh(
+                shuffle_id=spec.id,
+                spec=spec,
+                key=key,
+            )
+
+        if self.closed:
+            raise ShuffleClosedError(f"{self} has already been closed")
+        if shuffle_run._exception:
+            raise shuffle_run._exception
+        return shuffle_run
+
+    @overload
+    async def _refresh(
+        self,
+        shuffle_id: ShuffleId,
+    ) -> ShuffleRun:
+        ...
+
+    @overload
+    async def _refresh(
+        self,
+        shuffle_id: ShuffleId,
+        spec: ShuffleSpec,
+        key: str,
+    ) -> ShuffleRun:
+        ...
+
+    async def _refresh(
+        self,
+        shuffle_id: ShuffleId,
+        spec: ShuffleSpec | None = None,
+        key: str | None = None,
+    ) -> ShuffleRun:
+        # FIXME: This should never be ToPickle[ShuffleRunSpec]
+        result: ShuffleRunSpec | ToPickle[ShuffleRunSpec]
+        if spec is None:
+            result = await self._plugin.worker.scheduler.shuffle_get(
+                id=shuffle_id,
+                worker=self._plugin.worker.address,
+            )
+        else:
+            result = await self._plugin.worker.scheduler.shuffle_get_or_create(
+                spec=ToPickle(spec),
+                key=key,
+                worker=self._plugin.worker.address,
+            )
+        if isinstance(result, ToPickle):
+            result = result.data
+        if self.closed:
+            raise ShuffleClosedError(f"{self} has already been closed")
+        if existing := self._active_runs.get(shuffle_id, None):
+            if existing.run_id >= result.run_id:
+                return existing
+            else:
+                self.fail(
+                    shuffle_id,
+                    existing.run_id,
+                    f"{existing!r} stale, expected run_id=={result.run_id}",
+                )
+
+        shuffle_run = result.spec.create_run_on_worker(
+            result.run_id, result.worker_for, self._plugin
+        )
+        self._active_runs[shuffle_id] = shuffle_run
+        self._runs.add(shuffle_run)
+        return shuffle_run
+
+
 class ShuffleWorkerPlugin(WorkerPlugin):
     """Interface between a Worker and a Shuffle.
 
@@ -44,9 +214,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     """
 
     worker: Worker
-    _active_runs: dict[ShuffleId, ShuffleRun]
-    _runs: set[ShuffleRun]
-    _runs_cleanup_condition: asyncio.Condition
+    shuffle_runs: ShuffleRunManager
     memory_limiter_comms: ResourceLimiter
     memory_limiter_disk: ResourceLimiter
     closed: bool
@@ -60,9 +228,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
         # Initialize
         self.worker = worker
-        self._active_runs = {}
-        self._runs = set()
-        self._runs_cleanup_condition = asyncio.Condition()
+        self.shuffle_runs = ShuffleRunManager(self)
         self.memory_limiter_comms = ResourceLimiter(parse_bytes("100 MiB"))
         self.memory_limiter_disk = ResourceLimiter(parse_bytes("1 GiB"))
         self.closed = False
@@ -79,9 +245,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     # NOTE: handlers are not threadsafe, but they're called from async comms, so that's okay
 
     def heartbeat(self) -> dict[ShuffleId, Any]:
-        return {
-            id: shuffle_run.heartbeat() for id, shuffle_run in self._active_runs.items()
-        }
+        return self.shuffle_runs.heartbeat()
 
     async def shuffle_receive(
         self,
@@ -105,15 +269,6 @@ class ShuffleWorkerPlugin(WorkerPlugin):
             shuffle_run = await self._get_shuffle_run(shuffle_id, run_id)
             await shuffle_run.inputs_done()
 
-    async def _close_shuffle_run(self, shuffle_run: ShuffleRun) -> None:
-        with log_errors():
-            try:
-                await shuffle_run.close()
-            finally:
-                async with self._runs_cleanup_condition:
-                    self._runs.remove(shuffle_run)
-                    self._runs_cleanup_condition.notify_all()
-
     def shuffle_fail(self, shuffle_id: ShuffleId, run_id: int, message: str) -> None:
         """Fails the shuffle run with the message as exception and triggers cleanup.
 
@@ -123,16 +278,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
             https://github.com/dask/distributed/pull/7486#discussion_r1088857185
             for more details.
         """
-        shuffle_run = self._active_runs.get(shuffle_id, None)
-        if shuffle_run is None or shuffle_run.run_id != run_id:
-            return
-        self._active_runs.pop(shuffle_id)
-        exception = RuntimeError(message)
-        shuffle_run.fail(exception)
-
-        self.worker._ongoing_background_tasks.call_soon(
-            self._close_shuffle_run, shuffle_run
-        )
+        self.shuffle_runs.fail(shuffle_id=shuffle_id, run_id=run_id, message=message)
 
     def add_partition(
         self,
@@ -172,141 +318,22 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         shuffle_id: ShuffleId,
         run_id: int,
     ) -> ShuffleRun:
-        """Get the shuffle matching the ID and run ID.
-
-        If necessary, this method fetches the shuffle run from the scheduler plugin.
-
-        Parameters
-        ----------
-        shuffle_id
-            Unique identifier of the shuffle
-        run_id
-            Unique identifier of the shuffle run
-
-        Raises
-        ------
-        KeyError
-            If the shuffle does not exist
-        RuntimeError
-            If the run_id is stale
-        """
-        shuffle_run = self._active_runs.get(shuffle_id, None)
-        if shuffle_run is None or shuffle_run.run_id < run_id:
-            shuffle_run = await self._refresh_shuffle(
-                shuffle_id=shuffle_id,
-            )
-
-        if shuffle_run.run_id > run_id:
-            raise RuntimeError(f"{run_id=} stale, got {shuffle_run}")
-        elif shuffle_run.run_id < run_id:
-            raise RuntimeError(f"{run_id=} invalid, got {shuffle_run}")
-
-        if self.closed:
-            raise ShuffleClosedError(f"{self} has already been closed")
-        if shuffle_run._exception:
-            raise shuffle_run._exception
-        return shuffle_run
+        return await self.shuffle_runs.get_with_run_id(
+            shuffle_id=shuffle_id, run_id=run_id
+        )
 
     async def _get_or_create_shuffle(
         self,
         spec: ShuffleSpec,
         key: str,
     ) -> ShuffleRun:
-        """Get or create a shuffle matching the ID and data spec.
-
-        Parameters
-        ----------
-        shuffle_id
-            Unique identifier of the shuffle
-        type:
-            Type of the shuffle operation
-        key:
-            Task key triggering the function
-        """
-        shuffle_run = self._active_runs.get(spec.id, None)
-        if shuffle_run is None:
-            shuffle_run = await self._refresh_shuffle(
-                shuffle_id=spec.id,
-                spec=spec,
-                key=key,
-            )
-
-        if self.closed:
-            raise ShuffleClosedError(f"{self} has already been closed")
-        if shuffle_run._exception:
-            raise shuffle_run._exception
-        return shuffle_run
-
-    @overload
-    async def _refresh_shuffle(
-        self,
-        shuffle_id: ShuffleId,
-    ) -> ShuffleRun:
-        ...
-
-    @overload
-    async def _refresh_shuffle(
-        self,
-        shuffle_id: ShuffleId,
-        spec: ShuffleSpec,
-        key: str,
-    ) -> ShuffleRun:
-        ...
-
-    async def _refresh_shuffle(
-        self,
-        shuffle_id: ShuffleId,
-        spec: ShuffleSpec | None = None,
-        key: str | None = None,
-    ) -> ShuffleRun:
-        # FIXME: This should never be ToPickle[ShuffleRunSpec]
-        result: ShuffleRunSpec | ToPickle[ShuffleRunSpec]
-        if spec is None:
-            result = await self.worker.scheduler.shuffle_get(
-                id=shuffle_id,
-                worker=self.worker.address,
-            )
-        else:
-            result = await self.worker.scheduler.shuffle_get_or_create(
-                spec=ToPickle(spec),
-                key=key,
-                worker=self.worker.address,
-            )
-        if isinstance(result, ToPickle):
-            result = result.data
-        if self.closed:
-            raise ShuffleClosedError(f"{self} has already been closed")
-        if existing := self._active_runs.get(shuffle_id, None):
-            if existing.run_id >= result.run_id:
-                return existing
-            else:
-                self.shuffle_fail(
-                    shuffle_id,
-                    existing.run_id,
-                    f"{existing!r} stale, expected run_id=={result.run_id}",
-                )
-
-        shuffle_run = result.spec.create_run_on_worker(
-            result.run_id, result.worker_for, self
-        )
-        self._active_runs[shuffle_id] = shuffle_run
-        self._runs.add(shuffle_run)
-        return shuffle_run
+        return await self.shuffle_runs.get_or_create(spec=spec, key=key)
 
     async def teardown(self, worker: Worker) -> None:
         assert not self.closed
 
         self.closed = True
-
-        while self._active_runs:
-            _, shuffle_run = self._active_runs.popitem()
-            self.worker._ongoing_background_tasks.call_soon(
-                self._close_shuffle_run, shuffle_run
-            )
-
-        async with self._runs_cleanup_condition:
-            await self._runs_cleanup_condition.wait_for(lambda: not self._runs)
-
+        await self.shuffle_runs.teardown()
         try:
             self._executor.shutdown(cancel_futures=True)
         except Exception:  # pragma: no cover
@@ -327,7 +354,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
     ) -> ShuffleRun:
         return sync(
             self.worker.loop,
-            self._get_shuffle_run,
+            self.shuffle_runs.get_with_run_id,
             shuffle_id,
             run_id,
         )
@@ -339,7 +366,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         key = thread_state.key
         return sync(
             self.worker.loop,
-            self._get_or_create_shuffle,
+            self.shuffle_runs.get_or_create,
             spec,
             key,
         )

--- a/distributed/shuffle/tests/test_graph.py
+++ b/distributed/shuffle/tests/test_graph.py
@@ -83,17 +83,20 @@ async def test_basic_state(c, s, *workers):
 
     exts = [w.extensions["shuffle"] for w in workers]
     for ext in exts:
-        assert not ext._active_runs
+        assert not ext.shuffle_runs._active_runs
 
     f = c.compute(shuffled)
     # TODO this is a bad/pointless test. the `f.done()` is necessary in case the shuffle is really fast.
     # To test state more thoroughly, we'd need a way to 'stop the world' at various stages. Like have the
     # scheduler pause everything when the barrier is reached. Not sure yet how to implement that.
-    while not all(len(ext._active_runs) == 1 for ext in exts) and not f.done():
+    while (
+        not all(len(ext.shuffle_runs._active_runs) == 1 for ext in exts)
+        and not f.done()
+    ):
         await asyncio.sleep(0.1)
 
     await f
-    assert all(not ext._active_runs for ext in exts)
+    assert all(not ext.shuffle_runs._active_runs for ext in exts)
 
 
 def test_multiple_linear(client):

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -430,7 +430,7 @@ class BlockedGetOrCreateShuffleRunManager(_ShuffleRunManager):
 
 
 @mock.patch(
-    "distributed.shuffle._worker_plugin.ShuffleRunManager",
+    "distributed.shuffle._worker_plugin._ShuffleRunManager",
     BlockedGetOrCreateShuffleRunManager,
 )
 @gen_cluster(
@@ -2038,7 +2038,7 @@ class BlockedShuffleAccessAndFailShuffleRunManager(_ShuffleRunManager):
 
 
 @mock.patch(
-    "distributed.shuffle._worker_plugin.ShuffleRunManager",
+    "distributed.shuffle._worker_plugin._ShuffleRunManager",
     BlockedShuffleAccessAndFailShuffleRunManager,
 )
 @gen_cluster(client=True, nthreads=[("", 1)] * 2)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -51,7 +51,7 @@ from distributed.shuffle._shuffle import (
     split_by_partition,
     split_by_worker,
 )
-from distributed.shuffle._worker_plugin import ShuffleRunManager, ShuffleWorkerPlugin
+from distributed.shuffle._worker_plugin import ShuffleWorkerPlugin, _ShuffleRunManager
 from distributed.shuffle.tests.utils import (
     AbstractShuffleTestPool,
     invoke_annotation_chaos,
@@ -168,7 +168,7 @@ def get_active_shuffle_run(shuffle_id: ShuffleId, worker: Worker) -> ShuffleRun:
     return get_active_shuffle_runs(worker)[shuffle_id]
 
 
-def get_shuffle_run_manager(worker: Worker) -> ShuffleRunManager:
+def get_shuffle_run_manager(worker: Worker) -> _ShuffleRunManager:
     return cast(ShuffleWorkerPlugin, worker.plugins["shuffle"]).shuffle_runs
 
 
@@ -417,7 +417,7 @@ async def test_restarting_during_transfer_raises_killed_worker(c, s, a, b):
     await check_scheduler_cleanup(s)
 
 
-class BlockedGetOrCreateShuffleRunManager(ShuffleRunManager):
+class BlockedGetOrCreateShuffleRunManager(_ShuffleRunManager):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.in_get_or_create = asyncio.Event()
@@ -2010,7 +2010,7 @@ async def test_shuffle_run_consistency(c, s, a):
     await check_scheduler_cleanup(s)
 
 
-class BlockedShuffleAccessAndFailShuffleRunManager(ShuffleRunManager):
+class BlockedShuffleAccessAndFailShuffleRunManager(_ShuffleRunManager):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.in_get_or_create_shuffle = asyncio.Event()


### PR DESCRIPTION
Refactoring that helps with maintainability and is necessary for future work on consistency.

This PR does not contain any functional changes, it just moves and deduplicates existing logic.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
