### PR TITLE
Omit unhelpful files from profiling

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import bisect
 import dis
 import linecache
+import os
 import sys
 import threading
 from collections import defaultdict, deque
@@ -125,12 +126,20 @@ def info_frame(frame: FrameType) -> dict[str, Any]:
     }
 
 
+_skip_default = (
+    os.path.join("concurrent", "futures", "_base.py"),
+    "threading.py",
+    os.path.join("distributed", "utils.py"),
+)
+
+
 def process(
     frame: FrameType,
     child: object | None,
     state: dict[str, Any],
     *,
     stop: str | None = None,
+    skip: Collection[str] = _skip_default,
     omit: Collection[str] = (),
     depth: int | None = None,
 ) -> dict[str, Any] | None:
@@ -184,6 +193,7 @@ def process(
         return None
 
     prev = frame.f_back
+
     if (
         depth > 0
         and prev is not None
@@ -193,6 +203,9 @@ def process(
         if new_state is None:
             return None
         state = new_state
+
+    if any(frame.f_code.co_filename.endswith(s) for s in skip):
+        return state
 
     ident = identifier(frame)
 


### PR DESCRIPTION
Systems like concurrent.futures and distributed/utils.py::sync aren't helpful to include in user profiles.  This omits them.

Not a big deal if this doesn't go in, it just felt a little cleaner.