### PR TITLE
Do not reuse shuffles between merges

### DIFF
--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -363,10 +363,14 @@ class HashJoinP2PLayer(Layer):
         token_left = tokenize(
             self.name,
             self.name_input_left,
+            self.left_on,
+            self.left_index,
         )
         token_right = tokenize(
             self.name,
             self.name_input_right,
+            self.right_on,
+            self.right_index,
         )
         dsk: dict[tuple | str, tuple] = {}
         name_left = "hash-join-transfer-" + token_left

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -361,18 +361,12 @@ class HashJoinP2PLayer(Layer):
 
     def _construct_graph(self) -> dict[tuple | str, tuple]:
         token_left = tokenize(
-            "hash-join",
+            self.name,
             self.name_input_left,
-            self.left_on,
-            self.npartitions,
-            self.parts_out,
         )
         token_right = tokenize(
-            "hash-join",
+            self.name,
             self.name_input_right,
-            self.right_on,
-            self.npartitions,
-            self.parts_out,
         )
         dsk: dict[tuple | str, tuple] = {}
         name_left = "hash-join-transfer-" + token_left

--- a/distributed/shuffle/_merge.py
+++ b/distributed/shuffle/_merge.py
@@ -361,12 +361,18 @@ class HashJoinP2PLayer(Layer):
 
     def _construct_graph(self) -> dict[tuple | str, tuple]:
         token_left = tokenize(
+            # Include self.name to ensure that shuffle IDs are unique for individual
+            # merge operations. Reusing shuffles between merges is dangerous because of
+            # required coordination and complexity introduced through dynamic clusters.
             self.name,
             self.name_input_left,
             self.left_on,
             self.left_index,
         )
         token_right = tokenize(
+            # Include self.name to ensure that shuffle IDs are unique for individual
+            # merge operations. Reusing shuffles between merges is dangerous because of
+            # required coordination and complexity introduced through dynamic clusters.
             self.name,
             self.name_input_right,
             self.right_on,

--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -112,7 +112,9 @@ async def test_merge_p2p_shuffle_reused_dataframe_with_different_parameters(c, s
         # Vary the number of output partitions for the shuffles of dd2
         .repartition(20).merge(ddf2, left_on="b", right_on="x", shuffle="p2p")
     )
-    # Generate unique shuffle IDs if the input frame is the same but parameters differ
+    # Generate unique shuffle IDs if the input frame is the same but
+    # parameters differ. Reusing shuffles in merges is dangerous because of the
+    # required coordination and complexity introduced through dynamic clusters.
     assert sum(id_from_key(k) is not None for k in out.dask) == 4
     result = await c.compute(out)
     expected = pdf1.merge(pdf2, left_on="a", right_on="x").merge(
@@ -147,8 +149,10 @@ async def test_merge_p2p_shuffle_reused_dataframe_with_same_parameters(c, s, a, 
         right_on="b",
         shuffle="p2p",
     )
-    # Generate the same shuffle IDs if the input frame is the same and all its parameters match
-    assert sum(id_from_key(k) is not None for k in out.dask) == 3
+    # Generate unique shuffle IDs if the input frame is the same and all its
+    # parameters match. Reusing shuffles in merges is dangerous because of the
+    # required coordination and complexity introduced through dynamic clusters.
+    assert sum(id_from_key(k) is not None for k in out.dask) == 4
     result = await c.compute(out)
     expected = pdf2.merge(
         pdf1.merge(pdf2, left_on="a", right_on="x"), left_on="x", right_on="b"


### PR DESCRIPTION
Reverts reuse introduced in #8306. In hindsight, this opened up a Pandora's box of possible failure scenarios given that clusters are dynamic and we need to align output partitioning between individual shuffles used in each merge.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
