### PR TITLE
Fix sphinx extlinks configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -385,8 +385,8 @@ epub_exclude_files = ["search.html"]
 # Link to GitHub issues and pull requests using :pr:`1234` and :issue:`1234`
 # syntax
 extlinks = {
-    "issue": ("https://github.com/dask/distributed/issues/%s", "GH#"),
-    "pr": ("https://github.com/dask/distributed/pull/%s", "GH#"),
+    "issue": ("https://github.com/dask/distributed/issues/%s", "GH#%s"),
+    "pr": ("https://github.com/dask/distributed/pull/%s", "GH#%s"),
 }
 
 # Configuration for intersphinx: refer to the Python standard library


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

The sphinx configuration for extlinks is missing a `%s` in the displayed text field, so fails to build the documentation with (at least) Sphinx 7.2.6.  This patch fixes this.