### PR TITLE
Respect cgroups v2 "low" memory limit

### DIFF
--- a/distributed/system.py
+++ b/distributed/system.py
@@ -31,6 +31,7 @@ def memory_limit() -> int:
             "/sys/fs/cgroup/memory/memory.soft_limit_in_bytes",  # cgroups v1 soft limit
             "/sys/fs/cgroup/memory.max",  # cgroups v2 hard limit
             "/sys/fs/cgroup/memory.high",  # cgroups v2 soft limit
+            "/sys/fs/cgroup/memory.low",  # cgroups v2 softest limit
         ]:
             try:
                 with open(path) as f:

--- a/distributed/tests/test_system.py
+++ b/distributed/tests/test_system.py
@@ -87,6 +87,7 @@ def test_soft_memory_limit_cgroups2(monkeypatch):
     limit = memory_limit()
     assert limit == 10
 
+
 def test_softest_memory_limit_cgroups2(monkeypatch):
     builtin_open = builtins.open
 
@@ -104,6 +105,7 @@ def test_softest_memory_limit_cgroups2(monkeypatch):
 
     limit = memory_limit()
     assert limit == 10
+
 
 @pytest.mark.xfail(
     MACOS,

--- a/distributed/tests/test_system.py
+++ b/distributed/tests/test_system.py
@@ -87,6 +87,24 @@ def test_soft_memory_limit_cgroups2(monkeypatch):
     limit = memory_limit()
     assert limit == 10
 
+def test_softest_memory_limit_cgroups2(monkeypatch):
+    builtin_open = builtins.open
+
+    def myopen(path, *args, **kwargs):
+        if path == "/sys/fs/cgroup/memory.max":
+            # Absurdly low, unlikely to match real value
+            return io.StringIO("20")
+        if path == "/sys/fs/cgroup/memory.low":
+            # should take precedence
+            return io.StringIO("10")
+        return builtin_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", myopen)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    limit = memory_limit()
+    assert limit == 10
+
 
 @pytest.mark.xfail(
     MACOS,

--- a/distributed/tests/test_system.py
+++ b/distributed/tests/test_system.py
@@ -105,7 +105,6 @@ def test_softest_memory_limit_cgroups2(monkeypatch):
     limit = memory_limit()
     assert limit == 10
 
-
 @pytest.mark.xfail(
     MACOS,
     reason="Mac OS raises 'ValueError: current limit exceeds maximum limit' "


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Missed an option for cgroups v2. Reference for it is here https://facebookmicrosites.github.io/cgroup2/docs/memory-controller.html

Real world usage of this is someone running docker with the "memory-reservation" parameter set

https://docs.docker.com/config/containers/resource_constraints/

Ideally dask should work to stay under it, but will not punished if exceeded. 

Possibly dask could ignore this limit, but I suspect users will have a sad time to see dask going up to their harder limits and being OOM killed.