### PR TITLE
Avoid `RecursionError` when failing to pickle key in `SpillBuffer` and using `tblib=3`

### DIFF
--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -136,7 +136,7 @@ class SpillBuffer(zict.Buffer[Key, object]):
             logger.error("Spill to disk failed; keeping data in memory", exc_info=True)
             raise HandledError()
         except PickleError as e:
-            key_e, orig_e = e.args
+            (key_e,) = e.args
             assert key_e in self.fast
             assert key_e not in self.slow
             if key_e == key:
@@ -146,7 +146,7 @@ class SpillBuffer(zict.Buffer[Key, object]):
                 # The exception will be caught by Worker and logged; the status of
                 # the task will be set to error.
                 del self[key]
-                raise orig_e
+                raise
             else:
                 # The key we just inserted is smaller than target, but it caused
                 # another, unrelated key to be spilled out of the LRU, and that key
@@ -324,7 +324,7 @@ class Slow(zict.Func[Key, object, bytes]):
             # zict.LRU ensures that the key remains in fast if we raise.
             # Wrap the exception so that it's recognizable by SpillBuffer,
             # which will then unwrap it.
-            raise PickleError(key, e)
+            raise PickleError(key) from e
 
         # Thanks to Buffer.__setitem__, we never update existing
         # keys in slow, but always delete them and reinsert them.

--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -136,25 +136,24 @@ class SpillBuffer(zict.Buffer[Key, object]):
             logger.error("Spill to disk failed; keeping data in memory", exc_info=True)
             raise HandledError()
         except PickleError as e:
-            (key_e, orig_e) = e.args
-            assert key_e in self.fast
-            assert key_e not in self.slow
-            if key_e == key:
+            assert e.key in self.fast
+            assert e.key not in self.slow
+            if e.key == key:
                 assert key is not None
                 # The key we just inserted failed to serialize.
                 # This happens only when the key is individually larger than target.
                 # The exception will be caught by Worker and logged; the status of
                 # the task will be set to error.
                 del self[key]
-                raise TypeError(f"Failed to pickle {key_e!r}") from orig_e
+                raise
             else:
                 # The key we just inserted is smaller than target, but it caused
                 # another, unrelated key to be spilled out of the LRU, and that key
                 # failed to serialize. There's nothing wrong with the new key. The older
                 # key is still in memory.
-                if key_e not in self.logged_pickle_errors:
-                    logger.error("Failed to pickle %r", key_e, exc_info=True)
-                    self.logged_pickle_errors.add(key_e)
+                if e.key not in self.logged_pickle_errors:
+                    logger.error("Failed to pickle %r", e.key, exc_info=True)
+                    self.logged_pickle_errors.add(e.key)
                 raise HandledError()
 
     def __setitem__(self, key: Key, value: object) -> None:
@@ -267,8 +266,13 @@ class MaxSpillExceeded(Exception):
     pass
 
 
-class PickleError(Exception):
-    pass
+class PickleError(TypeError):
+    def __str__(self) -> str:
+        return f"Failed to pickle {self.key!r}"
+
+    @property
+    def key(self) -> Key:
+        return self.args[0]
 
 
 class HandledError(Exception):
@@ -324,7 +328,7 @@ class Slow(zict.Func[Key, object, bytes]):
             # zict.LRU ensures that the key remains in fast if we raise.
             # Wrap the exception so that it's recognizable by SpillBuffer,
             # which will then unwrap it.
-            raise PickleError(key, e) from e
+            raise PickleError(key) from e
 
         # Thanks to Buffer.__setitem__, we never update existing
         # keys in slow, but always delete them and reinsert them.

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -14,9 +14,9 @@ from dask.sizeof import sizeof
 from distributed import profile
 from distributed.compatibility import WINDOWS
 from distributed.metrics import meter
-from distributed.spill import PickleError, SpillBuffer
+from distributed.spill import SpillBuffer
 from distributed.utils import RateLimiterFilter
-from distributed.utils_test import captured_logger, raises_with_cause
+from distributed.utils_test import captured_logger
 
 
 def psize(tmp_path: Path, **objs: object) -> tuple[int, int]:
@@ -219,7 +219,7 @@ def test_spillbuffer_fail_to_serialize(tmp_path):
     a = Bad(size=201)
 
     # Exception caught in the worker
-    with raises_with_cause(PickleError, "a", TypeError, "Could not serialize"):
+    with pytest.raises(TypeError, match="Failed to pickle"):
         with captured_logger("distributed.spill") as logs_bad_key:
             buf["a"] = a
 

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -14,9 +14,9 @@ from dask.sizeof import sizeof
 from distributed import profile
 from distributed.compatibility import WINDOWS
 from distributed.metrics import meter
