### PR TITLE
More robust wait_for for python 3.10 and below

### DIFF
--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -37,7 +37,7 @@ from distributed.core import (
 from distributed.metrics import time
 from distributed.protocol import to_serialize
 from distributed.protocol.compression import compressions
-from distributed.utils import get_ip, get_ipv6, wait_for
+from distributed.utils import get_ip, get_ipv6, open_port, wait_for
 from distributed.utils_test import (
     assert_can_connect,
     assert_can_connect_from_everywhere_4,
@@ -1146,7 +1146,7 @@ async def test_close_properly():
 
     server = await Server({"sleep": sleep})
     assert server.status == Status.running
-    ports = [8881, 8882, 8883]
+    ports = [open_port() for _ in range(3)]
 
     # Previously we close *one* listener, therefore ensure we always use more
     # than one for this test

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -1096,3 +1096,44 @@ def test_tuple_comparable_eq(obj1, obj2, expected):
 def test_tuple_comparable_error():
     with pytest.raises(ValueError):
         TupleComparable("string")
+
+
+@gen_test()
+async def test_wait_for():
+    # See https://github.com/python/cpython/issues/86296#issuecomment-1281339374
+    import asyncio
+
+    from distributed.utils import wait_for
+
+    async def left(tasks, event):
+        me = asyncio.current_task()
+        assert tasks[0] is me
+        await asyncio.sleep(0.1)
+        event.set()
+        tasks[1].cancel()
+
+    not_cancelled = False
+
+    async def right(tasks, event, use_wait_for):
+        nonlocal not_cancelled
+        try:
+            me = asyncio.current_task()
+            assert tasks[1] is me
+            if use_wait_for:
+                await wait_for(event.wait(), 1)
+            else:
+                await event.wait()
+            not_cancelled = True
+        except asyncio.CancelledError:
+            raise
+
+    async def left_right(use_wait_for):
+        tasks = []
+        event = asyncio.Event()
+        tasks.append(asyncio.create_task(left(tasks, event)))
+        tasks.append(asyncio.create_task(right(tasks, event, use_wait_for)))
+        await asyncio.wait(tasks)
+
+    await left_right(False)
+    await left_right(True)
+    assert not not_cancelled

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1930,14 +1930,33 @@ class RateLimiterFilter(logging.Filter):
 
 if sys.version_info >= (3, 11):
 
-    async def wait_for(fut: Awaitable[T], timeout: float) -> T:
+    async def wait_for(fut: Awaitable[T], timeout: float | None) -> T:
         async with asyncio.timeout(timeout):
             return await fut
 
 else:
 
-    async def wait_for(fut: Awaitable[T], timeout: float) -> T:
-        return await asyncio.wait_for(fut, timeout)
+    async def wait_for(fut: Awaitable[T], timeout: float | None) -> T:
+        if timeout is None:
+            return await fut
+        fut = asyncio.ensure_future(fut)
+        done = asyncio.Event()
+        fut.add_done_callback(lambda _: done.set())
+        sl = asyncio.create_task(asyncio.sleep(timeout))
+        for aw in asyncio.as_completed([done.wait(), sl]):
+            await aw
+            if not done.is_set():
+                fut.cancel()
+                try:
+                    raise asyncio.TimeoutError()
+                finally:
+                    try:
+                        await fut
+                    except asyncio.CancelledError:
+                        pass
+            sl.cancel()
+            return fut.result()
+        raise RuntimeError("Unreachable")
 
 
 class TupleComparable:


### PR DESCRIPTION
This is an attempt at fixing the flaky `test_tell_workers_when_peers_have_left`.

The test fails because we're cancelling an ongoing connection attempt which is reraised by the cpython wait_for as a TimeoutError such that the connect goes into a retry mode until the timeout is reached, effectively failing this test.

This is fixed in python 3.11 and above but older python versions can still experience this error. There are plenty of edge cases this implementation also doesn't get right but I believe it's a net positive for us (pending CI results)