### PR TITLE
Allow `ResourceLimiter` to be unlimited

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -4459,7 +4459,9 @@ class Shuffling(DashboardComponent):
                 for prefix in ["comm", "disk"]:
                     data[f"{prefix}_total"].append(d[prefix]["total"])
                     data[f"{prefix}_memory"].append(d[prefix]["memory"])
-                    data[f"{prefix}_memory_limit"].append(d[prefix]["memory_limit"])
+                    data[f"{prefix}_memory_limit"].append(
+                        d[prefix]["memory_limit"] or 0
+                    )
                     data[f"{prefix}_buckets"].append(d[prefix]["buckets"])
                     data[f"{prefix}_avg_duration"].append(
                         d[prefix]["diagnostics"].get("avg_duration", 0)

--- a/distributed/shuffle/_buffer.py
+++ b/distributed/shuffle/_buffer.py
@@ -46,7 +46,7 @@ class ShardsBuffer(Generic[ShardType]):
     shards: defaultdict[str, _List[ShardType]]
     sizes: defaultdict[str, int]
     concurrency_limit: int
-    memory_limiter: ResourceLimiter | None
+    memory_limiter: ResourceLimiter
     diagnostics: dict[str, float]
     max_message_size: int
 
@@ -74,7 +74,7 @@ class ShardsBuffer(Generic[ShardType]):
         self._exception = None
         self.concurrency_limit = concurrency_limit
         self._inputs_done = False
-        self.memory_limiter = memory_limiter
+        self.memory_limiter = memory_limiter or ResourceLimiter()
         self.diagnostics: dict[str, float] = defaultdict(float)
         self._tasks = [
             asyncio.create_task(self._background_task())
@@ -97,7 +97,7 @@ class ShardsBuffer(Generic[ShardType]):
             "written": self.bytes_written,
             "read": self.bytes_read,
             "diagnostics": self.diagnostics,
-            "memory_limit": self.memory_limiter._maxvalue if self.memory_limiter else 0,
+            "memory_limit": self.memory_limiter.limit,
         }
 
     async def process(self, id: str, shards: list[ShardType], size: int) -> None:

--- a/distributed/shuffle/_buffer.py
+++ b/distributed/shuffle/_buffer.py
@@ -119,8 +119,7 @@ class ShardsBuffer(Generic[ShardType]):
                 "avg_duration"
             ] + 0.02 * (stop - start)
         finally:
-            if self.memory_limiter:
-                await self.memory_limiter.decrease(size)
+            await self.memory_limiter.decrease(size)
             self.bytes_memory -= size
 
     async def _process(self, id: str, shards: list[ShardType]) -> None:
@@ -198,15 +197,13 @@ class ShardsBuffer(Generic[ShardType]):
         self.bytes_memory += total_batch_size
         self.bytes_total += total_batch_size
 
-        if self.memory_limiter:
-            self.memory_limiter.increase(total_batch_size)
+        self.memory_limiter.increase(total_batch_size)
         async with self._shards_available:
             for worker, shard in data.items():
                 self.shards[worker].append(shard)
                 self.sizes[worker] += sizes[worker]
             self._shards_available.notify()
-        if self.memory_limiter:
-            await self.memory_limiter.wait_for_available()
+        await self.memory_limiter.wait_for_available()
         del data
         assert total_batch_size
 

--- a/distributed/shuffle/_buffer.py
+++ b/distributed/shuffle/_buffer.py
@@ -64,7 +64,7 @@ class ShardsBuffer(Generic[ShardType]):
 
     def __init__(
         self,
-        memory_limiter: ResourceLimiter | None,
+        memory_limiter: ResourceLimiter,
         concurrency_limit: int = 2,
         max_message_size: int = -1,
     ) -> None:
@@ -74,7 +74,7 @@ class ShardsBuffer(Generic[ShardType]):
         self._exception = None
         self.concurrency_limit = concurrency_limit
         self._inputs_done = False
