### PR TITLE
P2P shuffle: pickle tiny buffers into monolithic bytes objects

### DIFF
--- a/distributed/protocol/tests/test_utils_test.py
+++ b/distributed/protocol/tests/test_utils_test.py
@@ -21,6 +21,8 @@ def test_get_host_array():
     a = np.frombuffer(buf[1:], dtype="u1")
     assert get_host_array(a) is buf.obj
 
-    a = np.frombuffer(bytearray(3), dtype="u1")
-    with pytest.raises(TypeError):
-        get_host_array(a)
+    for buf in (b"123", bytearray(b"123")):
+        a = np.frombuffer(buf, dtype="u1")
+        assert get_host_array(a) is buf
+        a = np.frombuffer(memoryview(buf), dtype="u1")
+        assert get_host_array(a) is buf

--- a/distributed/protocol/utils_test.py
+++ b/distributed/protocol/utils_test.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     import numpy
 
 
-def get_host_array(a: numpy.ndarray) -> numpy.ndarray:
+def get_host_array(a: numpy.ndarray) -> numpy.ndarray | bytes | bytearray:
     """Given a numpy array, find the underlying memory allocated by either
     distributed.protocol.utils.host_array or internally by numpy
     """
@@ -22,9 +22,7 @@ def get_host_array(a: numpy.ndarray) -> numpy.ndarray:
                 o = o.base
             else:
                 return o
-        else:
-            # distributed.comm.utils.host_array() uses numpy.empty()
-            raise TypeError(
-                "Array uses a buffer allocated neither internally nor by host_array: "
-                f"{type(o)}"
-            )
+        elif isinstance(o, (bytes, bytearray)):
+            return o
+        else:  # pragma: nocover
+            raise TypeError(f"Unexpected numpy buffer: {o!r}")

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -273,7 +273,6 @@ def convert_chunk(shards: list[list[tuple[NDIndex, np.ndarray]]]) -> np.ndarray:
     for sublist in shards:
         for index, shard in sublist:
             indexed[index] = shard
-    del shards
 
     subshape = [max(dim) + 1 for dim in zip(*indexed.keys())]
     assert len(indexed) == np.prod(subshape)

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -455,9 +455,6 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         self.partitions_of = dict(partitions_of)
         self.worker_for = pd.Series(worker_for, name="_workers").astype("category")
 
-    async def receive(self, data: list[tuple[int, bytes]]) -> None:
-        await self._receive(data)
-
     async def _receive(self, data: list[tuple[int, bytes]]) -> None:
         self.raise_if_closed()
 

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -299,7 +299,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         self,
         shuffle_id: ShuffleId,
         run_id: int,
-        data: list[tuple[int, Any]],
+        data: list[tuple[int, Any]] | bytes,
     ) -> None:
         """
         Handler: Receive an incoming shard of data from a peer worker.

--- a/distributed/shuffle/tests/test_core.py
+++ b/distributed/shuffle/tests/test_core.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from distributed.shuffle._core import _mean_shard_size
+
+
+def test_mean_shard_size():
+    assert _mean_shard_size([]) == 0
+    assert _mean_shard_size([b""]) == 0
+    assert _mean_shard_size([b"123", b"45678"]) == 4
+    # Don't fully iterate over large collections
+    assert _mean_shard_size([b"12" * n for n in range(1000)]) == 9
+    # Support any Buffer object
+    assert _mean_shard_size([b"12", bytearray(b"1234"), memoryview(b"123456")]) == 4
+    # Recursion into lists or tuples; ignore int
+    assert _mean_shard_size([(1, 2, [3, b"123456"])]) == 6
+    # Don't blindly call sizeof() on unexpected objects
+    with pytest.raises(TypeError):
+        _mean_shard_size([1.2])
+    with pytest.raises(TypeError):
+        _mean_shard_size([{1: 2}])
+
+
+def test_mean_shard_size_numpy():
+    """Test that _mean_shard_size doesn't call len() on multi-byte data types"""
+    np = pytest.importorskip("numpy")
+    assert _mean_shard_size([np.zeros(10, dtype="u1")]) == 10
+    assert _mean_shard_size([np.zeros(10, dtype="u8")]) == 80

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -147,7 +147,12 @@ async def test_lowlevel_rechunk(tmp_path, n_workers, barrier_first_worker, disk)
                 total_bytes_recvd += metrics["disk"]["total"]
                 total_bytes_recvd_shuffle += s.total_recvd
 
-            assert total_bytes_recvd_shuffle == total_bytes_sent
+            # Allow for some uncertainty due to slight differences in measuring
+            assert (
+                total_bytes_sent * 0.95
+                < total_bytes_recvd_shuffle
+                < total_bytes_sent * 1.05
+            )
 
             all_chunks = np.empty(tuple(len(dim) for dim in new), dtype="O")
             for ix, worker in worker_for_mapping.items():

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1816,7 +1816,7 @@ async def test_error_receive(tmp_path, loop_in_thread):
         partitions_for_worker[w].append(part)
 
     class ErrorReceive(DataFrameShuffleRun):
-        async def receive(self, data: list[tuple[int, bytes]]) -> None:
+        async def _receive(self, data: list[tuple[int, bytes]]) -> None:
             raise RuntimeError("Error during receive")
 
     with DataFrameShuffleTestPool() as local_shuffle_pool:


### PR DESCRIPTION
- In dataframe shuffle with shards >= 128 kiB each, avoid one deep copy of the buffers by letting the network stack transfer the shards as individual buffers
- In array shuffle with shards < 128 kiB each, avoid the overhead of sending the  buffers separately through the network stack by pickling everything into a single opaque bytes object ahead of time

- Blocked by and incorporates #8282 
See only the last commit for review.
- Fixes performance regression with small chunks introduced by #8282 
- See performance measures in #8318