### PR TITLE
Update cuDF test with explicit `dtype=object`

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -181,7 +181,7 @@ async def test_ucx_deserialize(ucx_loop):
     [
         lambda cudf: cudf.Series([1, 2, 3]),
         lambda cudf: cudf.Series([], dtype=object),
-        lambda cudf: cudf.DataFrame([]),
+        lambda cudf: cudf.DataFrame([], dtype=object),
         lambda cudf: cudf.DataFrame([1]).head(0),
         lambda cudf: cudf.DataFrame([1.0]).head(0),
         lambda cudf: cudf.DataFrame({"a": []}),


### PR DESCRIPTION
Recent cuDF changes now require explicit `dtype=object` in UCX test.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
