### PR TITLE
Fix flaky test_subprocess_cluster_does_not_depend_on_logging

### DIFF
--- a/distributed/deploy/tests/test_subprocess.py
+++ b/distributed/deploy/tests/test_subprocess.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 import pytest
@@ -78,19 +77,11 @@ async def test_raise_if_scheduler_fails_to_start():
 @pytest.mark.skipif(WINDOWS, reason="distributed#7434")
 @gen_test()
 async def test_subprocess_cluster_does_not_depend_on_logging():
-    async def _start():
-        async with SubprocessCluster(
-            asynchronous=True,
-            dashboard_address=":0",
-            scheduler_kwargs={"idle_timeout": "5s"},
-            worker_kwargs={"death_timeout": "5s"},
-        ):
-            pass
-
     with new_config_file(
         {"distributed": {"logging": {"distributed": logging.CRITICAL + 1}}}
     ):
-        await asyncio.wait_for(_start(), timeout=2)
+        async with SubprocessCluster(asynchronous=True, dashboard_address=":0"):
+            pass
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Fix flaky test introduced by #8398
Remove bespoke timeout code; increase timeout from 2 to 30s.
@hendrikmakait I may not fully understand the intent of your original code though.
