### PR TITLE
Fix `/shuffle` dashboard with in-memory storage

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -4457,11 +4457,10 @@ class Shuffling(DashboardComponent):
                 data["y"].append(i)
                 data["worker"].append(worker)
                 for prefix in ["comm", "disk"]:
+                    memory_limit = d[prefix]["memory_limit"] or 0
                     data[f"{prefix}_total"].append(d[prefix]["total"])
                     data[f"{prefix}_memory"].append(d[prefix]["memory"])
-                    data[f"{prefix}_memory_limit"].append(
-                        d[prefix]["memory_limit"] or 0
-                    )
+                    data[f"{prefix}_memory_limit"].append(memory_limit)
                     data[f"{prefix}_buckets"].append(d[prefix]["buckets"])
                     data[f"{prefix}_avg_duration"].append(
                         d[prefix]["diagnostics"].get("avg_duration", 0)
@@ -4473,7 +4472,7 @@ class Shuffling(DashboardComponent):
                     data[f"{prefix}_written"].append(d[prefix]["written"])
                     if self.scheduler.workers[worker].last_seen < now - 5:
                         data[f"{prefix}_color"].append("gray")
-                    elif d[prefix]["memory"] > d[prefix]["memory_limit"]:
+                    elif d[prefix]["memory"] > memory_limit:
                         data[f"{prefix}_color"].append("red")
                     else:
                         data[f"{prefix}_color"].append("blue")


### PR DESCRIPTION
Fixes
```
bokeh.util.tornado - ERROR - Traceback (most recent call last):
  File "/opt/coiled/env/lib/python3.11/site-packages/tornado/gen.py", line 530, in callback
    result_list.append(f.result())
                       ^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/server/session.py", line 94, in _needs_document_lock_wrapper
    result = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/server/session.py", line 226, in with_document_locked
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/document/callbacks.py", line 485, in wrapper
    return invoke_with_curdoc(doc, invoke)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/document/callbacks.py", line 443, in invoke_with_curdoc
    return f()
           ^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/document/callbacks.py", line 484, in invoke
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/dashboard/components/__init__.py", line 41, in <lambda>
    doc.add_periodic_callback(lambda: update(ref), interval)
                                      ^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/core/property/validation.py", line 95, in func
    return input_function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/dashboard/components/__init__.py", line 49, in update
    comp.update()
  File "/opt/coiled/env/lib/python3.11/site-packages/bokeh/core/property/validation.py", line 95, in func
    return input_function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/dashboard/components/scheduler.py", line 4476, in update
    elif d[prefix]["memory"] > d[prefix]["memory_limit"]:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'int' and 'NoneType'
```

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
