### PR TITLE
Clean up redundant minimum versions

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -13,19 +13,19 @@ dependencies:
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
-  - gilknocker>=0.4.0
+  - gilknocker
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
-  - jinja2 >=2.10.3
-  - locket >=1.0
+  - jinja2
+  - locket
   - msgpack-python
   - netcdf4
   - paramiko
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow>=7
+  - pyarrow
   - pytest
   - pytest-cov
   - pytest-faulthandler
@@ -39,9 +39,9 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado >=6.2
+  - tornado
   - zict  # overridden by git tip below
-  - zstandard >=0.9.0
+  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/s3fs

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -13,19 +13,19 @@ dependencies:
   - coverage
   - dask  # overridden by git tip below
   - filesystem-spec  # overridden by git tip below
-  - gilknocker>=0.4.0
+  - gilknocker
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
   - jinja2
-  - locket >=1.0
+  - locket
   - msgpack-python
   - netcdf4
   - paramiko
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow>=7
+  - pyarrow
   - pytest
   - pytest-cov
   - pytest-faulthandler
@@ -39,9 +39,9 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  - tornado >=6.2
+  - tornado
   - zict  # overridden by git tip below
-  - zstandard >=0.9.0
+  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/s3fs

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -15,20 +15,20 @@ dependencies:
   - cython  # Only tested here; also a dependency of crick
   - dask  # overridden by git tip below
   - filesystem-spec
-  - gilknocker>=0.4.0
+  - gilknocker
   - h5py
   - ipykernel <6.22.0  # https://github.com/dask/distributed/issues/7688
   - ipywidgets <8.0.5  # https://github.com/dask/distributed/issues/7688
-  - jinja2 >=2.10.3
-  - locket >=1.0
-  - lz4 >=0.23.1  # Only tested here
+  - jinja2
+  - locket
+  - lz4  # Only tested here
   - msgpack-python
   - netcdf4
   - paramiko
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow=12
+  - pyarrow
   - pynvml  # Only tested here
   - pytest
   - pytest-cov
@@ -36,7 +36,7 @@ dependencies:
   - pytest-repeat
   - pytest-rerunfailures
   - pytest-timeout
-  - python-snappy >=0.5.3  # Only tested here
+  - python-snappy  # Only tested here
   - pytorch  # Only tested here
   - requests
   - s3fs
@@ -46,9 +46,9 @@ dependencies:
   - tblib
   - toolz
   - torchvision  # Only tested here
-  - tornado >=6.2
+  - tornado
   - zict
-  - zstandard >=0.9.0
+  - zstandard
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/crick  # Only tested here


### PR DESCRIPTION
This PR bumps up pyarrow from 12 to 13 on python 3.9 (we are missing a mindeps-optional CI env like in dask/dask, but that's a different topic).

All other changes are purely cosmetic and aimed at removing unnecessary, misleading clutter.