### PR TITLE
Do not always check if `__main__ in result` when pickling

### DIFF
--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -67,14 +67,16 @@ def dumps(x, *, buffer_callback=None, protocol=HIGHEST_PROTOCOL):
             buffers.clear()
             pickler.dump(x)
             result = f.getvalue()
-        if (
+
+        if not _always_use_pickle_for(x) and (
             CLOUDPICKLE_GE_20
             and getattr(inspect.getmodule(x), "__name__", None)
             in cloudpickle.list_registry_pickle_by_value()
-        ) or (
-            (len(result) < 1000 and not _always_use_pickle_for(x))
-            # this is pretty expensive so check very last
-            and b"__main__" in result
+            or (
+                len(result) < 1000
+                # Do this very last since it's expensive
+                and b"__main__" in result
+            )
         ):
             buffers.clear()
             result = cloudpickle.dumps(x, **dump_kwargs)

--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -72,7 +72,7 @@ def dumps(x, *, buffer_callback=None, protocol=HIGHEST_PROTOCOL):
             and getattr(inspect.getmodule(x), "__name__", None)
             in cloudpickle.list_registry_pickle_by_value()
         ) or (
-            (len(result) < 1000 or not _always_use_pickle_for(x))
+            (len(result) < 1000 and not _always_use_pickle_for(x))
             # this is pretty expensive so check very last
             and b"__main__" in result
         ):


### PR DESCRIPTION
This logic evolved over time but the doc string already suggests that we're performing type checks first before we do the "is main in result" check. Some refactoring along the way changed this. Particularly for large results this can be a big difference such that the `thing in result` check can be more expensive than the actual serialization. This can be most strongly observed when pickling bytes directly (not sure if we're actually doing that) or more generally for everything that we're blocklisting in `_always_use_pickle_for` (I think we should expand this, e.g. to include arrow tables for p2p)


I ended up rewriting the logic to something that is easier to understand imo. This includes a minor functional change. Previously, it would have been possible for an object to be classified as eligible for cloudpickle by the `main in result or pickle_by_value` guard even though it is blocklisted by the `always_use_pickle_for` but only if the object was very small. This is a bit off an odd logic. In fact, it cannot even occur since  `always_use_pickle_for` concerns instances while the pickle_by_value and main in result check concerns functions and classes. Still, imo this made the logic less readable. The new logic is subjectively easier to read and short circuits much more quickly in the happy path or `always_use_pickle_for==True`