### PR TITLE
Rewrite `test_subprocess_cluster_does_not_depend_on_logging`

### DIFF
--- a/distributed/deploy/tests/test_subprocess.py
+++ b/distributed/deploy/tests/test_subprocess.py
@@ -76,6 +76,7 @@ async def test_raise_if_scheduler_fails_to_start():
 
 
 @pytest.mark.skipif(WINDOWS, reason="distributed#7434")
+@pytest.mark.slow
 @gen_test()
 async def test_subprocess_cluster_does_not_depend_on_logging():
     async def _start():
@@ -90,7 +91,7 @@ async def test_subprocess_cluster_does_not_depend_on_logging():
     with new_config_file(
         {"distributed": {"logging": {"distributed": logging.CRITICAL + 1}}}
     ):
-        await asyncio.wait_for(_start(), timeout=2)
+        await asyncio.wait_for(_start(), timeout=5)
 
 
 @pytest.mark.skipif(

--- a/distributed/deploy/tests/test_subprocess.py
+++ b/distributed/deploy/tests/test_subprocess.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import pytest
@@ -79,19 +78,18 @@ async def test_raise_if_scheduler_fails_to_start():
 @pytest.mark.slow
 @gen_test()
 async def test_subprocess_cluster_does_not_depend_on_logging():
-    async def _start():
+    with new_config_file(
+        {"distributed": {"logging": {"distributed": logging.CRITICAL + 1}}}
+    ):
         async with SubprocessCluster(
             asynchronous=True,
             dashboard_address=":0",
             scheduler_kwargs={"idle_timeout": "5s"},
             worker_kwargs={"death_timeout": "5s"},
-        ):
-            pass
-
-    with new_config_file(
-        {"distributed": {"logging": {"distributed": logging.CRITICAL + 1}}}
-    ):
-        await asyncio.wait_for(_start(), timeout=8)
+        ) as cluster:
+            async with Client(cluster, asynchronous=True) as client:
+                result = await client.submit(lambda x: x + 1, 10)
+                assert result == 11
 
 
 @pytest.mark.skipif(

--- a/distributed/deploy/tests/test_subprocess.py
+++ b/distributed/deploy/tests/test_subprocess.py
@@ -91,7 +91,7 @@ async def test_subprocess_cluster_does_not_depend_on_logging():
     with new_config_file(
         {"distributed": {"logging": {"distributed": logging.CRITICAL + 1}}}
     ):
-        await asyncio.wait_for(_start(), timeout=5)
+        await asyncio.wait_for(_start(), timeout=8)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #8408

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
