### PR TITLE
Replace `Client.register_plugin`'s `idempotent` argument with `.idempotent` attribute on plugins

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4834,7 +4834,7 @@ class Client(SyncMethodMixin):
         self,
         plugin: NannyPlugin | SchedulerPlugin | WorkerPlugin,
         name: str | None = None,
-        idempotent: bool = False,
+        idempotent: bool | None = None,
     ):
         """Register a plugin.
 
@@ -4849,11 +4849,14 @@ class Client(SyncMethodMixin):
             plugin instance or automatically generated if not present.
         idempotent :
             Do not re-register if a plugin of the given name already exists.
+            If None, ``plugin.idempotent`` is taken if defined, False otherwise.
         """
         if name is None:
             name = _get_plugin_name(plugin)
         assert name
-
+        if idempotent is None:
+            idempotent = getattr(plugin, "idempotent", False)
+        assert isinstance(idempotent, bool)
         return self._register_plugin(plugin, name, idempotent)
 
     @singledispatchmethod

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4854,7 +4854,14 @@ class Client(SyncMethodMixin):
         if name is None:
             name = _get_plugin_name(plugin)
         assert name
-        if idempotent is None:
+        if idempotent is not None:
+            warnings.warn(
+                "The `idempotent` argument is deprecated and will be removed in a "
+                "future version. Please mark your plugin as idempotent by setting its "
+                "`.idempotent` atrribute to `True`.",
+                FutureWarning,
+            )
+        else:
             idempotent = getattr(plugin, "idempotent", False)
         assert isinstance(idempotent, bool)
         return self._register_plugin(plugin, name, idempotent)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -48,8 +48,8 @@ class SchedulerPlugin:
     3. register the plugin using :meth:`Client.register_plugin<distributed.Client.register_plugin>`.
 
     The ``idempotent`` attribute is used to control whether or not the plugin should
-    skip installation if a scheduler plugin with the same name is already registered.
-    If ``True``, the installation is skipped, otherwise the existing plugin is replaced.
+    be ignored upon registration if a scheduler plugin with the same name already exists.
+    If ``True``, the plugin is ignored, otherwise the existing plugin is replaced.
     Defaults to ``False``.
 
     Examples
@@ -226,8 +226,8 @@ class WorkerPlugin:
     3. register the plugin using :meth:`Client.register_plugin<distributed.Client.register_plugin>`.
 
     The ``idempotent`` attribute is used to control whether or not the plugin should
-    skip installation if a worker plugin with the same name is already registered.
-    If ``True``, the installation is skipped, otherwise the existing plugin is replaced.
+    be ignored upon registration if a worker plugin with the same name already exists.
+    If ``True``, the plugin is ignored, otherwise the existing plugin is replaced.
     Defaults to ``False``.
 
     Examples
@@ -314,8 +314,8 @@ class NannyPlugin:
     3. register the plugin using :meth:`Client.register_plugin<distributed.Client.register_plugin>`.
 
     The ``idempotent`` attribute is used to control whether or not the plugin should
