### PR TITLE
ci: allow tests workflow to be dispatched manually by maintainers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
   schedule:
     - cron: "0 6,18 * * *"
+  workflow_dispatch:
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch


### PR DESCRIPTION
Like this, its possible for maintainers to trigger a test workflow. This can be useful if reviewing a PR and the tests suddenly fails and it seems unrelated - then one can go and trigger the tests on the main branch, if they fail - its clear that the test failures are unrelated to the PR.

Here is an example of such trigger button in another project where I'm a maintainer:

![image](https://github.com/dask/distributed/assets/3837114/e19a685c-80e3-4ee9-ae66-553d700a93bd)
