### PR TITLE
Replace all occurrences of sys.is_finalizing

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -107,7 +107,7 @@ def _():
     Note
     ----
     This function must be registered with atexit *after* any class that invokes
-    ``dstributed.utils.is_python_shutting_down`` has been defined. This way it
+    ``distributed.utils.is_python_shutting_down`` has been defined. This way it
     will be called before the ``__del__`` method of those classes.
 
     See Also

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -507,7 +507,7 @@ class Future(WrappedKey):
         except AttributeError:
             # Occasionally we see this error when shutting down the client
             # https://github.com/dask/distributed/issues/4305
-            if not sys.is_finalizing():
+            if not is_python_shutting_down():
                 raise
         except RuntimeError:  # closed event loop
             pass
@@ -1786,7 +1786,7 @@ class Client(SyncMethodMixin):
 
         assert self.status == "closed"
 
-        if not sys.is_finalizing():
+        if not is_python_shutting_down():
             self._loop_runner.stop()
 
     async def _shutdown(self):

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -187,7 +187,7 @@ class InProc(Comm):
         r = repr(self)
 
         def finalize(write_q=self._write_q, write_loop=self._write_loop, r=r):
-            if not self.closed():
+            if write_q.peek(None) is not _EOF:
                 logger.warning(f"Closing dangling queue in {r}")
                 write_loop.add_callback(write_q.put_nowait, _EOF)
 

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -187,8 +187,9 @@ class InProc(Comm):
         r = repr(self)
 
         def finalize(write_q=self._write_q, write_loop=self._write_loop, r=r):
-            logger.warning(f"Closing dangling queue in {r}")
-            write_loop.add_callback(write_q.put_nowait, _EOF)
+            if not self.closed():
+                logger.warning(f"Closing dangling queue in {r}")
+                write_loop.add_callback(write_q.put_nowait, _EOF)
 
         return finalize
 

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -39,7 +39,14 @@ from distributed.comm.utils import (
 )
 from distributed.protocol.utils import host_array, pack_frames_prelude, unpack_frames
 from distributed.system import MEMORY_LIMIT
-from distributed.utils import ensure_ip, ensure_memoryview, get_ip, get_ipv6, nbytes
+from distributed.utils import (
+    ensure_ip,
+    ensure_memoryview,
+    get_ip,
+    get_ipv6,
+    is_python_shutting_down,
+    nbytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +240,7 @@ class TCP(Comm):
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
-            if not sys.is_finalizing():
+            if not is_python_shutting_down():
                 convert_stream_closed_error(self, e)
         except BaseException:
             # Some OSError, CancelledError or another "low-level" exception.
@@ -305,7 +312,7 @@ class TCP(Comm):
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
-            if not sys.is_finalizing():
+            if not is_python_shutting_down():
                 convert_stream_closed_error(self, e)
         except BaseException:
             # Some OSError or a another "low-level" exception. We do not really know

--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -39,14 +39,7 @@ from distributed.comm.utils import (
 )
 from distributed.protocol.utils import host_array, pack_frames_prelude, unpack_frames
 from distributed.system import MEMORY_LIMIT
-from distributed.utils import (
-    ensure_ip,
-    ensure_memoryview,
-    get_ip,
-    get_ipv6,
-    is_python_shutting_down,
-    nbytes,
-)
+from distributed.utils import ensure_ip, ensure_memoryview, get_ip, get_ipv6, nbytes
 
 logger = logging.getLogger(__name__)
 
@@ -240,8 +233,7 @@ class TCP(Comm):
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
-            if not is_python_shutting_down():
-                convert_stream_closed_error(self, e)
+            convert_stream_closed_error(self, e)
         except BaseException:
             # Some OSError, CancelledError or another "low-level" exception.
             # We do not really know what was already read from the underlying
@@ -312,8 +304,7 @@ class TCP(Comm):
         except StreamClosedError as e:
             self.stream = None
             self._closed = True
-            if not is_python_shutting_down():
-                convert_stream_closed_error(self, e)
+            convert_stream_closed_error(self, e)
         except BaseException:
             # Some OSError or a another "low-level" exception. We do not really know
             # what was already written to the underlying socket, so it is not even safe

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -54,6 +54,7 @@ from distributed.utils import (
     get_traceback,
     has_keyword,
     import_file,
+    is_python_shutting_down,
     iscoroutinefunction,
     offload,
     recursive_to_dict,
@@ -899,7 +900,7 @@ class Server:
                     msg = await comm.read()
                     logger.debug("Message from %r: %s", address, msg)
                 except OSError as e:
-                    if not sys.is_finalizing():
+                    if not is_python_shutting_down():
                         logger.debug(
                             "Lost connection to %r while reading message: %s."
                             " Last operation: %s",
@@ -1003,7 +1004,7 @@ class Server:
 
         finally:
             del self._comms[comm]
-            if not sys.is_finalizing() and not comm.closed():
+            if not is_python_shutting_down() and not comm.closed():
                 try:
                     comm.abort()
                 except Exception as e:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -13,7 +13,6 @@ import operator
 import os
 import pickle
 import random
-import sys
 import textwrap
 import uuid
 import warnings
@@ -119,6 +118,7 @@ from distributed.utils import (
     TimeoutError,
     format_dashboard_link,
     get_fileno_limit,
+    is_python_shutting_down,
     key_split_group,
     log_errors,
     offload,
@@ -5595,7 +5595,7 @@ class Scheduler(SchedulerState, ServerNode):
             if not comm.closed():
                 self.client_comms[client].send({"op": "stream-closed"})
             try:
-                if not sys.is_finalizing():
+                if not is_python_shutting_down():
                     await self.client_comms[client].close()
                     del self.client_comms[client]
                     if self.status == Status.running:


### PR DESCRIPTION
We stumbled again over some noisiness during interpreter shutdown inside of the Futures `__del__`. For this we implemented the `is_python_shutting_down` utility which has slightly different semantics than the actual python `sys.is_finalizing`. I have to admit that I don't fully understand the differences but from what I can tell our toggle is set a little bit earlier. Reviewing all of our usage of `sys.is_finalizing` I think it is safe to use the utility everywhere for simplicity.