### PR TITLE
Fix `Cluster`/`SpecCluster` calls to async close methods

### DIFF
--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -546,7 +546,7 @@ class Cluster(SyncMethodMixin):
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.close()
+        await self._close()
 
     @property
     def scheduler_address(self) -> str:

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -475,7 +475,7 @@ class SpecCluster(Cluster):
             assert self.status == Status.running
             return self
         except Exception:
-            await self.close()
+            await self._close()
             raise
 
     def _threads_per_worker(self) -> int:


### PR DESCRIPTION
`Cluster` and `SpecCluster` both have a sync method `close()` and an async method `_close()`. In their async context managers the sync version `close()` is erroneously called and awaited in a few instances, this change is now correcting those.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
