### PR TITLE
Don't share host_array when receiving from network

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -365,9 +365,8 @@ async def read_bytes_rw(stream: IOStream, n: int) -> memoryview:
         range(0, n + OPENSSL_MAX_CHUNKSIZE, OPENSSL_MAX_CHUNKSIZE),
     ):
         chunk = buf[i:j]
-        chunk_nbytes = chunk.nbytes
-        n = await stream.read_into(chunk)  # type: ignore[arg-type]
-        assert n == chunk_nbytes, (n, chunk_nbytes)
+        actual = await stream.read_into(chunk)  # type: ignore[arg-type]
+        assert actual == chunk.nbytes
 
     return buf
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -220,18 +220,16 @@ class TCP(Comm):
         fmt_size = struct.calcsize(fmt)
 
         try:
-            frames_nbytes = await stream.read_bytes(fmt_size)
-            (frames_nbytes,) = struct.unpack(fmt, frames_nbytes)
+            # Don't store multiple numpy or parquet buffers into the same buffer, or
+            # none will be released until all are released.
+            frames_nosplit_nbytes_bin = await stream.read_bytes(fmt_size)
+            (frames_nosplit_nbytes,) = struct.unpack(fmt, frames_nosplit_nbytes_bin)
+            frames_nosplit = await read_bytes_rw(stream, frames_nosplit_nbytes)
+            frames, buffers_nbytes = unpack_frames(frames_nosplit, partial=True)
+            for buffer_nbytes in buffers_nbytes:
+                buffer = await read_bytes_rw(stream, buffer_nbytes)
+                frames.append(buffer)
 
-            frames = host_array(frames_nbytes)
-            for i, j in sliding_window(
-                2,
-                range(0, frames_nbytes + OPENSSL_MAX_CHUNKSIZE, OPENSSL_MAX_CHUNKSIZE),
-            ):
-                chunk = frames[i:j]
-                chunk_nbytes = chunk.nbytes
-                n = await stream.read_into(chunk)
-                assert n == chunk_nbytes, (n, chunk_nbytes)
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
@@ -247,8 +245,6 @@ class TCP(Comm):
             raise
         else:
             try:
-                frames = unpack_frames(frames)
-
                 msg = await from_frames(
                     frames,
                     deserialize=self.deserialize,
@@ -278,23 +274,10 @@ class TCP(Comm):
             },
             frame_split_size=self.max_shard_size,
         )
-        frames_nbytes = [nbytes(f) for f in frames]
-        frames_nbytes_total = sum(frames_nbytes)
-
-        header = pack_frames_prelude(frames)
-        header = struct.pack("Q", nbytes(header) + frames_nbytes_total) + header
-
-        frames = [header, *frames]
-        frames_nbytes = [nbytes(header), *frames_nbytes]
-        frames_nbytes_total += frames_nbytes[0]
-
-        if frames_nbytes_total < 2**17:  # 128kiB
-            # small enough, send in one go
-            frames = [b"".join(frames)]
-            frames_nbytes = [frames_nbytes_total]
+        frames, frames_nbytes, frames_nbytes_total = _add_frames_header(frames)
 
         try:
-            # trick to enque all frames for writing beforehand
+            # trick to enqueue all frames for writing beforehand
             for each_frame_nbytes, each_frame in zip(frames_nbytes, frames):
                 if each_frame_nbytes:
                     # Make sure that `len(data) == data.nbytes`
@@ -369,6 +352,79 @@ class TCP(Comm):
     @property
     def extra_info(self):
         return self._extra
