### PR TITLE
Run coverage on test failures

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -240,13 +240,19 @@ jobs:
       # as opposed to root. This is causing filename mismatches in Codecov.
       # This step edits `coverage.xml` in-file by adding `distributed` to all filenames.
       - name: Prepare coverage report
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: >
+          always() &&
+          (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure') &&
+          matrix.os != 'windows-latest'
         shell: bash -l {0}
         run: sed -i'' -e 's/filename="/filename="distributed\//g' coverage.xml
 
       # Do not upload coverage reports for cron jobs
       - name: Coverage
-        if: github.event_name != 'schedule'
+        if: >
+          always() &&
+          (steps.run_tests.outcome == 'success' || steps.run_tests.outcome == 'failure') &&
+          github.event_name != 'schedule'
         uses: codecov/codecov-action@v3
         with:
           name: ${{ env.TEST_ID }}


### PR DESCRIPTION
Fix bug where none of the test coverage of a test run would be uploaded to coveralls if *any* test failed.