### PR TITLE
Delegate wait_for_workers to cluster instances only when implemented

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1454,10 +1454,10 @@ class Client(SyncMethodMixin):
                 f"`n_workers` must be a positive integer. Instead got {n_workers}."
             )
 
-        if self.cluster is None:
-            return self.sync(self._wait_for_workers, n_workers, timeout=timeout)
+        if self.cluster and hasattr(self.cluster, "wait_for_workers"):
+            return self.cluster.wait_for_workers(n_workers, timeout)
 
-        return self.cluster.wait_for_workers(n_workers, timeout)
+        return self.sync(self._wait_for_workers, n_workers, timeout=timeout)
 
     def _heartbeat(self):
         # Don't send heartbeat if scheduler comm or cluster are already closed


### PR DESCRIPTION
In https://github.com/dask/distributed/pull/6700 the client started delegating a `wait_for_workers` call to a cluster instance if one was set, but that forced all cluster instances to implement such method. This PR makes it optional to implement such method.

This change is motivated by https://github.com/dask/dask-gateway/issues/782 thanks to guidance from @TomAugspurger in a comment there. There a cluster instance was available, but `wait_for_workers` hasn't yet been implemented by the class defined by the dask/dask-gateway project.

- [ ] Tests added / passed
  I've for the moment opted to not try to develop a test for this small fix without further input.
- [x] Passes `pre-commit run --all-files`
