### PR TITLE
Fix test_statistical_profiling_cylce

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1234,7 +1234,7 @@ async def test_statistical_profiling_2(c, s, a, b):
     client=True,
     config={
         "distributed.worker.profile.enabled": True,
-        "distributed.worker.profile.cycle": "100ms",
+        "distributed.worker.profile.cycle": "10ms",
     },
 )
 async def test_statistical_profiling_cycle(c, s, a, b):


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8348

I could reproduce this locally very easily and this fixes the issue.

If the event loop is too slow for whatever reason, the heuristics don't add up. if we're sampling a little more aggressively, this works out well again.


