### PR TITLE
Improve type reconciliation for P2P

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,12 +71,12 @@ jobs:
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=13]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=14]
             partition: "ci1"
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=13]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=14]
             partition: "not ci1"
 
           - os: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,12 +71,12 @@ jobs:
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=14]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7]
             partition: "ci1"
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=14]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7]
             partition: "not ci1"
 
           - os: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,12 +71,12 @@ jobs:
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=12]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=13]
             partition: "ci1"
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=12]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=13]
             partition: "not ci1"
 
           - os: ubuntu-latest

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow=13
+  - pyarrow=14
   - pytest
   - pytest-cov
   - pytest-faulthandler

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -25,7 +25,7 @@ dependencies:
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow
+  - pyarrow=13
   - pytest
   - pytest-cov
   - pytest-faulthandler

--- a/distributed/shuffle/_arrow.py
+++ b/distributed/shuffle/_arrow.py
@@ -35,7 +35,7 @@ def check_minimal_arrow_version() -> None:
     ImportError if the installed version is not recent enough.
     """
     # First version to implement type promotion for pa.concat_tables (apache/arrow#36846)
-    minversion = "13.0.0"
+    minversion = "14.0.0"
     try:
         import pyarrow as pa
     except ModuleNotFoundError:

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -306,8 +306,6 @@ def split_by_worker(
 
     from dask.dataframe.dispatch import to_pyarrow_table_dispatch
 
-    df = df.astype(meta.dtypes, copy=False)
-
     # (cudf support) Avoid pd.Series
     constructor = df._constructor_sliced
     assert isinstance(constructor, type)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2287,7 +2287,7 @@ async def test_reconcile_partitions(c, s, a, b):
     ddf = dd.from_map(make_partition, range(50))
     out = ddf.shuffle(on="a", shuffle="p2p", ignore_index=True)
 
-    if parse(pa.__version__) >= "14.0.0":
+    if parse(pa.__version__) >= parse("14.0.0"):
         result, expected = c.compute([ddf, out])
         result = await result
         expected = await expected
@@ -2316,7 +2316,7 @@ async def test_raise_on_incompatible_partitions(c, s, a, b):
 
     ddf = dd.from_map(make_partition, range(50))
     out = ddf.shuffle(on="a", shuffle="p2p", ignore_index=True)
-    if parse(pa.__version) >= parse("14.0.0"):
+    if parse(pa.__version__) >= parse("14.0.0"):
         with raises_with_cause(
             RuntimeError,
             r"shuffling \w* failed",

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1065,14 +1065,10 @@ def test_processing_chain(tmp_path):
         columns.update(
             {
                 # Extension types
-                f"col{next(counter)}": pd.array(
-                    [pd.Period("2022-01-01", freq="D") + i for i in range(100)],
-                    dtype="period[D]",
+                f"col{next(counter)}": pd.period_range(
+                    "2022-01-01", periods=100, freq="D"
                 ),
-                f"col{next(counter)}": pd.array(
-                    [pd.Interval(left=i, right=i + 2) for i in range(100)],
-                    dtype="Interval",
-                ),
+                f"col{next(counter)}": pd.interval_range(start=0, end=100, freq=1),
             }
         )
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -2300,7 +2300,7 @@ async def test_raise_on_incompatible_partitions(c, s, a, b):
     ddf = dd.from_map(make_partition, range(50))
     out = ddf.shuffle(on="a", shuffle="p2p", ignore_index=True)
     with raises_with_cause(
-        RuntimeError, "failed during transfer", pa.ArrowTypeError, "incompatible types"
+        RuntimeError, r"shuffling \w* failed", pa.ArrowTypeError, "incompatible types"
     ):
         await c.compute(out)
 


### PR DESCRIPTION
* Closes #8183 
* Closes #8186 

This PR does not address #8310 and dask/dask#10014. Due to its dependency on Arrow, I doubt that the current P2P shuffle implementation will be able to gracefully handle these cases without a _significant_ increase in complexity. To improve the user experience in those cases, we may want to add a better exception. I'd like to leave that to a future PR.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
