### PR TITLE
Install `pyarrow-hotfix` on `mindeps-pandas` CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,12 +71,12 @@ jobs:
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7, pyarrow-hotfix]
             partition: "ci1"
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7]
+            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7, pyarrow-hotfix]
             partition: "not ci1"
 
           - os: ubuntu-latest


### PR DESCRIPTION
Fixes CI errors for `mindeps-pandas` (e.g., https://github.com/dask/distributed/actions/runs/6866819869/job/18673886868#step:19:182)

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
