### PR TITLE
Switch to newer GPU CI images

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -3,10 +3,10 @@ PYTHON_VER:
 - "3.10"
 
 CUDA_VER:
-- "11.5"
+- "11.5.2"
 
 LINUX_VER:
-- ubuntu18.04
+- ubuntu20.04
 
 RAPIDS_VER:
 - "23.12"


### PR DESCRIPTION
With rapidsai/dask-build-environment#74 merged in, newer image builds now use an updated `CUDA_VER` and `LINUX_VER`; this PR updates them so we can continue pulling the latest images.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
