### PR TITLE
Fall back to `pickle` in `protocol.dumps`  instead of failing hard

### DIFF
--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -108,7 +108,10 @@ def dumps(  # type: ignore[no-untyped-def]
         try:
             frames[0] = msgpack.dumps(msg, default=_encode_default, use_bin_type=True)
         except TypeError as e:
-            logger.info(e)
+            logger.info(
+                f"Failed to serialize ({e}); falling back to pickle. "
+                "Be aware that this may degrade performance."
+            )
 
             def _encode_default_safe(obj):
                 encoded = _encode_default(obj)

--- a/distributed/protocol/core.py
+++ b/distributed/protocol/core.py
@@ -128,6 +128,10 @@ def dumps(  # type: ignore[no-untyped-def]
                     frames.extend(create_pickled_sub_frames(obj))
                     return {"__Pickled__": offset}
 
+            # If possible, we want to avoid the performance penalty from the checks
+            # implemented in _encode_default_safe to fall back to pickle, so we
+            # try to serialize the data without the fallback first assuming that
+            # this succeeds in the overwhelming majority of cases.
             frames[0] = msgpack.dumps(
                 msg, default=_encode_default_safe, use_bin_type=True
             )

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -189,7 +189,7 @@ def test_fallback_to_pickle():
     with captured_logger("distributed.protocol.core") as logger:
         L = dumps(d)
     assert "can not serialize 'numpy.int64'" in logger.getvalue()
-    assert b"__Pickled__" in L[0]
+    assert L[0].count(b"__Pickled__") == 1
     assert loads(L) == d
 
     d = {np.int64(1): {np.int64(2): "a"}, 3: ("b", "c"), 4: "d"}

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -199,3 +199,12 @@ def test_fallback_to_pickle():
     # Make sure that we pickle the individual ints, not the entire dict
     assert L[0].count(b"__Pickled__") == 2
     assert loads(L) == d
+
+    d = {np.int64(1): {Serialize(2): "a"}, 3: ("b", "c"), 4: "d"}
+    with captured_logger("distributed.protocol.core") as logger:
+        L = dumps(d)
+    assert "can not serialize 'numpy.int64'" in logger.getvalue()
+    # Make sure that we still serialize and don't pickle indiscriminately
+    assert L[0].count(b"__Pickled__") == 1
+    assert L[0].count(b"__Serialized__") == 1
+    assert loads(L) == {np.int64(1): {2: "a"}, 3: ("b", "c"), 4: "d"}

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -20,6 +20,7 @@ from distributed.protocol.serialize import (
     serialize,
 )
 from distributed.utils import nbytes
+from distributed.utils_test import captured_logger
 
 
 def test_protocol():
@@ -174,3 +175,27 @@ def test_deeply_nested_structures():
 
     msg = gen_deeply_nested(sys.getrecursionlimit() // 4)
     assert isinstance(serialize(msg), tuple)
+
+
+def test_fallback_to_pickle():
+    np = pytest.importorskip("numpy")
+
+    d = 1
+    L = dumps(d)
+    assert b"__Pickled__" not in L[0]
+    assert loads(L) == d
+
+    d = np.int64(1)
+    with captured_logger("distributed.protocol.core") as logger:
+        L = dumps(d)
+    assert "can not serialize 'numpy.int64'" in logger.getvalue()
+    assert b"__Pickled__" in L[0]
+    assert loads(L) == d
+
+    d = {np.int64(1): {np.int64(2): "a"}, 3: ("b", "c"), 4: "d"}
+    with captured_logger("distributed.protocol.core") as logger:
+        L = dumps(d)
+    assert "can not serialize 'numpy.int64'" in logger.getvalue()
+    # Make sure that we pickle the individual ints, not the entire dict
+    assert L[0].count(b"__Pickled__") == 2
+    assert loads(L) == d


### PR DESCRIPTION
Closes #8446

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
