### PR TITLE
[POC][WIP] Delayed partition loading in p2p shuffle

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -91,7 +91,7 @@ def shuffle_unpack(
         )
 
 
-def shuffle_unpack_unloaded(
+def delayed_shuffle_unpack(
     id: ShuffleId, output_partition: int, barrier_run_id: int
 ) -> pd.DataFrame:
     with handle_unpack_errors(id):
@@ -305,7 +305,7 @@ class P2PShuffleLayer(Layer):
         name = self.name
         for part_out in self.parts_out:
             dsk[(name, part_out)] = (
-                shuffle_unpack_unloaded,
+                delayed_shuffle_unpack,
                 token,
                 part_out,
                 _barrier_key,

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -417,6 +417,7 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         run_id: int,
         partition_id: int | NDIndex,
         meta: pd.DataFrame | None = None,
+        load: bool = True,
     ) -> Any:
         """
         Task: Retrieve a shuffled output partition from the ShuffleWorkerPlugin.
@@ -425,7 +426,13 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         """
         shuffle_run = self.get_shuffle_run(shuffle_id, run_id)
         key = thread_state.key
-        return shuffle_run.get_output_partition(
+        if load:
+            return shuffle_run.get_output_partition(
+                partition_id=partition_id,
+                key=key,
+                meta=meta,
+            )
+        return shuffle_run.get_unloaded_output_partition(
             partition_id=partition_id,
             key=key,
             meta=meta,


### PR DESCRIPTION
This is a rough POC for a slight modification to the current "p2p" shuffle algorithm. The general idea is to avoid loading shuffled on-disk partitions into pandas/cudf DataFrame objects until those objects are actually **needed** by down-stream tasks. The primary goal of this modification is to further enhance the (memory) stability of the p2p shuffle for the cudf backend. However, I would also expect the change to improve stability for the pandas backend as well.

### Motivation

<img width="1110" alt="Screen Shot 2023-12-05 at 8 18 58 AM" src="https://github.com/dask/distributed/assets/20461013/28816e4b-07dd-4fae-be30-f55215b07650">

### Details

- In order to delay the loading of output partitions, we wrap the usual output of `shuffle_unpack` in an `UnloadedPartition` wrapper class.
- In order to ensure that the partition is actually loaded and converted from `pa.Table` to `pd/cudf.DataFrame` when a down-stream task **needs** the data, we add a `Blockwise` layer to do exactly this.
- Since an `UnloadedPartition` object may be moved to a different worker after the shuffle, we register custom serialization logic for `UnloadedPartition` to load the data before it is moved.
  - Note that we can still delay the conversion from `pa.Table` to `pd/cudf.DataFrame` until the data is actually used, but  I am leaving this change to follow-up work to keep this PR as simple as possible.
  
### TODO

- **Benchmarking**: Test this on problematic shuffle + merge NeMo Data Curator workflows that were previously failing with p2p. Also need to perform A/B testing to measure general impact.
- **Cleanup**:   If this mechanism proves valuable, we should certainly clean up this POC before anything is merged.