### PR TITLE
[RFC] Do not set parallelism controlling env vars

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -188,10 +188,6 @@ distributed:
     pre-spawn-environ:
       # See https://distributed.dask.org/en/stable/worker-memory.html#automatically-trim-memory
       MALLOC_TRIM_THRESHOLD_: 65536
-      # Numpy configuration
-      OMP_NUM_THREADS: 1
-      MKL_NUM_THREADS: 1
-      OPENBLAS_NUM_THREADS: 1
 
   client:
     heartbeat: 5s  # Interval between client heartbeats


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/5098 we set a malloc trim threshold by default to more aggressively control memory trimming. also related https://github.com/dask/distributed/pull/7177

At the same time, we included these default settings but didn't have incredibly solid arguments for it. It's been a long standing best practice when using dask to disable this nested parallelism.

We haven't received a lot of user feedback about this. However, we had some internal reports of users who were struggling with this because this was quite unexpected behavior for them and non-trivial to debug for the ordinary end user.

In https://github.com/apache/arrow/issues/38389#issuecomment-1774845268 this also suggests to negatively impact read performance of parquet tables.

We should consider removing this again

Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
