### PR TITLE
use numpy._core on numpy>=2.dev0

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 import math
 
 import numpy as np
+from packaging.version import parse as parse_version
 
 from distributed.protocol import pickle
 from distributed.protocol.serialize import dask_deserialize, dask_serialize
 from distributed.utils import log_errors
+
+if parse_version(np.__version__) >= parse_version("2.dev0"):
+    from numpy import _core as np_core
+else:
+    from numpy import core as np_core  # type: ignore[no-redef]
 
 
 def itemsize(dt):
@@ -22,7 +28,7 @@ def itemsize(dt):
 
 @dask_serialize.register(np.ndarray)
 def serialize_numpy_ndarray(x, context=None):
-    if x.dtype.hasobject or (x.dtype.flags & np.core.multiarray.LIST_PICKLE):
+    if x.dtype.hasobject or (x.dtype.flags & np_core.multiarray.LIST_PICKLE):
         header = {"pickle": True}
         frames = [None]
 


### PR DESCRIPTION
No tests added as we don't test on numpy v2 - we rely on the tests in dask/dask

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
