### PR TITLE
shuffle: clean up BARRIER_PREFIX in scheduler plugin

### DIFF
--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -14,6 +14,8 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, NewType, TypeVar
 
+from dask.typing import Key
+
 from distributed.core import PooledRPCCall
 from distributed.exceptions import Reschedule
 from distributed.protocol import to_serialize
@@ -269,9 +271,10 @@ def barrier_key(shuffle_id: ShuffleId) -> str:
     return _BARRIER_PREFIX + shuffle_id
 
 
-def id_from_key(key: str) -> ShuffleId:
-    assert key.startswith(_BARRIER_PREFIX)
-    return ShuffleId(key.replace(_BARRIER_PREFIX, ""))
+def id_from_key(key: Key) -> ShuffleId | None:
+    if not isinstance(key, str) or not key.startswith(_BARRIER_PREFIX):
+        return None
+    return ShuffleId(key[len(_BARRIER_PREFIX) :])
 
 
 class ShuffleType(Enum):

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -291,9 +291,9 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         """Clean up scheduler and worker state once a shuffle becomes inactive."""
         if finish not in ("released", "forgotten"):
             return
-        if not isinstance(key, str) or not key.startswith("shuffle-barrier-"):
-            return
         shuffle_id = id_from_key(key)
+        if not shuffle_id:
+            return
 
         if shuffle := self.active_shuffles.get(shuffle_id):
             self._fail_on_workers(shuffle, message=f"{shuffle} forgotten")


### PR DESCRIPTION
Minor code quality tweak.
Remove copy-pasted BARRIER_PREFIX constant value from scheduler module and clean up the code.