### PR TITLE
Remove GPU executor

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -30,7 +30,6 @@ from dask import delayed
 from dask.system import CPU_COUNT
 from dask.utils import tmpfile
 
-import distributed
 from distributed import (
     Client,
     Event,
@@ -46,7 +45,6 @@ from distributed.comm.registry import backends
 from distributed.comm.utils import OFFLOAD_THRESHOLD
 from distributed.compatibility import LINUX, WINDOWS
 from distributed.core import CommClosedError, Status, rpc
-from distributed.diagnostics import nvml
 from distributed.diagnostics.plugin import ForwardOutput
 from distributed.metrics import time
 from distributed.protocol import pickle
@@ -2265,17 +2263,6 @@ async def test_process_executor_raise_exception(c, s, a, b):
 
         with pytest.raises(RuntimeError, match="foo"):
             await future
-
-
-@pytest.mark.gpu
-@gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
-async def test_gpu_executor(c, s, w):
-    if nvml.device_get_count() > 0:
-        e = w.executors["gpu"]
-        assert isinstance(e, distributed.threadpoolexecutor.ThreadPoolExecutor)
-        assert e._max_workers == 1
-    else:
-        assert "gpu" not in w.executors
 
 
 async def assert_task_states_on_worker(

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -636,10 +636,6 @@ class Worker(BaseWorker, ServerNode):
             "offload": utils._offload_executor,
             "actor": ThreadPoolExecutor(1, thread_name_prefix="Dask-Actor-Threads"),
         }
-        if nvml.device_get_count() > 0:
-            self.executors["gpu"] = ThreadPoolExecutor(
-                1, thread_name_prefix="Dask-GPU-Threads"
-            )
 
         # Find the default executor
         if executor == "offload":


### PR DESCRIPTION
Closes #8338 by removing the GPU executor. I am not aware of any usage of the GPU executor, so I'd recommend ripping it out instead of worrying about maintenance. I'm happy to reconsider if anybody brings an example of the executor being used to my attention.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
