### PR TITLE
Invert offloading between event loop and threads for P2P

### DIFF
--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -14,6 +14,8 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, NewType, TypeVar
 
+from tornado.ioloop import IOLoop
+
 import dask.config
 from dask.typing import Key
 from dask.utils import parse_timedelta
@@ -26,6 +28,7 @@ from distributed.shuffle._disk import DiskShardsBuffer
 from distributed.shuffle._exceptions import ShuffleClosedError
 from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._memory import MemoryShardsBuffer
+from distributed.utils import sync
 from distributed.utils_comm import retry
 
 if TYPE_CHECKING:
@@ -58,6 +61,12 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
     _disk_buffer: DiskShardsBuffer | MemoryShardsBuffer
     _comm_buffer: CommShardsBuffer
     diagnostics: dict[str, float]
+    received: set[_T_partition_id]
+    total_recvd: int
+    start_time: float
+    _exception: Exception | None
+    _closed_event: asyncio.Event
+    _loop: IOLoop
 
     def __init__(
         self,
@@ -71,6 +80,7 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
         memory_limiter_disk: ResourceLimiter,
         memory_limiter_comms: ResourceLimiter,
         disk: bool,
+        loop: IOLoop,
     ):
         self.id = id
         self.run_id = run_id
@@ -94,13 +104,14 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
         # TODO: reduce number of connections to number of workers
         # MultiComm.max_connections = min(10, n_workers)
 
-        self.diagnostics: dict[str, float] = defaultdict(float)
+        self.diagnostics = defaultdict(float)
         self.transferred = False
-        self.received: set[_T_partition_id] = set()
+        self.received = set()
         self.total_recvd = 0
         self.start_time = time.time()
-        self._exception: Exception | None = None
+        self._exception = None
         self._closed_event = asyncio.Event()
+        self._loop = loop
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: id={self.id!r}, run_id={self.run_id!r}, local_address={self.local_address!r}, closed={self.closed!r}, transferred={self.transferred!r}>"
@@ -265,18 +276,18 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
     ) -> int:
         """Add an input partition to the shuffle run"""
 
-    async def get_output_partition(
+    def get_output_partition(
         self, partition_id: _T_partition_id, key: str, **kwargs: Any
     ) -> _T_partition_type:
         self.raise_if_closed()
-        await self._ensure_output_worker(partition_id, key)
+        sync(self._loop, self._ensure_output_worker, partition_id, key)
         if not self.transferred:
             raise RuntimeError("`get_output_partition` called before barrier task")
-        await self.flush_receive()
-        return await self._get_output_partition(partition_id, key, **kwargs)
+        sync(self._loop, self.flush_receive)
+        return self._get_output_partition(partition_id, key, **kwargs)
 
     @abc.abstractmethod
-    async def _get_output_partition(
+    def _get_output_partition(
         self, partition_id: _T_partition_id, key: str, **kwargs: Any
     ) -> _T_partition_type:
         """Get an output partition to the shuffle run"""

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import toolz
+from tornado.ioloop import IOLoop
 
 import dask
 from dask.base import tokenize
@@ -431,6 +432,7 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         memory_limiter_disk: ResourceLimiter,
         memory_limiter_comms: ResourceLimiter,
         disk: bool,
+        loop: IOLoop,
     ):
         import pandas as pd
 
@@ -445,6 +447,7 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
             memory_limiter_comms=memory_limiter_comms,
             memory_limiter_disk=memory_limiter_disk,
             disk=disk,
+            loop=loop,
         )
         self.column = column
         self.meta = meta
@@ -504,22 +507,17 @@ class DataFrameShuffleRun(ShuffleRun[int, "pd.DataFrame"]):
         await self._write_to_comm(out)
         return self.run_id
 
