### PR TITLE
Restart on stale transfers from resumed tasks in P2P shuffling

### DIFF
--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -75,9 +75,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
     def shuffle_ids(self) -> set[ShuffleId]:
         return set(self.active_shuffles)
 
-    async def barrier(
-        self, id: ShuffleId, run_id: int, consistent: bool = True
-    ) -> None:
+    async def barrier(self, id: ShuffleId, run_id: int, consistent: bool) -> None:
         shuffle = self.active_shuffles[id]
         if shuffle.run_id != run_id:
             raise ValueError(f"{run_id=} does not match {shuffle}")

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from dask.typing import Key
 
 from distributed.diagnostics.plugin import SchedulerPlugin
+from distributed.metrics import time
 from distributed.protocol.pickle import dumps
 from distributed.protocol.serialize import ToPickle
 from distributed.shuffle._core import (
@@ -74,10 +75,18 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
     def shuffle_ids(self) -> set[ShuffleId]:
         return set(self.active_shuffles)
 
-    async def barrier(self, id: ShuffleId, run_id: int) -> None:
+    async def barrier(
+        self, id: ShuffleId, run_id: int, consistent: bool = True
+    ) -> None:
         shuffle = self.active_shuffles[id]
         if shuffle.run_id != run_id:
             raise ValueError(f"{run_id=} does not match {shuffle}")
+        if not consistent:
+            return self._restart_shuffle(
+                shuffle.id,
+                self.scheduler,
+                stimulus_id=f"p2p-barrier-inconsistent-{time()}",
+            )
         msg = {"op": "shuffle_inputs_done", "shuffle_id": id, "run_id": run_id}
         await self.scheduler.broadcast(
             msg=msg,

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -18,6 +18,7 @@ from dask.layers import Layer
 from dask.typing import Key
 
 from distributed.core import PooledRPCCall
+from distributed.exceptions import Reschedule
 from distributed.shuffle._arrow import (
     check_dtype_support,
     check_minimal_arrow_version,
@@ -87,6 +88,8 @@ def shuffle_unpack(
 def shuffle_barrier(id: ShuffleId, run_ids: list[int]) -> int:
     try:
         return get_worker_plugin().barrier(id, run_ids)
+    except Reschedule as e:
+        raise e
     except Exception as e:
         raise RuntimeError(f"shuffle_barrier failed during shuffle {id}") from e
 

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -118,12 +118,13 @@ async def test_lowlevel_rechunk(
         else:
             barrier_worker = random.sample(shuffles, k=1)[0]
 
+        run_ids = []
         try:
             for i, (idx, arr) in enumerate(old_chunks.items()):
                 s = shuffles[i % len(shuffles)]
-                await s.add_partition(arr, idx)
+                run_ids.append(await s.add_partition(arr, idx))
 
-            await barrier_worker.barrier()
+            await barrier_worker.barrier(run_ids)
 
             total_bytes_sent = 0
             total_bytes_recvd = 0

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1624,12 +1624,13 @@ async def test_basic_lowlevel_shuffle(
         else:
             barrier_worker = random.sample(shuffles, k=1)[0]
 
+        run_ids = []
         try:
             for ix, df in enumerate(dfs):
                 s = shuffles[ix % len(shuffles)]
-                await s.add_partition(df, ix)
+                run_ids.append(await s.add_partition(df, ix))
 
-            await barrier_worker.barrier()
+            await barrier_worker.barrier(run_ids=run_ids)
 
             total_bytes_sent = 0
             total_bytes_recvd = 0
@@ -1704,7 +1705,7 @@ async def test_error_offload(tmp_path, loop_in_thread):
             await sB.add_partition(dfs[0], 0)
             with pytest.raises(RuntimeError, match="Error during deserialization"):
                 await sB.add_partition(dfs[1], 1)
-                await sB.barrier()
+                await sB.barrier(run_ids=[sB.run_id, sB.run_id])
         finally:
             await asyncio.gather(*[s.close() for s in [sA, sB]])
 
@@ -1757,7 +1758,7 @@ async def test_error_send(tmp_path, loop_in_thread):
         try:
             await sA.add_partition(dfs[0], 0)
             with pytest.raises(RuntimeError, match="Error during send"):
-                await sA.barrier()
+                await sA.barrier(run_ids=[sA.run_id])
         finally:
             await asyncio.gather(*[s.close() for s in [sA, sB]])
 
@@ -1810,7 +1811,7 @@ async def test_error_receive(tmp_path, loop_in_thread):
         try:
             await sB.add_partition(dfs[0], 0)
             with pytest.raises(RuntimeError, match="Error during receive"):
-                await sB.barrier()
+                await sB.barrier(run_ids=[sB.run_id])
         finally:
             await asyncio.gather(*[s.close() for s in [sA, sB]])
 
@@ -2291,10 +2292,10 @@ class BlockedBarrierShuffleRun(DataFrameShuffleRun):
         self.in_barrier = asyncio.Event()
         self.block_barrier = asyncio.Event()
 
-    async def barrier(self):
+    async def barrier(self, *args: Any, **kwargs: Any) -> int:
         self.in_barrier.set()
         await self.block_barrier.wait()
-        return await super().barrier()
+        return await super().barrier(*args, **kwargs)
 
 
 @mock.patch(

--- a/distributed/shuffle/tests/utils.py
+++ b/distributed/shuffle/tests/utils.py
@@ -43,7 +43,9 @@ class AbstractShuffleTestPool:
     def __call__(self, addr: str, *args: Any, **kwargs: Any) -> PooledRPCShuffle:
         return PooledRPCShuffle(self.shuffles[addr])
 
-    async def shuffle_barrier(self, id: ShuffleId, run_id: int) -> dict[str, None]:
+    async def shuffle_barrier(
+        self, id: ShuffleId, run_id: int, consistent: bool
+    ) -> dict[str, None]:
         out = {}
         for addr, s in self.shuffles.items():
             out[addr] = await s.inputs_done()


### PR DESCRIPTION
Our `transfer` tasks are impure and the `cancelled->resumed` logic cannot handle that correctly. This can lead to stale attempts for the transfer tasks and failing P2P shuffles.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
