### PR TITLE
Set charset encoding for the HTTP API

### DIFF
--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -8,7 +8,7 @@ from distributed.http.utils import RequestHandler
 class APIHandler(RequestHandler):
     def get(self):
         self.write("API V1")
-        self.set_header("Content-Type", "text/plain")
+        self.set_header("Content-Type", "text/plain; charset=ISO-8859-1")
 
 
 class RetireWorkersHandler(RequestHandler):

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -415,7 +415,7 @@ async def test_api(c, s, a, b):
             "http://localhost:%d/api/v1" % s.http_server.port
         ) as resp:
             assert resp.status == 200
-            assert resp.headers["Content-Type"] == "text/plain"
+            assert resp.headers["Content-Type"] == "text/plain; charset=ISO-8859-1"
             assert (await resp.text()) == "API V1"
 
 


### PR DESCRIPTION
aiohttp now raises a deprecation warning that it will no longer "infer" the charset encoding.

https://www.w3.org/International/articles/http-charset/index suggests to use this ISO (for HTTP 1.1) which is basically ascii.

I don't expect this to have a real world impact

Closes https://github.com/dask/distributed/issues/8248