### PR TITLE
Fix `test_merge_p2p_shuffle_reused_dataframe_with_different_parameters`

### DIFF
--- a/distributed/shuffle/tests/test_merge.py
+++ b/distributed/shuffle/tests/test_merge.py
@@ -116,7 +116,9 @@ async def test_merge_p2p_shuffle_reused_dataframe_with_different_parameters(c, s
     out = (
         ddf1.merge(ddf2, left_on="a", right_on="x", shuffle="p2p")
         # Vary the number of output partitions for the shuffles of dd2
-        .repartition(20).merge(ddf2, left_on="b", right_on="x", shuffle="p2p")
+        .repartition(npartitions=20).merge(
+            ddf2, left_on="b", right_on="x", shuffle="p2p"
+        )
     )
     # Generate unique shuffle IDs if the input frame is the same but
     # parameters differ. Reusing shuffles in merges is dangerous because of the


### PR DESCRIPTION
https://github.com/dask/dask/pull/10691 broke `test_merge_p2p_shuffle_reused_dataframe_with_different_parameters`, this PR fixes it.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
