### PR TITLE
Allow tasks to override `is_rootish` heuristic 

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1365,15 +1365,6 @@ class TaskState:
     #: Task annotations
     annotations: dict[str, Any] | None
 
-    #: Whether to consider this task rootish in the context of task queueing
-    #: True
-    #:     Always consider this task rootish
-    #: False
-    #:     Never consider this task rootish
-    #: None
-    #:     Use a heuristic to determine whether this task should be considered rootish
-    rootish: bool | None
-
     #: The unique identifier of a specific execution of a task. This identifier
     #: is used to sign a task such that the assigned worker is expected to return
     #: the same identifier in the task-finished message. This is used to correlate
@@ -1381,6 +1372,15 @@ class TaskState:
     #: Only the most recently assigned worker is trusted. All other results will
     #: be rejected.
     run_id: int | None
+
+    #: Whether to consider this task rootish in the context of task queueing
+    #: True
+    #:     Always consider this task rootish
+    #: False
+    #:     Never consider this task rootish
+    #: None
+    #:     Use a heuristic to determine whether this task should be considered rootish
+    _rootish: bool | None
 
     #: Cached hash of :attr:`~TaskState.client_key`
     _hash: int
@@ -1439,7 +1439,7 @@ class TaskState:
         self.metadata = None
         self.annotations = None
         self.erred_on = None
-        self.rootish = None
+        self._rootish = None
         self.run_id = None
         TaskState._instances.add(self)
 
@@ -2922,8 +2922,8 @@ class SchedulerState:
         and have few or no dependencies. Tasks may also be explicitly marked as rootish
         to override this heuristic.
         """
-        if ts.rootish is not None:
-            return ts.rootish
+        if ts._rootish is not None:
+            return ts._rootish
         if ts.resource_restrictions or ts.worker_restrictions or ts.host_restrictions:
             return False
         tg = ts.group

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1365,6 +1365,15 @@ class TaskState:
     #: Task annotations
     annotations: dict[str, Any] | None
 
+    #: Whether to consider this task rootish in the context of task queueing
+    #: True
+    #:     Always consider this task rootish
+    #: False
+    #:     Never consider this task rootish
+    #: None
+    #:     Use a heuristic to determine whether this task should be considered rootish
+    rootish: bool | None
+
     #: The unique identifier of a specific execution of a task. This identifier
     #: is used to sign a task such that the assigned worker is expected to return
     #: the same identifier in the task-finished message. This is used to correlate
@@ -1430,6 +1439,7 @@ class TaskState:
         self.metadata = None
         self.annotations = None
         self.erred_on = None
+        self.rootish = None
         self.run_id = None
         TaskState._instances.add(self)
 
@@ -2909,8 +2919,11 @@ class SchedulerState:
         Whether ``ts`` is a root or root-like task.
 
         Root-ish tasks are part of a group that's much larger than the cluster,
-        and have few or no dependencies.
+        and have few or no dependencies. Tasks may also be explicitly marked as rootish
+        to override this heuristic.
         """
+        if ts.rootish is not None:
+            return ts.rootish
         if ts.resource_restrictions or ts.worker_restrictions or ts.host_restrictions:
             return False
         tg = ts.group

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -279,6 +279,28 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
     test_decide_worker_coschedule_order_neighbors_()
 
 
+@gen_cluster(
+    client=True,
+    nthreads=[],
+)
+async def test_override_is_rootish(c, s):
+    x = c.submit(lambda x: x + 1, 1, key="x")
+    await async_poll_for(lambda: "x" in s.tasks, timeout=5)
+    ts_x = s.tasks["x"]
+    assert ts_x._rootish is None
+    assert s.is_rootish(ts_x)
+    ts_x._rootish = False
+    assert not s.is_rootish(ts_x)
+
+    y = c.submit(lambda y: y + 1, 1, key="y", workers=["not-existing"])
+    await async_poll_for(lambda: "y" in s.tasks, timeout=5)
+    ts_y = s.tasks["y"]
+    assert ts_y._rootish is None
+    assert not s.is_rootish(ts_y)
+    ts_y._rootish = True
+    assert s.is_rootish(ts_y)
+
+
 @pytest.mark.skipif(
     QUEUING_ON_BY_DEFAULT,
     reason="Not relevant with queuing on; see https://github.com/dask/distributed/issues/7204",

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -289,6 +289,7 @@ async def test_override_is_rootish(c, s):
     ts_x = s.tasks["x"]
     assert ts_x._rootish is None
     assert s.is_rootish(ts_x)
+
     ts_x._rootish = False
     assert not s.is_rootish(ts_x)
 
@@ -297,6 +298,7 @@ async def test_override_is_rootish(c, s):
     ts_y = s.tasks["y"]
     assert ts_y._rootish is None
     assert not s.is_rootish(ts_y)
+
     ts_y._rootish = True
     assert s.is_rootish(ts_y)
 


### PR DESCRIPTION
The `is_rootish` heuristic is not perfect and might make the wrong choice in certain cases. For example, the performance regression in https://github.com/coiled/benchmarks/issues/1226#issuecomment-1855779673 is likely caused by P2P's `unpack` tasks being considered rootish after we delayed applying worker restrictions to them. 

This PR introduces a `TaskState.rootish` flag that allows tasks to override the heuristic. For now, the flag will need to be set explicitly on the scheduler (with the main use case of forcing P2P's unpack task to never be rootish). I can also see a future where this can be applied via annotations (should we not rip out annotations or queueing beforehand).

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