-        self.memory_limiter = memory_limiter or ResourceLimiter()
+        self.memory_limiter = memory_limiter
         self.diagnostics: dict[str, float] = defaultdict(float)
         self._tasks = [
             asyncio.create_task(self._background_task())

--- a/distributed/shuffle/_comms.py
+++ b/distributed/shuffle/_comms.py
@@ -39,12 +39,11 @@ class CommShardsBuffer(ShardsBuffer):
         How to send a list of shards to a worker
         Expects an address of the target worker (string)
         and a payload of shards (list of bytes) to send to that worker
-    memory_limiter : ResourceLimiter, optional
-        Limiter for memory usage (in bytes), or None if no limiting
-        should be applied. If the incoming data that has yet to be
-        processed exceeds this limit, then the buffer will block until
-        below the threshold. See :meth:`.write` for the implementation
-        of this scheme.
+    memory_limiter : ResourceLimiter
+        Limiter for memory usage (in bytes). If the incoming data that
+        has yet to be processed exceeds this limit, then the buffer will
+        block until below the threshold. See :meth:`.write` for the
+        implementation of this scheme.
     concurrency_limit : int
         Number of background tasks to run.
     """
@@ -54,7 +53,7 @@ class CommShardsBuffer(ShardsBuffer):
     def __init__(
         self,
         send: Callable[[str, list[tuple[Any, bytes]]], Awaitable[None]],
-        memory_limiter: ResourceLimiter | None = None,
+        memory_limiter: ResourceLimiter,
         concurrency_limit: int = 10,
     ):
         super().__init__(

--- a/distributed/shuffle/_disk.py
+++ b/distributed/shuffle/_disk.py
@@ -110,7 +110,7 @@ class DiskShardsBuffer(ShardsBuffer):
     ----------
     directory : str or pathlib.Path
         Where to write and read data.  Ideally points to fast disk.
-    memory_limiter : ResourceLimiter, optional
+    memory_limiter : ResourceLimiter
         Limiter for in-memory buffering (at most this much data)
         before writes to disk occur. If the incoming data that has yet
         to be processed exceeds this limit, then the buffer will block
@@ -122,7 +122,7 @@ class DiskShardsBuffer(ShardsBuffer):
         self,
         directory: str | pathlib.Path,
         read: Callable[[pathlib.Path], tuple[Any, int]],
-        memory_limiter: ResourceLimiter | None = None,
+        memory_limiter: ResourceLimiter,
     ):
         super().__init__(
             memory_limiter=memory_limiter,

--- a/distributed/shuffle/tests/test_buffer.py
+++ b/distributed/shuffle/tests/test_buffer.py
@@ -70,7 +70,7 @@ async def test_memory_limit(big_payloads):
 
         many_small = [asyncio.create_task(buf.write(small_payload)) for _ in range(11)]
         assert buf.memory_limiter
-        while buf.memory_limiter.available():
+        while buf.memory_limiter.available:
             await asyncio.sleep(0.1)
 
         new_put = asyncio.create_task(buf.write(small_payload))
@@ -80,7 +80,7 @@ async def test_memory_limit(big_payloads):
         many_small = asyncio.gather(*many_small)
         await new_put
 
-        while not buf.memory_limiter.free():
+        while not buf.memory_limiter.empty:
             await asyncio.sleep(0.1)
         buf.allow_process.clear()
         big_tasks = [

--- a/distributed/shuffle/tests/test_comm_buffer.py
+++ b/distributed/shuffle/tests/test_comm_buffer.py
@@ -20,7 +20,7 @@ async def test_basic(tmp_path):
     async def send(address, shards):
         d[address].extend(shards)
 
-    mc = CommShardsBuffer(send=send)
+    mc = CommShardsBuffer(send=send, memory_limiter=ResourceLimiter(None))
     await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
     await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
 
@@ -37,7 +37,7 @@ async def test_exceptions(tmp_path):
     async def send(address, shards):
         raise Exception(123)
 
-    mc = CommShardsBuffer(send=send)
+    mc = CommShardsBuffer(send=send, memory_limiter=ResourceLimiter(None))
     await mc.write({"x": b"0" * 1000, "y": b"1" * 500})
 
     while not mc._exception:
@@ -63,7 +63,9 @@ async def test_slow_send(tmp_path):
         d[address].extend(shards)
         sending_first.set()
 
-    mc = CommShardsBuffer(send=send, concurrency_limit=1)
+    mc = CommShardsBuffer(
+        send=send, concurrency_limit=1, memory_limiter=ResourceLimiter(None)
+    )
     await mc.write({"x": b"0", "y": b"1"})
     await mc.write({"x": b"0", "y": b"1"})
     flush_task = asyncio.create_task(mc.flush())
@@ -96,7 +98,7 @@ async def test_concurrent_puts():
         send=send, memory_limiter=ResourceLimiter(parse_bytes("100 MiB"))
     )
     payload = {
-        x: gen_bytes(frac, comm_buffer.memory_limiter._maxvalue) for x in range(nshards)
+        x: gen_bytes(frac, comm_buffer.memory_limiter.limit) for x in range(nshards)
     }
 
     async with comm_buffer as mc:
@@ -113,7 +115,7 @@ async def test_concurrent_puts():
     assert len(d) == 10
     assert (
         sum(map(len, d[0]))
-        == len(gen_bytes(frac, comm_buffer.memory_limiter._maxvalue)) * nputs
+        == len(gen_bytes(frac, comm_buffer.memory_limiter.limit)) * nputs
     )
 
 
@@ -137,7 +139,7 @@ async def test_concurrent_puts_error():
         send=send, memory_limiter=ResourceLimiter(parse_bytes("100 MiB"))
     )
     payload = {
-        x: gen_bytes(frac, comm_buffer.memory_limiter._maxvalue) for x in range(nshards)
+        x: gen_bytes(frac, comm_buffer.memory_limiter.limit) for x in range(nshards)
     }
 
     async with comm_buffer as mc:

--- a/distributed/shuffle/tests/test_disk_buffer.py
+++ b/distributed/shuffle/tests/test_disk_buffer.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from distributed.shuffle._disk import DiskShardsBuffer
+from distributed.shuffle._limiter import ResourceLimiter
 from distributed.utils_test import gen_test
 
 
@@ -20,7 +21,9 @@ def read_bytes(path: Path) -> tuple[bytes, int]:
 
 @gen_test()
 async def test_basic(tmp_path):
-    async with DiskShardsBuffer(directory=tmp_path, read=read_bytes) as mf:
+    async with DiskShardsBuffer(
+        directory=tmp_path, read=read_bytes, memory_limiter=ResourceLimiter(None)
+    ) as mf:
         await mf.write({"x": b"0" * 1000, "y": b"1" * 500})
         await mf.write({"x": b"0" * 1000, "y": b"1" * 500})
 
@@ -41,7 +44,9 @@ async def test_basic(tmp_path):
 @gen_test()
 async def test_read_before_flush(tmp_path):
     payload = {"1": b"foo"}
-    async with DiskShardsBuffer(directory=tmp_path, read=read_bytes) as mf:
+    async with DiskShardsBuffer(
+        directory=tmp_path, read=read_bytes, memory_limiter=ResourceLimiter(None)
+    ) as mf:
         with pytest.raises(RuntimeError):
             mf.read(1)
 
@@ -59,7 +64,9 @@ async def test_read_before_flush(tmp_path):
 @pytest.mark.parametrize("count", [2, 100, 1000])
 @gen_test()
 async def test_many(tmp_path, count):
-    async with DiskShardsBuffer(directory=tmp_path, read=read_bytes) as mf:
+    async with DiskShardsBuffer(
+        directory=tmp_path, read=read_bytes, memory_limiter=ResourceLimiter(None)
+    ) as mf:
         d = {i: str(i).encode() * 100 for i in range(count)}
 
         for _ in range(10):
@@ -84,7 +91,9 @@ class BrokenDiskShardsBuffer(DiskShardsBuffer):
 
 @gen_test()
 async def test_exceptions(tmp_path):
-    async with BrokenDiskShardsBuffer(directory=tmp_path, read=read_bytes) as mf:
+    async with BrokenDiskShardsBuffer(
+        directory=tmp_path, read=read_bytes, memory_limiter=ResourceLimiter(None)
+    ) as mf:
         await mf.write({"x": [b"0" * 1000], "y": [b"1" * 500]})
 
         while not mf._exception:
@@ -114,8 +123,7 @@ async def test_high_pressure_flush_with_exception(tmp_path):
     payload = {f"shard-{ix}": [f"shard-{ix}".encode() * 100] for ix in range(100)}
 
     async with EventuallyBrokenDiskShardsBuffer(
-        directory=tmp_path,
-        read=read_bytes,
+        directory=tmp_path, read=read_bytes, memory_limiter=ResourceLimiter(None)
     ) as mf:
         tasks = []
         for _ in range(10):

--- a/distributed/shuffle/tests/test_limiter.py
+++ b/distributed/shuffle/tests/test_limiter.py
@@ -60,19 +60,19 @@ async def test_limiter_basic():
 
 @gen_test()
 async def test_unlimited_limiter():
-    res = ResourceLimiter()
+    res = ResourceLimiter(None)
 
-    assert res.free
+    assert res.empty
     assert res.available is None
     assert not res.full
 
     res.increase(3)
-    assert not res.free
+    assert not res.empty
     assert res.available is None
     assert not res.full
 
     res.increase(2**40)
-    assert not res.free
+    assert not res.empty
     assert res.available is None
     assert not res.full
 

--- a/distributed/shuffle/tests/test_limiter.py
+++ b/distributed/shuffle/tests/test_limiter.py
@@ -16,33 +16,33 @@ async def test_limiter_basic():
 
     assert isinstance(repr(res), str)
     res.increase(2)
-    assert res.available() == 3
+    assert res.available == 3
     res.increase(3)
 
-    assert not res.available()
+    assert not res.available
     # This is too much
     res.increase(1)
-    assert not res.available()
+    assert not res.available
     with pytest.raises(asyncio.TimeoutError):
         await wait_for(res.wait_for_available(), 0.1)
 
     await res.decrease(1)
-    assert not res.available()
+    assert not res.available
 
     with pytest.raises(asyncio.TimeoutError):
         await wait_for(res.wait_for_available(), 0.1)
 
     await res.decrease(1)
-    assert res.available() == 1
+    assert res.available == 1
     await res.wait_for_available()
 
     res.increase(1)
-    assert not res.available()
+    assert not res.available
     with pytest.raises(asyncio.TimeoutError):
         await wait_for(res.wait_for_available(), 0.1)
 
     await res.decrease(5)
-    assert res.available() == 5
+    assert res.available == 5
 
     with pytest.raises(RuntimeError, match="more"):
         await res.decrease(1)
@@ -52,10 +52,32 @@ async def test_limiter_basic():
         await wait_for(res.wait_for_available(), 0.1)
 
     await res.decrease(3)
-    assert not res.available()
+    assert not res.available
 
     await res.decrease(5)
-    assert res.available() == 3
+    assert res.available == 3
+
+
+@gen_test()
+async def test_unlimited_limiter():
+    res = ResourceLimiter()
+
+    assert res.free
+    assert res.available is None
+    assert not res.full
+
+    res.increase(3)
+    assert not res.free
+    assert res.available is None
+    assert not res.full
+
+    res.increase(2**40)
+    assert not res.free
+    assert res.available is None
+    assert not res.full
+
+    await res.wait_for_available()
+    assert res.time_blocked_total == 0
 
 
 @gen_test()


### PR DESCRIPTION
Alternative to adding the `NoopLimiter` from #7618.

Also includes some refactoring changes.

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