-    async def _get_output_partition(
+    def _get_output_partition(
         self,
         partition_id: int,
         key: str,
         **kwargs: Any,
     ) -> pd.DataFrame:
         try:
-
-            def _(partition_id: int, meta: pd.DataFrame) -> pd.DataFrame:
-                data = self._read_from_disk((partition_id,))
-                return convert_shards(data, meta)
-
-            out = await self.offload(_, partition_id, self.meta)
+            data = self._read_from_disk((partition_id,))
+            return convert_shards(data, self.meta)
         except KeyError:
-            out = self.meta.copy()
-        return out
+            return self.meta.copy()
 
     def _get_assigned_worker(self, id: int) -> str:
         return self.worker_for[id]
@@ -564,6 +562,7 @@ class DataFrameShuffleSpec(ShuffleSpec[int]):
             else ResourceLimiter(None),
             memory_limiter_comms=plugin.memory_limiter_comms,
             disk=self.disk,
+            loop=plugin.worker.loop,
         )
 
 

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -428,9 +428,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         """
         shuffle_run = self.get_shuffle_run(shuffle_id, run_id)
         key = thread_state.key
-        return sync(
-            self.worker.loop,
-            shuffle_run.get_output_partition,
+        return shuffle_run.get_output_partition(
             partition_id=partition_id,
             key=key,
             meta=meta,

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -336,9 +336,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         **kwargs: Any,
     ) -> int:
         shuffle_run = self.get_or_create_shuffle(spec)
-        return sync(
-            self.worker.loop,
-            shuffle_run.add_partition,
+        return shuffle_run.add_partition(
             data=data,
             partition_id=partition_id,
             **kwargs,

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -13,6 +13,8 @@ da = pytest.importorskip("dask.array")
 
 from concurrent.futures import ThreadPoolExecutor
 
+from tornado.ioloop import IOLoop
+
 import dask
 from dask.array.core import concatenate3
 from dask.array.rechunk import normalize_chunks, rechunk
@@ -71,6 +73,7 @@ class ArrayRechunkTestPool(AbstractShuffleTestPool):
             memory_limiter_disk=ResourceLimiter(10000000),
             memory_limiter_comms=ResourceLimiter(10000000),
             disk=disk,
+            loop=loop,
         )
         self.shuffles[name] = s
         return s
@@ -83,9 +86,8 @@ from itertools import product
 @pytest.mark.parametrize("barrier_first_worker", [True, False])
 @pytest.mark.parametrize("disk", [True, False])
 @gen_test()
-async def test_lowlevel_rechunk(
-    tmp_path, loop_in_thread, n_workers, barrier_first_worker, disk
-):
+async def test_lowlevel_rechunk(tmp_path, n_workers, barrier_first_worker, disk):
+    loop = IOLoop.current()
     old = ((1, 2, 3, 4), (5,) * 6)
     new = ((5, 5), (12, 18))
 
@@ -115,7 +117,7 @@ async def test_lowlevel_rechunk(
                     old=old,
                     new=new,
                     directory=tmp_path,
-                    loop=loop_in_thread,
+                    loop=loop,
                     disk=disk,
                 )
             )
@@ -148,7 +150,9 @@ async def test_lowlevel_rechunk(
             all_chunks = np.empty(tuple(len(dim) for dim in new), dtype="O")
             for ix, worker in worker_for_mapping.items():
                 s = local_shuffle_pool.shuffles[worker]
-                all_chunks[ix] = await s.get_output_partition(ix, f"key-{ix}")
+                all_chunks[ix] = await asyncio.to_thread(
+                    s.get_output_partition, ix, f"key-{ix}"
+                )
 
         finally:
             await asyncio.gather(*[s.close() for s in shuffles])

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -131,7 +131,7 @@ async def test_lowlevel_rechunk(tmp_path, n_workers, barrier_first_worker, disk)
         try:
             for i, (idx, arr) in enumerate(old_chunks.items()):
                 s = shuffles[i % len(shuffles)]
-                run_ids.append(await s.add_partition(arr, idx))
+                run_ids.append(await asyncio.to_thread(s.add_partition, arr, idx))
 
             await barrier_worker.barrier(run_ids)
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1653,7 +1653,7 @@ async def test_basic_lowlevel_shuffle(
         try:
             for ix, df in enumerate(dfs):
                 s = shuffles[ix % len(shuffles)]
-                run_ids.append(await s.add_partition(df, ix))
+                run_ids.append(await asyncio.to_thread(s.add_partition, df, ix))
 
             await barrier_worker.barrier(run_ids=run_ids)
 
@@ -1733,9 +1733,9 @@ async def test_error_offload(tmp_path, loop_in_thread):
             disk=True,
         )
         try:
-            await sB.add_partition(dfs[0], 0)
+            sB.add_partition(dfs[0], 0)
             with pytest.raises(RuntimeError, match="Error during deserialization"):
-                await sB.add_partition(dfs[1], 1)
+                sB.add_partition(dfs[1], 1)
                 await sB.barrier(run_ids=[sB.run_id, sB.run_id])
         finally:
             await asyncio.gather(*[s.close() for s in [sA, sB]])
@@ -1789,7 +1789,7 @@ async def test_error_send(tmp_path, loop_in_thread):
             disk=True,
         )
         try:
-            await sA.add_partition(dfs[0], 0)
+            sA.add_partition(dfs[0], 0)
             with pytest.raises(RuntimeError, match="Error during send"):
                 await sA.barrier(run_ids=[sA.run_id])
         finally:
@@ -1844,7 +1844,7 @@ async def test_error_receive(tmp_path, loop_in_thread):
             disk=True,
         )
         try:
-            await sB.add_partition(dfs[0], 0)
+            sB.add_partition(dfs[0], 0)
             with pytest.raises(RuntimeError, match="Error during receive"):
                 await sB.barrier(run_ids=[sB.run_id])
         finally:


### PR DESCRIPTION
For methods called from worker threads, P2P used to run async functions on the event loop and offload CPU-intensive tasks onto another thread pool. This PR inverts this such that CPU-intensive tasks run on the worker thread when possible and only run async functions on the event loop when necessary.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