+
+
+async def read_bytes_rw(stream: IOStream, n: int) -> memoryview:
+    """Read n bytes from stream. Unlike stream.read_bytes, allow for
+    very large messages and return a writeable buffer.
+    """
+    buf = host_array(n)
+
+    for i, j in sliding_window(
+        2,
+        range(0, n + OPENSSL_MAX_CHUNKSIZE, OPENSSL_MAX_CHUNKSIZE),
+    ):
+        chunk = buf[i:j]
+        chunk_nbytes = chunk.nbytes
+        n = await stream.read_into(chunk)  # type: ignore[arg-type]
+        assert n == chunk_nbytes, (n, chunk_nbytes)
+
+    return buf
+
+
+def _add_frames_header(
+    frames: list[bytes | memoryview],
+) -> tuple[list[bytes | memoryview], list[int], int]:
+    """ """
+    frames_nbytes = [nbytes(f) for f in frames]
+    frames_nbytes_total = sum(frames_nbytes)
+
+    # Calculate the number of bytes that are inclusive of:
+    # - prelude
+    # - msgpack header
+    # - simple pickle bytes
+    # - compressed buffers
+    # - first uncompressed buffer (possibly sharded), IFF the pickle bytes are
+    #   negligible in size
+    #
+    # All these can be fetched by read() into a single buffer with a single call to
+    # Tornado, because they will be dereferenced soon after they are deserialized.
+    # Read uncompressed numpy/parquet buffers, which will survive indefinitely past
+    # the end of read(), into their own host arrays so that their memory can be
+    # released independently.
+    frames_nbytes_nosplit = 0
+    first_uncompressed_buffer: object = None
+    for frame, nb in zip(frames, frames_nbytes):
+        buffer = frame.obj if isinstance(frame, memoryview) else frame
+        if not isinstance(buffer, bytes):
+            # Uncompressed buffer; it will be referenced by the unpickled object
+            if first_uncompressed_buffer is None:
+                if frames_nbytes_nosplit > max(2048, nb * 0.05):
+                    # Don't extend the lifespan of non-trivial amounts of pickled bytes
+                    # to that of the buffers
+                    break
+                first_uncompressed_buffer = buffer
+            elif first_uncompressed_buffer is not buffer:  # don't split sharded frame
+                # Always store 2+ separate numpy/parquet objects onto separate
+                # buffers
+                break
+
+        frames_nbytes_nosplit += nb
+
+    header = pack_frames_prelude(frames)
+    header = struct.pack("Q", nbytes(header) + frames_nbytes_nosplit) + header
+    header_nbytes = nbytes(header)
+
+    frames = [header, *frames]
+    frames_nbytes = [header_nbytes, *frames_nbytes]
+    frames_nbytes_total += header_nbytes
+
+    if frames_nbytes_total < 2**17:  # 128kiB
+        # small enough, send in one go
+        frames = [b"".join(frames)]
+        frames_nbytes = [frames_nbytes_total]
+
+    return frames, frames_nbytes, frames_nbytes_total
 
 
 class TLS(TCP):

--- a/distributed/protocol/tests/test_utils_test.py
+++ b/distributed/protocol/tests/test_utils_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from distributed.protocol.utils import host_array
+from distributed.protocol.utils_test import get_host_array
+
+
+def test_get_host_array():
+    np = pytest.importorskip("numpy")
+
+    a = np.array([1, 2, 3])
+    assert get_host_array(a) is a
+    assert get_host_array(a[1:]) is a
+    assert get_host_array(a[1:][1:]) is a
+
+    buf = host_array(3)
+    a = np.frombuffer(buf, dtype="u1")
+    assert get_host_array(a) is buf.obj
+    assert get_host_array(a[1:]) is buf.obj
+    a = np.frombuffer(buf[1:], dtype="u1")
+    assert get_host_array(a) is buf.obj
+
+    a = np.frombuffer(bytearray(3), dtype="u1")
+    with pytest.raises(TypeError):
+        get_host_array(a)

--- a/distributed/protocol/utils_test.py
+++ b/distributed/protocol/utils_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy
+
+
+def get_host_array(a: numpy.ndarray) -> numpy.ndarray:
+    """Given a numpy array, find the underlying memory allocated by either
+    distributed.protocol.utils.host_array or internally by numpy
+    """
+    import numpy
+
+    assert isinstance(a, numpy.ndarray)
+    o: object = a
+    while True:
+        if isinstance(o, memoryview):
+            o = o.obj
+        elif isinstance(o, numpy.ndarray):
+            if o.base is not None:
+                o = o.base
+            else:
+                return o
+        else:
+            # distributed.comm.utils.host_array() uses numpy.empty()
+            raise TypeError(
+                "Array uses a buffer allocated neither internally nor by host_array: "
+                f"{type(o)}"
+            )


### PR DESCRIPTION
- This PR is blocked by and incorporates https://github.com/dask/distributed/pull/8312

Resolve issues with memory deallocation:

1. Two or more numpy or pandas objects are packed into the same network message by `WorkerStateMachine._select_for_gather`, `scatter`, or `Client.gather`. After they are received, one of the objects is dereferenced, but its memory won't be released until *all* objects with a buffer in the original message have been dereferenced.

2. An object with both buffers and non-trivial amounts of pure-pickle data - such as a pandas.DataFrame with object columns - is sent over the network. For as long as the object lives, the memory holding the pickled version of the object column won't be released.

3. In #8282, when using a MemoryBuffer the shards that have already been merged into output chunks are not dereferenced until *all* shards on the same worker have been merged. This is because shards belonging to different output chunks were sent over within the same RPC call.

## Notes
- These issues only apply to uncompressed data.
- Use case 2 also afflicts the SpillBuffer. It is out of scope of this PR.