### PR TITLE
[WIP] [P2P/DataFrame] Faster split by worker 

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -311,10 +311,11 @@ def split_by_worker(
     df = df.astype(meta.dtypes, copy=False)
     tab = to_pyarrow_table_dispatch(df, preserve_index=True)
     np_arr = np.asarray(df[column])
-    out = {
-        worker: tab.take(np.nonzero(np.isin(np_arr, parts))[0])
-        for worker, parts in partitions_of.items()
-    }
+    out = {}
+    for worker, parts in partitions_of.items():
+        split = tab.take(np.nonzero(np.isin(np_arr, parts))[0])
+        if split.num_rows > 0:
+            out[worker] = split
     assert sum(map(len, out.values())) == len(df)
     return out
 

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -308,7 +308,7 @@ def split_by_worker(
     from dask.dataframe.dispatch import to_pyarrow_table_dispatch
 
     df = df.astype(meta.dtypes, copy=False)
-    tab = to_pyarrow_table_dispatch(df)
+    tab = to_pyarrow_table_dispatch(df, preserve_index=True)
     np_arr = np.asarray(df[column])
     out = {
         worker: tab.take(np.nonzero(np.isin(np_arr, parts))[0])

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1112,11 +1112,12 @@ def test_processing_chain(tmp_path):
     df = pd.DataFrame(columns)
     df["_partitions"] = df.col4 % npartitions
     worker_for = {i: random.choice(workers) for i in list(range(npartitions))}
-    worker_for = pd.Series(worker_for, name="_worker").astype("category")
-
+    partitions_of = defaultdict(list)
+    for worker, part in worker_for.items():
+        partitions_of[worker].append(part)
     meta = df.head(0)
-    data = split_by_worker(df, "_partitions", worker_for=worker_for, meta=meta)
-    assert set(data) == set(worker_for.cat.categories)
+    data = split_by_worker(df, "_partitions", partitions_of=partitions_of, meta=meta)
+    assert set(data) == set(partitions_of)
     assert sum(map(len, data.values())) == len(df)
 
     batches = {worker: [serialize_table(t)] for worker, t in data.items()}
@@ -1190,15 +1191,6 @@ async def test_head(c, s, a, b):
     await check_worker_cleanup(b)
     del out
     await check_scheduler_cleanup(s)
-
-
-def test_split_by_worker():
-    workers = ["a", "b", "c"]
-    npartitions = 5
-    df = pd.DataFrame({"x": range(100), "y": range(100)})
-    df["_partitions"] = df.x % npartitions
-    worker_for = {i: random.choice(workers) for i in range(npartitions)}
-    s = pd.Series(worker_for, name="_worker").astype("category")
 
 
 @gen_cluster(client=True, nthreads=[("", 1)] * 2)


### PR DESCRIPTION
This is the primary CPU intensive part of the shuffle transfer. In micro benchmarks this new implementation is twice as fast since it doesn't have to join or sort and I _think_ that pandas is copying the data for the merge. I have to run a couple more tests to be sure this is actually doing something