### PR TITLE
Reuse identical shuffles in P2P hash join

### DIFF
--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -362,20 +362,12 @@ class HashJoinP2PLayer(Layer):
             return self, culled_deps
 
     def _construct_graph(self) -> dict[tuple | str, tuple]:
-        args_left = (
-            self.left_on,
-            self.npartitions,
-            self.n_partitions_left,
-            self.parts_out,
+        token_left = tokenize(
+            self.name_input_left, self.left_on, self.npartitions, self.parts_out
         )
-        args_right = (
-            self.right_on,
-            self.npartitions,
-            self.n_partitions_right,
-            self.parts_out,
+        token_right = tokenize(
+            self.name_input_right, self.right_on, self.npartitions, self.parts_out
         )
-        token_left = tokenize(self.name_input_left, *args_left)
-        token_right = tokenize(self.name_input_right, *args_right)
         dsk: dict[tuple | str, tuple] = {}
         name_left = "hash-join-transfer-" + token_left
         name_right = "hash-join-transfer-" + token_right

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -362,18 +362,20 @@ class HashJoinP2PLayer(Layer):
             return self, culled_deps
 
     def _construct_graph(self) -> dict[tuple | str, tuple]:
-        args = (
+        args_left = (
             self.left_on,
-            self.how,
             self.npartitions,
             self.n_partitions_left,
+            self.parts_out,
+        )
+        args_right = (
+            self.right_on,
+            self.npartitions,
             self.n_partitions_right,
             self.parts_out,
-            self.suffixes,
-            self.indicator,
         )
-        token_left = tokenize(self.name_input_left, *args)
-        token_right = tokenize(self.name_input_right, *args)
+        token_left = tokenize(self.name_input_left, *args_left)
+        token_right = tokenize(self.name_input_right, *args_right)
         dsk: dict[tuple | str, tuple] = {}
         name_left = "hash-join-transfer-" + token_left
         name_right = "hash-join-transfer-" + token_right

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -363,10 +363,18 @@ class HashJoinP2PLayer(Layer):
 
     def _construct_graph(self) -> dict[tuple | str, tuple]:
         token_left = tokenize(
-            self.name_input_left, self.left_on, self.npartitions, self.parts_out
+            "hash-join",
+            self.name_input_left,
+            self.left_on,
+            self.npartitions,
+            self.parts_out,
         )
         token_right = tokenize(
-            self.name_input_right, self.right_on, self.npartitions, self.parts_out
+            "hash-join",
+            self.name_input_right,
+            self.right_on,
+            self.npartitions,
+            self.parts_out,
         )
         dsk: dict[tuple | str, tuple] = {}
         name_left = "hash-join-transfer-" + token_left

--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -147,7 +147,7 @@ async def test_merge_p2p_shuffle_reused_dataframe_with_same_parameters(c, s, a, 
 
     # This performs one shuffle:
     #   * ddf3 is shuffled on `b`
-    # We can reuse the shuffle from the previous merge.
+    # We can reuse the shuffle of dd2 on `x` from the previous merge.
     out = ddf2.merge(
         ddf3,
         left_on="x",

--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -146,7 +146,7 @@ async def test_merge_p2p_shuffle_reused_dataframe_with_same_parameters(c, s, a, 
     )
 
     # This performs one shuffle:
-    #   * ddf3 is shuffled on ``
+    #   * ddf3 is shuffled on `b`
     # We can reuse the shuffle from the previous merge.
     out = ddf2.merge(
         ddf3,


### PR DESCRIPTION
IFF a shuffle has the exact same input and parameters, P2P hash joins should reuse it.

Identical optimization as in dask-contrib/dask-expr#361

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
