### PR TITLE
Fix flaky test_subprocess_cluster_does_not_depend_on_logging

### DIFF
--- a/distributed/deploy/tests/test_subprocess.py
+++ b/distributed/deploy/tests/test_subprocess.py
@@ -82,14 +82,10 @@ async def test_subprocess_cluster_does_not_depend_on_logging():
         {"distributed": {"logging": {"distributed": logging.CRITICAL + 1}}}
     ):
         async with SubprocessCluster(
-            asynchronous=True,
-            dashboard_address=":0",
-            scheduler_kwargs={"idle_timeout": "5s"},
-            worker_kwargs={"death_timeout": "5s"},
-        ) as cluster:
-            async with Client(cluster, asynchronous=True) as client:
-                result = await client.submit(lambda x: x + 1, 10)
-                assert result == 11
+            asynchronous=True, dashboard_address=":0"
+        ) as cluster, Client(cluster, asynchronous=True) as client:
+            result = await client.submit(lambda x: x + 1, 10)
+            assert result == 11
 
 
 @pytest.mark.skipif(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1500,7 +1500,7 @@ def new_config(new_config):
 
 
 @contextmanager
-def new_config_file(c):
+def new_config_file(c: dict[str, Any]) -> Iterator[None]:
     """
     Temporarily change configuration file to match dictionary *c*.
     """
@@ -1508,18 +1508,16 @@ def new_config_file(c):
 
     old_file = os.environ.get("DASK_CONFIG")
     fd, path = tempfile.mkstemp(prefix="dask-config")
+    with os.fdopen(fd, "w") as f:
+        yaml.dump(c, f)
+    os.environ["DASK_CONFIG"] = path
     try:
-        with os.fdopen(fd, "w") as f:
-            f.write(yaml.dump(c))
-        os.environ["DASK_CONFIG"] = path
-        try:
-            yield
-        finally:
-            if old_file:
-                os.environ["DASK_CONFIG"] = old_file
-            else:
-                del os.environ["DASK_CONFIG"]
+        yield
     finally:
+        if old_file:
+            os.environ["DASK_CONFIG"] = old_file
+        else:
+            del os.environ["DASK_CONFIG"]
         os.remove(path)
 
 


### PR DESCRIPTION
The new test `test_subprocess_cluster_does_not_depend_on_logging` is very flaky due to excessively short timeouts, e.g.

https://github.com/dask/distributed/actions/runs/7224159232/job/19684807889?pr=8415

When it fails, it brings with it the next test `test_config.py::test_logging_default`. 

I could not figure out for the life of me why the config is not being properly reset in case of failure. The changes to utils_test.py are cosmetic.