### PR TITLE
Bump GPU CI to CUDA 11.8

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -3,7 +3,7 @@ PYTHON_VER:
 - "3.10"
 
 CUDA_VER:
-- "11.5.2"
+- "11.8.0"
 
 LINUX_VER:
 - ubuntu20.04

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -30,29 +30,29 @@ export DASK_DISTRIBUTED__ADMIN__SYSTEM_MONITOR__GIL__ENABLED=False
 # SETUP - Check environment
 ################################################################################
 
-gpuci_logger "Check environment variables"
+rapids-logger "Check environment variables"
 env
 
-gpuci_logger "Check GPU usage"
+rapids-logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "Activate conda env"
+rapids-logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate dask
 
-gpuci_logger "Install distributed"
+rapids-logger "Install distributed"
 python -m pip install -e .
 
-gpuci_logger "Install dask"
+rapids-logger "Install dask"
 python -m pip install git+https://github.com/dask/dask
 
-gpuci_logger "Check Python versions"
+rapids-logger "Check Python versions"
 python --version
 
-gpuci_logger "Check conda environment"
+rapids-logger "Check conda environment"
 conda info
 conda config --show-sources
 conda list --show-channel-urls
 
-gpuci_logger "Python py.test for distributed"
+rapids-logger "Python py.test for distributed"
 py.test distributed -v -m gpu --runslow --junitxml="$WORKSPACE/junit-distributed.xml"


### PR DESCRIPTION
This addresses the planned dropping of the CUDA 11.5 `miniforge-cuda` images we currently depend on in rapidsai/miniforge-cuda#55

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
