### PR TITLE
Support environment variables in `PipInstall` plugin

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -698,6 +698,9 @@ class _PipInstaller:
             self.INSTALLER,
             self.packages,
         )
+        # Use a requirements file under the hood to support
+        # environment variables
+        # See https://pip.pypa.io/en/stable/reference/requirements-file-format/#using-environment-variables
         with tempfile.NamedTemporaryFile(mode="w+") as f:
             f.writelines(self.packages)
             f.flush()

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -667,13 +667,12 @@ class PipInstall(InstallPlugin):
     --------
     >>> from dask.distributed import PipInstall
     >>> plugin = PipInstall(packages=["scikit-learn"], pip_options=["--upgrade"])
-
     >>> client.register_plugin(plugin)
 
     Install package from a private GitHub repository
+
     >>> from dask.distributed import PipInstall
     >>> plugin = PipInstall(packages=["private_package@git+https://${GITHUB_TOKEN}@github.com/dask/private_package.git])
-
     >>> client.register_plugin(plugin)
 
     See Also

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -660,8 +660,8 @@ class PipInstall(InstallPlugin):
     pip_options
         Additional options to pass to pip
     restart_workers
-        Whether or not to restart the worker after installing the packages
-        Only functions if the worker has an attached nanny process
+        Whether or not to restart the worker after installing the packages;
+        only functions if the worker has an attached nanny process.
 
     Examples
     --------
@@ -669,10 +669,10 @@ class PipInstall(InstallPlugin):
     >>> plugin = PipInstall(packages=["scikit-learn"], pip_options=["--upgrade"])
     >>> client.register_plugin(plugin)
 
-    Install package from a private GitHub repository
+    Install package from a private repository using a ``TOKEN`` environment variable.
 
     >>> from dask.distributed import PipInstall
-    >>> plugin = PipInstall(packages=["private_package@git+https://${GITHUB_TOKEN}@github.com/dask/private_package.git])
+    >>> plugin = PipInstall(packages=["private_package@git+https://${TOKEN}@github.com/dask/private_package.git])
     >>> client.register_plugin(plugin)
 
     See Also

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -652,7 +652,11 @@ class PipInstall(InstallPlugin):
     Parameters
     ----------
     packages
-        A list of packages (with optional versions) to install using pip
+        A list of packages to install using pip.
+        Packages should follow the structure defined for
+        `requirement files <https://pip.pypa.io/en/stable/reference/requirements-file-format/#structure>`_.
+        Packages also may include
+        `environment variables <https://pip.pypa.io/en/stable/reference/requirements-file-format/#using-environment-variables>`_.
     pip_options
         Additional options to pass to pip
     restart_workers
@@ -666,9 +670,15 @@ class PipInstall(InstallPlugin):
 
     >>> client.register_plugin(plugin)
 
+    Install package from a private GitHub repository
+    >>> from dask.distributed import PipInstall
+    >>> plugin = PipInstall(packages=["private_package@git+https://${GITHUB_TOKEN}@github.com/dask/private_package.git])
+
+    >>> client.register_plugin(plugin)
+
     See Also
     --------
-    PackageInstall
+    InstallPlugin
     CondaInstall
     """
 

--- a/distributed/diagnostics/tests/test_install_plugin.py
+++ b/distributed/diagnostics/tests/test_install_plugin.py
@@ -28,8 +28,10 @@ async def test_pip_install(c, s, a):
                 PipInstall(packages=["requests"], pip_options=["--upgrade"])
             )
             assert Popen.call_count > 0
-            python, *args, requirements_file = Popen.call_args[0][0]
+            python, *args, file = Popen.call_args[0][0]
             assert "python" in python
+            # Assert that we install using a requirements file to support
+            # environment variables
             assert args == ["-m", "pip", "install", "--upgrade", "-r"]
             logs = logger.getvalue()
             assert "pip installing" in logs

--- a/distributed/diagnostics/tests/test_install_plugin.py
+++ b/distributed/diagnostics/tests/test_install_plugin.py
@@ -28,9 +28,9 @@ async def test_pip_install(c, s, a):
                 PipInstall(packages=["requests"], pip_options=["--upgrade"])
             )
             assert Popen.call_count > 0
-            args = Popen.call_args[0][0]
-            assert "python" in args[0]
-            assert args[1:] == ["-m", "pip", "install", "--upgrade", "requests"]
+            python, *args, requirements_file = Popen.call_args[0][0]
+            assert "python" in python
+            assert args == ["-m", "pip", "install", "--upgrade", "-r"]
             logs = logger.getvalue()
             assert "pip installing" in logs
             assert "failed" not in logs

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -88,6 +88,7 @@ Built-In Scheduler Plugins
 
 .. autoclass:: distributed.diagnostics.plugin.PipInstall
 .. autoclass:: distributed.diagnostics.plugin.CondaInstall
+.. autoclass:: distributed.diagnostics.plugin.InstallPlugin
 .. autoclass:: distributed.diagnostics.plugin.SchedulerUploadFile
 
 Worker Plugins

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -83,6 +83,13 @@ the scheduler as so:
        plugin = MyPlugin(scheduler)
        scheduler.add_plugin(plugin)
 
+Built-In Scheduler Plugins
+--------------------------
+
+.. autoclass:: distributed.diagnostics.plugin.PipInstall
+.. autoclass:: distributed.diagnostics.plugin.CondaInstall
+.. autoclass:: distributed.diagnostics.plugin.SchedulerUploadFile
+
 Worker Plugins
 ==============
 
@@ -107,8 +114,6 @@ Watch the video below for an example using a ``WorkerPlugin`` to add a
 Built-In Worker Plugins
 -----------------------
 
-.. autoclass:: distributed.diagnostics.plugin.PipInstall
-.. autoclass:: distributed.diagnostics.plugin.CondaInstall
 .. autoclass:: distributed.diagnostics.plugin.UploadFile
 
 


### PR DESCRIPTION
Adds support for environment variables to the `PipInstall` plugin by using a requirement file under the hood (https://pip.pypa.io/en/stable/reference/requirements-file-format/#using-environment-variables). We should document this plugin better, but I would like to leave this to a dedicated PR.

Blocked by (and includes) #8343 

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