-from distributed.spill import SpillBuffer
+from distributed.spill import PickleError, SpillBuffer
 from distributed.utils import RateLimiterFilter
-from distributed.utils_test import captured_logger
+from distributed.utils_test import captured_logger, raises_with_cause
 
 
 def psize(tmp_path: Path, **objs: object) -> tuple[int, int]:
@@ -219,7 +219,7 @@ def test_spillbuffer_fail_to_serialize(tmp_path):
     a = Bad(size=201)
 
     # Exception caught in the worker
-    with pytest.raises(TypeError, match="Could not serialize"):
+    with raises_with_cause(PickleError, "a", TypeError, "Could not serialize"):
         with captured_logger("distributed.spill") as logs_bad_key:
             buf["a"] = a
 

--- a/distributed/tests/test_spill.py
+++ b/distributed/tests/test_spill.py
@@ -219,9 +219,10 @@ def test_spillbuffer_fail_to_serialize(tmp_path):
     a = Bad(size=201)
 
     # Exception caught in the worker
-    with pytest.raises(TypeError, match="Failed to pickle"):
+    with pytest.raises(TypeError, match="Failed to pickle 'a'") as e:
         with captured_logger("distributed.spill") as logs_bad_key:
             buf["a"] = a
+    assert isinstance(e.value.__cause__.__cause__, MyError)
 
     # spill.py must remain silent because we're already logging in worker.py
     assert not logs_bad_key.getvalue()
@@ -240,7 +241,7 @@ def test_spillbuffer_fail_to_serialize(tmp_path):
 
     # worker.py won't intercept the exception here, so spill.py must dump the traceback
     logs_value = logs_bad_key_mem.getvalue()
-    assert "Failed to pickle" in logs_value  # from distributed.spill
+    assert "Failed to pickle 'b'" in logs_value  # from distributed.spill
     assert "Traceback" in logs_value  # from distributed.spill
     assert_buf(buf, tmp_path, {"b": b, "c": c}, {})
 

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -20,6 +20,7 @@ from distributed import Client, Event, KilledWorker, Nanny, Scheduler, Worker, w
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import Status
 from distributed.metrics import monotonic
+from distributed.spill import PickleError
 from distributed.utils import RateLimiterFilter
 from distributed.utils_test import (
     NO_AMM,
@@ -27,6 +28,7 @@ from distributed.utils_test import (
     captured_logger,
     gen_cluster,
     inc,
+    raises_with_cause,
     wait_for_state,
 )
 from distributed.worker_memory import parse_memory_limit
@@ -174,7 +176,7 @@ async def test_fail_to_pickle_execute_1(c, s, a, b):
 
     assert x.status == "error"
 
-    with pytest.raises(TypeError, match="Could not serialize"):
+    with raises_with_cause(PickleError, "x", TypeError, "Could not serialize"):
         await x
 
     await assert_basic_futures(c)

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -174,8 +174,9 @@ async def test_fail_to_pickle_execute_1(c, s, a, b):
 
     assert x.status == "error"
 
-    with pytest.raises(TypeError, match="Failed to pickle"):
+    with pytest.raises(TypeError, match="Failed to pickle 'x'") as e:
         await x
+    assert isinstance(e.value.__cause__.__cause__, CustomError)
 
     await assert_basic_futures(c)
 

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -20,7 +20,6 @@ from distributed import Client, Event, KilledWorker, Nanny, Scheduler, Worker, w
 from distributed.compatibility import MACOS, WINDOWS
 from distributed.core import Status
 from distributed.metrics import monotonic
-from distributed.spill import PickleError
 from distributed.utils import RateLimiterFilter
 from distributed.utils_test import (
     NO_AMM,
@@ -28,7 +27,6 @@ from distributed.utils_test import (
     captured_logger,
     gen_cluster,
     inc,
-    raises_with_cause,
     wait_for_state,
 )
 from distributed.worker_memory import parse_memory_limit
@@ -176,7 +174,7 @@ async def test_fail_to_pickle_execute_1(c, s, a, b):
 
     assert x.status == "error"
 
-    with raises_with_cause(PickleError, "x", TypeError, "Could not serialize"):
+    with pytest.raises(TypeError, match="Failed to pickle"):
         await x
 
     await assert_basic_futures(c)


### PR DESCRIPTION
Closes #8397 

This PR fixes an infinite loop that was created because we re-raised the original exception of the `PickleError` which would set the original exception object's `__context__` to the `PickleError`. `tblib=3` added support for the `__context__` (https://github.com/ionelmc/python-tblib/blob/master/CHANGELOG.rst#300-2023-10-22), which caused this to only create an infinite loop now. 

As a fix, we now raise a `TypeError` that is chained with the original exception.  

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