-    skip installation if a nanny plugin with the same name is already registered.
-    If ``True``, the installation is skipped, otherwise the existing plugin is replaced.
+    be ignored upon registration if a nanny plugin with the same name already exists.
+    If ``True``, the plugin is ignored, otherwise the existing plugin is replaced.
     Defaults to ``False``.
 
     The ``restart`` attribute is used to control whether or not a running ``Worker``

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -413,7 +413,10 @@ class PackageInstall(SchedulerPlugin, abc.ABC):
                     self.installer, self.restart_workers, self.name
                 )
                 await scheduler.register_worker_plugin(
-                    comm=None, plugin=dumps(worker_plugin), name=self.name
+                    comm=None,
+                    plugin=dumps(worker_plugin),
+                    name=self.name,
+                    idempotent=True,
                 )
             else:
                 logger.info(

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -32,7 +32,8 @@ logger = logging.getLogger(__name__)
 class SchedulerPlugin:
     """Interface to extend the Scheduler
 
-    A plugin enables custom hooks to run when specific events occur.  The    scheduler will run the methods of this plugin whenever the corresponding
+    A plugin enables custom hooks to run when specific events occur.
+    The scheduler will run the methods of this plugin whenever the corresponding
     method of the scheduler is run.  This runs user code within the scheduler
     thread that can perform arbitrary operations in synchrony with the scheduler
     itself.
@@ -45,6 +46,11 @@ class SchedulerPlugin:
     1. inherit from this class
     2. override some of its methods
     3. register the plugin using :meth:`Client.register_plugin<distributed.Client.register_plugin>`.
+
+    The ``idempotent`` attribute is used to control whether or not the plugin should
+    skip installation if a scheduler plugin with the same name is already registered.
+    If ``True``, the installation is skipped, otherwise the existing plugin is replaced.
+    Defaults to ``False``.
 
     Examples
     --------
@@ -62,6 +68,8 @@ class SchedulerPlugin:
     >>> plugin = Counter()
     >>> scheduler.add_plugin(plugin)  # doctest: +SKIP
     """
+
+    idempotent: bool = False
 
     async def start(self, scheduler: Scheduler) -> None:
         """Run when the scheduler starts up
@@ -217,6 +225,11 @@ class WorkerPlugin:
     2. override some of its methods
     3. register the plugin using :meth:`Client.register_plugin<distributed.Client.register_plugin>`.
 
+    The ``idempotent`` attribute is used to control whether or not the plugin should
+    skip installation if a worker plugin with the same name is already registered.
+    If ``True``, the installation is skipped, otherwise the existing plugin is replaced.
+    Defaults to ``False``.
+
     Examples
     --------
     >>> class ErrorLogger(WorkerPlugin):
@@ -239,6 +252,8 @@ class WorkerPlugin:
     >>> plugin = ErrorLogger(logging)
     >>> client.register_plugin(plugin)  # doctest: +SKIP
     """
+
+    idempotent: bool = False
 
     def setup(self, worker: Worker) -> None | Awaitable[None]:
         """
@@ -298,6 +313,11 @@ class NannyPlugin:
     2. override some of its methods
     3. register the plugin using :meth:`Client.register_plugin<distributed.Client.register_plugin>`.
 
+    The ``idempotent`` attribute is used to control whether or not the plugin should
+    skip installation if a nanny plugin with the same name is already registered.
+    If ``True``, the installation is skipped, otherwise the existing plugin is replaced.
+    Defaults to ``False``.
+
     The ``restart`` attribute is used to control whether or not a running ``Worker``
     needs to be restarted when registering the plugin.
 
@@ -307,7 +327,8 @@ class NannyPlugin:
     SchedulerPlugin
     """
 
-    restart = False
+    idempotent: bool = False
+    restart: bool = False
 
     def setup(self, nanny):
         """

--- a/distributed/diagnostics/tests/test_nanny_plugin.py
+++ b/distributed/diagnostics/tests/test_nanny_plugin.py
@@ -83,29 +83,6 @@ async def test_register_idempotent_plugin(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)], Worker=Nanny)
-async def test_register_plugin_with_idempotent_keyword(c, s, a):
-    class IdempotentPlugin(NannyPlugin):
-        def __init__(self, instance=None):
-            self.name = "idempotentplugin"
-            self.instance = instance
-
-        def setup(self, nanny):
-            if self.instance != "first":
-                raise RuntimeError(
-                    "Only the first plugin should be started when idempotent is set"
-                )
-
-    first = IdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=True)
-    assert "idempotentplugin" in a.plugins
-
-    second = IdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=True)
-    assert "idempotentplugin" in a.plugins
-    assert a.plugins["idempotentplugin"].instance == "first"
-
-
-@gen_cluster(client=True, nthreads=[("", 1)], Worker=Nanny)
 async def test_register_non_idempotent_plugin(c, s, a):
     class NonIdempotentPlugin(NannyPlugin):
         def __init__(self, instance=None):
@@ -134,7 +111,7 @@ async def test_register_non_idempotent_plugin(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)], Worker=Nanny)
-async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a):
+async def test_register_plugin_with_idempotent_keyword_is_deprecated(c, s, a):
     class NonIdempotentPlugin(NannyPlugin):
         def __init__(self, instance=None):
             self.name = "nonidempotentplugin"
@@ -143,11 +120,13 @@ async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a)
             self.idempotent = True
 
     first = NonIdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=False)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(first, idempotent=False)
     assert "nonidempotentplugin" in a.plugins
 
     second = NonIdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=False)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(second, idempotent=False)
     assert "nonidempotentplugin" in a.plugins
     assert a.plugins["nonidempotentplugin"].instance == "second"
 
@@ -165,10 +144,12 @@ async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a)
                 )
 
     first = IdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=True)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(first, idempotent=True)
     assert "idempotentplugin" in a.plugins
 
     second = IdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=True)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(second, idempotent=True)
     assert "idempotentplugin" in a.plugins
     assert a.plugins["idempotentplugin"].instance == "first"

--- a/distributed/diagnostics/tests/test_nanny_plugin.py
+++ b/distributed/diagnostics/tests/test_nanny_plugin.py
@@ -124,7 +124,7 @@ async def test_register_non_idempotent_plugin(c, s, a):
     third = NonIdempotentPlugin(instance="third")
     with pytest.warns(
         FutureWarning,
-        match="`SchedulerPlugin.register_nanny_plugin` now requires `idempotent`",
+        match="`Scheduler.register_nanny_plugin` now requires `idempotent`",
     ):
         await s.register_nanny_plugin(
             comm=None, plugin=dumps(third), name="nonidempotentplugin"

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -426,7 +426,7 @@ async def test_unregister_scheduler_plugin(s):
             self.name = "plugin"
 
     plugin = Plugin()
-    await s.register_scheduler_plugin(plugin=dumps(plugin))
+    await s.register_scheduler_plugin(plugin=dumps(plugin), idempotent=False)
     assert "plugin" in s.plugins
 
     await s.unregister_scheduler_plugin(name="plugin")
@@ -478,7 +478,7 @@ async def test_register_plugin_on_scheduler(c, s, a, b):
         async def start(self, scheduler: Scheduler) -> None:
             scheduler._foo = "bar"  # type: ignore
 
-    await s.register_scheduler_plugin(MyPlugin())
+    await s.register_scheduler_plugin(MyPlugin(), idempotent=False)
 
     assert s._foo == "bar"
 
@@ -499,8 +499,8 @@ async def test_closing_errors_ok(c, s, a, b, capsys):
         async def close(self):
             raise Exception("AFTER_CLOSE")
 
-    await s.register_scheduler_plugin(OK())
-    await s.register_scheduler_plugin(Bad())
+    await s.register_scheduler_plugin(OK(), idempotent=False)
+    await s.register_scheduler_plugin(Bad(), idempotent=False)
 
     with captured_logger("distributed.scheduler") as logger:
         await s.close()
@@ -645,7 +645,7 @@ async def test_scheduler_plugin_in_register_worker_plugin_overrides_nanny(c, s, 
 
 @gen_cluster(client=True, nthreads=[])
 async def test_register_idempotent_plugin(c, s):
-    class IdempotentPlugin(Scheduler):
+    class IdempotentPlugin(SchedulerPlugin):
         def __init__(self, instance=None):
             self.name = "idempotentplugin"
             self.instance = instance

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -641,3 +641,168 @@ async def test_scheduler_plugin_in_register_worker_plugin_overrides_nanny(c, s, 
         await c.register_worker_plugin(DuckPlugin(), nanny=True)
     assert len(s.plugins) == n_existing_plugins + 1
     assert s.foo == 123
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_register_idempotent_plugin(c, s):
+    class IdempotentPlugin(Scheduler):
+        def __init__(self, instance=None):
+            self.name = "idempotentplugin"
+            self.instance = instance
+            self.idempotent = True
+
+        def start(self, scheduler):
+            if self.instance != "first":
+                raise RuntimeError(
+                    "Only the first plugin should be started when idempotent is set"
+                )
+
+    first = IdempotentPlugin(instance="first")
+    await c.register_plugin(first)
+    assert "idempotentplugin" in s.plugins
+
+    second = IdempotentPlugin(instance="second")
+    await c.register_plugin(second)
+    assert "idempotentplugin" in s.plugins
+    assert s.plugins["idempotentplugin"].instance == "first"
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_register_plugin_with_idempotent_keyword(c, s):
+    class IdempotentPlugin(SchedulerPlugin):
+        def __init__(self, instance=None):
+            self.name = "idempotentplugin"
+            self.instance = instance
+
+        def start(self, scheduler):
+            if self.instance != "first":
+                raise RuntimeError(
+                    "Only the first plugin should be started when idempotent is set"
+                )
+
+    first = IdempotentPlugin(instance="first")
+    await c.register_plugin(first, idempotent=True)
+    assert "idempotentplugin" in s.plugins
+
+    second = IdempotentPlugin(instance="second")
+    await c.register_plugin(second, idempotent=True)
+    assert "idempotentplugin" in s.plugins
+    assert s.plugins["idempotentplugin"].instance == "first"
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_register_non_idempotent_plugin(c, s):
+    class NonIdempotentPlugin(SchedulerPlugin):
+        def __init__(self, instance=None):
+            self.name = "nonidempotentplugin"
+            self.instance = instance
+
+    first = NonIdempotentPlugin(instance="first")
+    await c.register_plugin(first)
+    assert "nonidempotentplugin" in s.plugins
+
+    second = NonIdempotentPlugin(instance="second")
+    await c.register_plugin(second)
+    assert "nonidempotentplugin" in s.plugins
+    assert s.plugins["nonidempotentplugin"].instance == "second"
+
+    third = NonIdempotentPlugin(instance="third")
+    with pytest.warns(
+        FutureWarning,
+        match="`SchedulerPlugin.register_scheduler_plugin` now requires `idempotent`",
+    ):
+        await s.register_scheduler_plugin(
+            comm=None, plugin=dumps(third), name="nonidempotentplugin"
+        )
+    assert "nonidempotentplugin" in s.plugins
+    assert s.plugins["nonidempotentplugin"].instance == "third"
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s):
+    class NonIdempotentPlugin(SchedulerPlugin):
+        def __init__(self, instance=None):
+            self.name = "nonidempotentplugin"
+            self.instance = instance
+            # We want to overrule this
+            self.idempotent = True
+
+    first = NonIdempotentPlugin(instance="first")
+    await c.register_plugin(first, idempotent=False)
+    assert "nonidempotentplugin" in s.plugins
+
+    second = NonIdempotentPlugin(instance="second")
+    await c.register_plugin(second, idempotent=False)
+    assert "nonidempotentplugin" in s.plugins
+    assert s.plugins["nonidempotentplugin"].instance == "second"
+
+    class IdempotentPlugin(SchedulerPlugin):
+        def __init__(self, instance=None):
+            self.name = "idempotentplugin"
+            self.instance = instance
+            # We want to overrule this
+            self.idempotent = False
+
+        def start(self, scheduler):
+            if self.instance != "first":
+                raise RuntimeError(
+                    "Only the first plugin should be started when idempotent is set"
+                )
+
+    first = IdempotentPlugin(instance="first")
+    await c.register_plugin(first, idempotent=True)
+    assert "idempotentplugin" in s.plugins
+
+    second = IdempotentPlugin(instance="second")
+    await c.register_plugin(second, idempotent=True)
+    assert "idempotentplugin" in s.plugins
+    assert s.plugins["idempotentplugin"].instance == "first"
+
+
+@gen_cluster(nthreads=[])
+async def test_register_idempotent_plugins_directly(s):
+    class IdempotentPlugin(SchedulerPlugin):
+        def __init__(self, instance=None):
+            self.name = "idempotentplugin"
+            self.instance = instance
+
+        def start(self, scheduler):
+            if self.instance != "first":
+                raise RuntimeError(
+                    "Only the first plugin should be started when idempotent is set"
+                )
+
+    first = IdempotentPlugin(instance="first")
+    await s.register_scheduler_plugin(plugin=dumps(first), idempotent=True)
+    assert "idempotentplugin" in s.plugins
+
+    second = IdempotentPlugin(instance="second")
+    await s.register_scheduler_plugin(plugin=dumps(second), idempotent=True)
+    assert "idempotentplugin" in s.plugins
+    assert s.plugins["idempotentplugin"].instance == "first"
+
+
+@gen_cluster(nthreads=[])
+async def test_register_non_idempotent_plugins_directly(s):
+    class NonIdempotentPlugin(SchedulerPlugin):
+        def __init__(self, instance=None):
+            self.name = "nonidempotentplugin"
+            self.instance = instance
+
+    first = NonIdempotentPlugin(instance="first")
+    await s.register_scheduler_plugin(plugin=dumps(first), idempotent=False)
+    assert "nonidempotentplugin" in s.plugins
+
+    second = NonIdempotentPlugin(instance="second")
+    await s.register_scheduler_plugin(plugin=dumps(second), idempotent=False)
+    assert "nonidempotentplugin" in s.plugins
+    assert s.plugins["nonidempotentplugin"].instance == "second"
+
+    third = NonIdempotentPlugin(instance="third")
+    with pytest.warns(
+        FutureWarning,
+        match="`Scheduler.register_scheduler_plugin` now requires `idempotent`",
+    ):
+        await s.register_scheduler_plugin(plugin=dumps(third))
+    assert "nonidempotentplugin" in s.plugins
+    assert s.plugins["nonidempotentplugin"].instance == "third"

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -668,29 +668,6 @@ async def test_register_idempotent_plugin(c, s):
 
 
 @gen_cluster(client=True, nthreads=[])
-async def test_register_plugin_with_idempotent_keyword(c, s):
-    class IdempotentPlugin(SchedulerPlugin):
-        def __init__(self, instance=None):
-            self.name = "idempotentplugin"
-            self.instance = instance
-
-        def start(self, scheduler):
-            if self.instance != "first":
-                raise RuntimeError(
-                    "Only the first plugin should be started when idempotent is set"
-                )
-
-    first = IdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=True)
-    assert "idempotentplugin" in s.plugins
-
-    second = IdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=True)
-    assert "idempotentplugin" in s.plugins
-    assert s.plugins["idempotentplugin"].instance == "first"
-
-
-@gen_cluster(client=True, nthreads=[])
 async def test_register_non_idempotent_plugin(c, s):
     class NonIdempotentPlugin(SchedulerPlugin):
         def __init__(self, instance=None):
@@ -719,7 +696,7 @@ async def test_register_non_idempotent_plugin(c, s):
 
 
 @gen_cluster(client=True, nthreads=[])
-async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s):
+async def test_register_plugin_with_idempotent_keyword_is_deprecated(c, s):
     class NonIdempotentPlugin(SchedulerPlugin):
         def __init__(self, instance=None):
             self.name = "nonidempotentplugin"
@@ -728,11 +705,13 @@ async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s):
             self.idempotent = True
 
     first = NonIdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=False)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(first, idempotent=False)
     assert "nonidempotentplugin" in s.plugins
 
     second = NonIdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=False)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(second, idempotent=False)
     assert "nonidempotentplugin" in s.plugins
     assert s.plugins["nonidempotentplugin"].instance == "second"
 
@@ -750,11 +729,13 @@ async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s):
                 )
 
     first = IdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=True)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(first, idempotent=True)
     assert "idempotentplugin" in s.plugins
 
     second = IdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=True)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(second, idempotent=True)
     assert "idempotentplugin" in s.plugins
     assert s.plugins["idempotentplugin"].instance == "first"
 

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -709,10 +709,10 @@ async def test_register_non_idempotent_plugin(c, s):
     third = NonIdempotentPlugin(instance="third")
     with pytest.warns(
         FutureWarning,
-        match="`SchedulerPlugin.register_scheduler_plugin` now requires `idempotent`",
+        match="`Scheduler.register_scheduler_plugin` now requires `idempotent`",
     ):
         await s.register_scheduler_plugin(
-            comm=None, plugin=dumps(third), name="nonidempotentplugin"
+            plugin=dumps(third), name="nonidempotentplugin"
         )
     assert "nonidempotentplugin" in s.plugins
     assert s.plugins["nonidempotentplugin"].instance == "third"

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -388,7 +388,7 @@ async def test_register_non_idempotent_plugin(c, s, a):
     third = NonIdempotentPlugin(instance="third")
     with pytest.warns(
         FutureWarning,
-        match="`SchedulerPlugin.register_worker_plugin` now requires `idempotent`",
+        match="`Scheduler.register_worker_plugin` now requires `idempotent`",
     ):
         await s.register_worker_plugin(
             comm=None, plugin=dumps(third), name="nonidempotentplugin"

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -6,6 +6,7 @@ import warnings
 import pytest
 
 from distributed import Worker, WorkerPlugin
+from distributed.protocol.pickle import dumps
 from distributed.utils_test import async_poll_for, gen_cluster, inc
 
 
@@ -322,7 +323,31 @@ async def test_duck_typed_register_worker_plugin_is_deprecated(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
-async def test_register_idempotent_plugins(c, s, a):
+async def test_register_idempotent_plugin(c, s, a):
+    class IdempotentPlugin(WorkerPlugin):
+        def __init__(self, instance=None):
+            self.name = "idempotentplugin"
+            self.instance = instance
+            self.idempotent = True
+
+        def setup(self, worker):
+            if self.instance != "first":
+                raise RuntimeError(
+                    "Only the first plugin should be started when idempotent is set"
+                )
+
+    first = IdempotentPlugin(instance="first")
+    await c.register_plugin(first)
+    assert "idempotentplugin" in a.plugins
+
+    second = IdempotentPlugin(instance="second")
+    await c.register_plugin(second)
+    assert "idempotentplugin" in a.plugins
+    assert a.plugins["idempotentplugin"].instance == "first"
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_register_plugin_with_idempotent_keyword(c, s, a):
     class IdempotentPlugin(WorkerPlugin):
         def __init__(self, instance=None):
             self.name = "idempotentplugin"
@@ -345,11 +370,41 @@ async def test_register_idempotent_plugins(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
-async def test_register_non_idempotent_plugins(c, s, a):
+async def test_register_non_idempotent_plugin(c, s, a):
     class NonIdempotentPlugin(WorkerPlugin):
         def __init__(self, instance=None):
             self.name = "nonidempotentplugin"
             self.instance = instance
+
+    first = NonIdempotentPlugin(instance="first")
+    await c.register_plugin(first)
+    assert "nonidempotentplugin" in a.plugins
+
+    second = NonIdempotentPlugin(instance="second")
+    await c.register_plugin(second)
+    assert "nonidempotentplugin" in a.plugins
+    assert a.plugins["nonidempotentplugin"].instance == "second"
+
+    third = NonIdempotentPlugin(instance="third")
+    with pytest.warns(
+        FutureWarning,
+        match="`SchedulerPlugin.register_worker_plugin` now requires `idempotent`",
+    ):
+        await s.register_worker_plugin(
+            comm=None, plugin=dumps(third), name="nonidempotentplugin"
+        )
+    assert "nonidempotentplugin" in a.plugins
+    assert a.plugins["nonidempotentplugin"].instance == "third"
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a):
+    class NonIdempotentPlugin(WorkerPlugin):
+        def __init__(self, instance=None):
+            self.name = "nonidempotentplugin"
+            self.instance = instance
+            # We want to overrule this
+            self.idempotent = True
 
     first = NonIdempotentPlugin(instance="first")
     await c.register_plugin(first, idempotent=False)
@@ -359,3 +414,25 @@ async def test_register_non_idempotent_plugins(c, s, a):
     await c.register_plugin(second, idempotent=False)
     assert "nonidempotentplugin" in a.plugins
     assert a.plugins["nonidempotentplugin"].instance == "second"
+
+    class IdempotentPlugin(WorkerPlugin):
+        def __init__(self, instance=None):
+            self.name = "idempotentplugin"
+            self.instance = instance
+            # We want to overrule this
+            self.idempotent = False
+
+        def setup(self, worker):
+            if self.instance != "first":
+                raise RuntimeError(
+                    "Only the first plugin should be started when idempotent is set"
+                )
+
+    first = IdempotentPlugin(instance="first")
+    await c.register_plugin(first, idempotent=True)
+    assert "idempotentplugin" in a.plugins
+
+    second = IdempotentPlugin(instance="second")
+    await c.register_plugin(second, idempotent=True)
+    assert "idempotentplugin" in a.plugins
+    assert a.plugins["idempotentplugin"].instance == "first"

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -347,29 +347,6 @@ async def test_register_idempotent_plugin(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
-async def test_register_plugin_with_idempotent_keyword(c, s, a):
-    class IdempotentPlugin(WorkerPlugin):
-        def __init__(self, instance=None):
-            self.name = "idempotentplugin"
-            self.instance = instance
-
-        def setup(self, worker):
-            if self.instance != "first":
-                raise RuntimeError(
-                    "Only the first plugin should be started when idempotent is set"
-                )
-
-    first = IdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=True)
-    assert "idempotentplugin" in a.plugins
-
-    second = IdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=True)
-    assert "idempotentplugin" in a.plugins
-    assert a.plugins["idempotentplugin"].instance == "first"
-
-
-@gen_cluster(client=True, nthreads=[("", 1)])
 async def test_register_non_idempotent_plugin(c, s, a):
     class NonIdempotentPlugin(WorkerPlugin):
         def __init__(self, instance=None):
@@ -398,7 +375,7 @@ async def test_register_non_idempotent_plugin(c, s, a):
 
 
 @gen_cluster(client=True, nthreads=[("", 1)])
-async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a):
+async def test_register_plugin_with_idempotent_keyword_is_deprecated(c, s, a):
     class NonIdempotentPlugin(WorkerPlugin):
         def __init__(self, instance=None):
             self.name = "nonidempotentplugin"
@@ -407,11 +384,13 @@ async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a)
             self.idempotent = True
 
     first = NonIdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=False)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(first, idempotent=False)
     assert "nonidempotentplugin" in a.plugins
 
     second = NonIdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=False)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(second, idempotent=False)
     assert "nonidempotentplugin" in a.plugins
     assert a.plugins["nonidempotentplugin"].instance == "second"
 
@@ -429,10 +408,12 @@ async def test_register_plugin_with_idempotent_keyword_overrules_plugin(c, s, a)
                 )
 
     first = IdempotentPlugin(instance="first")
-    await c.register_plugin(first, idempotent=True)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(first, idempotent=True)
     assert "idempotentplugin" in a.plugins
 
     second = IdempotentPlugin(instance="second")
-    await c.register_plugin(second, idempotent=True)
+    with pytest.warns(FutureWarning, match="`idempotent` argument is deprecated"):
+        await c.register_plugin(second, idempotent=True)
     assert "idempotentplugin" in a.plugins
     assert a.plugins["idempotentplugin"].instance == "first"

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5836,7 +5836,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
         if idempotent is None:
             warnings.warn(
-                "The signature of `SchedulerPlugin.register_scheduler_plugin` now requires "
+                "The signature of `Scheduler.register_scheduler_plugin` now requires "
                 "`idempotent`. Not including `idempotent` in the signature will no longer "
                 "be supported in future versions.",
                 FutureWarning,
@@ -7553,7 +7553,7 @@ class Scheduler(SchedulerState, ServerNode):
         logger.info("Registering Worker plugin %s", name)
         if idempotent is None:
             warnings.warn(
-                "The signature of `SchedulerPlugin.register_worker_plugin` now requires "
+                "The signature of `Scheduler.register_worker_plugin` now requires "
                 "`idempotent`. Not including `idempotent` in the signature will no longer "
                 "be supported in future versions.",
                 FutureWarning,
@@ -7589,7 +7589,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         if idempotent is None:
             warnings.warn(
-                "The signature of `SchedulerPlugin.register_nanny_plugin` now requires "
+                "The signature of `Scheduler.register_nanny_plugin` now requires "
                 "`idempotent`. Not including `idempotent` in the signature will no longer "
                 "be supported in future versions.",
                 FutureWarning,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5824,7 +5824,7 @@ class Scheduler(SchedulerState, ServerNode):
         self,
         plugin: bytes | SchedulerPlugin,
         name: str | None = None,
-        idempotent: bool = False,
+        idempotent: bool | None = None,
     ) -> None:
         """Register a plugin on the scheduler."""
         if not dask.config.get("distributed.scheduler.pickle"):
@@ -5834,6 +5834,14 @@ class Scheduler(SchedulerState, ServerNode):
                 "arbitrary bytestrings using pickle via the "
                 "'distributed.scheduler.pickle' configuration setting."
             )
+        if idempotent is None:
+            warnings.warn(
+                "The signature of `SchedulerPlugin.register_scheduler_plugin` now requires "
+                "`idempotent`. Not including `idempotent` in the signature will no longer "
+                "be supported in future versions.",
+                FutureWarning,
+            )
+            idempotent = False
         if not isinstance(plugin, SchedulerPlugin):
             plugin = loads(plugin)
             assert isinstance(plugin, SchedulerPlugin)
@@ -7539,10 +7547,18 @@ class Scheduler(SchedulerState, ServerNode):
         return {"metadata": plugin.metadata, "state": plugin.state}
 
     async def register_worker_plugin(
-        self, comm: None, plugin: bytes, name: str, idempotent: bool = False
+        self, comm: None, plugin: bytes, name: str, idempotent: bool | None = None
     ) -> dict[str, OKMessage]:
         """Registers a worker plugin on all running and future workers"""
         logger.info("Registering Worker plugin %s", name)
+        if idempotent is None:
+            warnings.warn(
+                "The signature of `SchedulerPlugin.register_worker_plugin` now requires "
+                "`idempotent`. Not including `idempotent` in the signature will no longer "
+                "be supported in future versions.",
+                FutureWarning,
+            )
+            idempotent = False
         if name in self.worker_plugins and idempotent:
             return {}
 
@@ -7566,10 +7582,20 @@ class Scheduler(SchedulerState, ServerNode):
         return responses
 
     async def register_nanny_plugin(
-        self, comm: None, plugin: bytes, name: str, idempotent: bool = False
+        self, comm: None, plugin: bytes, name: str, idempotent: bool | None = None
     ) -> dict[str, OKMessage]:
         """Registers a nanny plugin on all running and future nannies"""
         logger.info("Registering Nanny plugin %s", name)
+
+        if idempotent is None:
+            warnings.warn(
+                "The signature of `SchedulerPlugin.register_nanny_plugin` now requires "
+                "`idempotent`. Not including `idempotent` in the signature will no longer "
+                "be supported in future versions.",
+                FutureWarning,
+            )
+            idempotent = False
+
         if name in self.nanny_plugins and idempotent:
             return {}
 

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -69,7 +69,7 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
     async def start(self, scheduler: Scheduler) -> None:
         worker_plugin = ShuffleWorkerPlugin()
         await self.scheduler.register_worker_plugin(
-            None, dumps(worker_plugin), name="shuffle"
+            None, dumps(worker_plugin), name="shuffle", idempotent=False
         )
 
     def shuffle_ids(self) -> set[ShuffleId]:

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4176,46 +4176,6 @@ async def test_dump_cluster_state(s, *workers, format):
         fs.rm("state-dumps", recursive=True)
 
 
-@gen_cluster(nthreads=[])
-async def test_idempotent_plugins(s):
-    class IdempotentPlugin(SchedulerPlugin):
-        def __init__(self, instance=None):
-            self.name = "idempotentplugin"
-            self.instance = instance
-
-        def start(self, scheduler):
-            if self.instance != "first":
-                raise RuntimeError(
-                    "Only the first plugin should be started when idempotent is set"
-                )
-
-    first = IdempotentPlugin(instance="first")
-    await s.register_scheduler_plugin(plugin=dumps(first), idempotent=True)
-    assert "idempotentplugin" in s.plugins
-
-    second = IdempotentPlugin(instance="second")
-    await s.register_scheduler_plugin(plugin=dumps(second), idempotent=True)
-    assert "idempotentplugin" in s.plugins
-    assert s.plugins["idempotentplugin"].instance == "first"
-
-
-@gen_cluster(nthreads=[])
-async def test_non_idempotent_plugins(s):
-    class NonIdempotentPlugin(SchedulerPlugin):
-        def __init__(self, instance=None):
-            self.name = "nonidempotentplugin"
-            self.instance = instance
-
-    first = NonIdempotentPlugin(instance="first")
-    await s.register_scheduler_plugin(plugin=dumps(first), idempotent=False)
-    assert "nonidempotentplugin" in s.plugins
-
-    second = NonIdempotentPlugin(instance="second")
-    await s.register_scheduler_plugin(plugin=dumps(second), idempotent=False)
-    assert "nonidempotentplugin" in s.plugins
-    assert s.plugins["nonidempotentplugin"].instance == "second"
-
-
 @gen_cluster(nthreads=[("", 1)])
 async def test_repr(s, a):
     async with Worker(s.address, nthreads=2) as b:  # name = address by default


### PR DESCRIPTION
This PR allows us to define plugin instances/classes as idempotent by setting `plugin.attribute` to `True`. This way, users can register idempotent plugins without having to specify the `idempotent` keyword` or even knowing that the plugin is `idempotent`.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
