### PR TITLE
Explicitly set charset=utf-8

### DIFF
--- a/distributed/http/health.py
+++ b/distributed/http/health.py
@@ -6,7 +6,7 @@ from tornado import web
 class HealthHandler(web.RequestHandler):
     def get(self):
         self.write("ok")
-        self.set_header("Content-Type", "text/plain")
+        self.set_header("Content-Type", "text/plain; charset=utf-8")
 
 
 routes: list[tuple] = [("/health", HealthHandler, {})]

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -8,7 +8,7 @@ from distributed.http.utils import RequestHandler
 class APIHandler(RequestHandler):
     def get(self):
         self.write("API V1")
-        self.set_header("Content-Type", "text/plain")
+        self.set_header("Content-Type", "text/plain; charset=utf-8")
 
 
 class RetireWorkersHandler(RequestHandler):

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -306,18 +306,17 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
     await ev.set()
 
 
-@gen_cluster(client=True, clean_kwargs={"threads": False})
-async def test_health(c, s, a, b):
-    http_client = AsyncHTTPClient()
+@gen_cluster(nthreads=[])
+async def test_health(s):
+    aiohttp = pytest.importorskip("aiohttp")
 
-    response = await http_client.fetch(
-        "http://localhost:%d/health" % s.http_server.port
-    )
-    assert response.code == 200
-    assert response.headers["Content-Type"] == "text/plain"
-
-    txt = response.body.decode("utf8")
-    assert txt == "ok"
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://localhost:{s.http_server.port}/health") as resp,
+    ):
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
+        assert (await resp.text()) == "ok"
 
 
 @gen_cluster()
@@ -400,23 +399,22 @@ def test_api_disabled_by_default():
 
 
 @gen_cluster(
-    client=True,
-    clean_kwargs={"threads": False},
+    nthreads=[],
     config={
         "distributed.scheduler.http.routes": DEFAULT_ROUTES
         + ["distributed.http.scheduler.api"]
     },
 )
-async def test_api(c, s, a, b):
+async def test_api(s):
     aiohttp = pytest.importorskip("aiohttp")
 
-    async with aiohttp.ClientSession() as session:
-        async with session.get(
-            "http://localhost:%d/api/v1" % s.http_server.port
-        ) as resp:
-            assert resp.status == 200
-            assert resp.headers["Content-Type"] == "text/plain"
-            assert (await resp.text()) == "API V1"
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://localhost:{s.http_server.port}/api/v1") as resp,
+    ):
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
+        assert (await resp.text()) == "API V1"
 
 
 @gen_cluster(

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import json
 from unittest import mock
 
 import pytest
-from tornado.httpclient import AsyncHTTPClient
 
 from distributed import Event, Worker, wait
 from distributed.sizeof import sizeof
@@ -133,28 +131,30 @@ async def test_prometheus_collect_task_states(c, s, a):
     await assert_metrics()
 
 
-@gen_cluster(client=True)
-async def test_health(c, s, a, b):
-    http_client = AsyncHTTPClient()
+@gen_cluster(nthreads=[("", 1)])
+async def test_health(s, a):
+    aiohttp = pytest.importorskip("aiohttp")
 
-    response = await http_client.fetch(
-        "http://localhost:%d/health" % a.http_server.port
-    )
-    assert response.code == 200
-    assert response.headers["Content-Type"] == "text/plain"
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://localhost:{a.http_server.port}/health") as resp,
+    ):
+        assert resp.status == 200
+        assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
+        assert (await resp.text()) == "ok"
 
-    txt = response.body.decode("utf8")
-    assert txt == "ok"
 
+@gen_cluster(nthreads=[("", 1)])
+async def test_sitemap(s, a):
+    aiohttp = pytest.importorskip("aiohttp")
 
-@gen_cluster()
-async def test_sitemap(s, a, b):
-    http_client = AsyncHTTPClient()
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://localhost:{a.http_server.port}/sitemap.json") as resp,
+    ):
+        assert resp.status == 200
+        out = await resp.json()
 
-    response = await http_client.fetch(
-        "http://localhost:%d/sitemap.json" % a.http_server.port
-    )
-    out = json.loads(response.body.decode())
     assert "paths" in out
     assert "/sitemap.json" in out["paths"]
     assert "/health" in out["paths"]


### PR DESCRIPTION
- Closes #8248
- Supersedes #8249

I don't have a strong preference for the tornado HTTP client vs. aiohttp, but I recall that there was a desire to lessen the dependency on tornado as much as possible? CC @graingert 