### PR TITLE
Adapt test_report.py to support dask/dask repository

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -162,9 +162,7 @@ def get_jobs(run, session, repo):
         df_jobs["suite_name"] = name_components.iloc[:, 0].str.cat(
             name_components.iloc[:, 1:], sep="-"
         )
-        df_jobs["suite_name"] = ("test-results-" + df_jobs.suite_name).str.replace(
-            "--", "-"
-        )
+        df_jobs["suite_name"] = df_jobs.suite_name.str.replace("--", "-")
     else:
         name_components = df_jobs.name.str.split("-", expand=True).dropna()
         if len(name_components.columns) != 5:

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -370,8 +370,6 @@ def download_and_parse_artifacts(
             jobs_df = get_jobs(r, session=session, repo=repo)
             r["dfs"] = []
             for a in r["artifacts"]:
-                if repo.endswith("/dask") and not a["name"].startswith("test-results-"):
-                    continue
                 url = a["archive_download_url"]
                 df: pandas.DataFrame | None
                 xml = download_and_parse_artifact(url, session=session)

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -10,7 +10,7 @@ import shelve
 import sys
 import zipfile
 from collections.abc import Iterable, Iterator
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ProcessPoolExecutor
 from typing import Any, cast
 
 import altair
@@ -374,9 +374,6 @@ def download_and_parse_artifacts(
             for a in r["artifacts"]:
                 if repo.endswith("/dask") and not a["name"].startswith("test-results-"):
                     continue
-                # TODO: only applies to milesgranger/dask from bad prior test
-                if a["name"] == "test-results-":
-                    continue
                 url = a["archive_download_url"]
                 df: pandas.DataFrame | None
                 xml = download_and_parse_artifact(url, session=session)
@@ -508,7 +505,7 @@ def main(argv: list[str] | None = None) -> None:
             if not len(df):
                 continue
             jobs.append(executor.submit(make_chart, name, df, times))
-        charts = [job.result() for job in as_completed(jobs)]
+        charts = [job.result() for job in jobs]
 
     # Concat the sub-charts and output to file
     chart = (

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -10,6 +10,7 @@ import shelve
 import sys
 import zipfile
 from collections.abc import Iterable, Iterator
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import Any, cast
 
 import altair
@@ -121,7 +122,7 @@ def maybe_get_next_page_path(response: requests.Response) -> str | None:
     return next_page_path
 
 
-def get_jobs(run, session):
+def get_jobs(run, session, repo):
     with shelve.open("test_report_jobs") as cache:
         url = run["jobs_url"]
         try:
@@ -140,17 +141,48 @@ def get_jobs(run, session):
     # Somehow the job ID is not part of the workflow schema and we have no other way to later join
     # this to the JXML results.
 
-    name_components = df_jobs.name.str.split("-", expand=True).dropna()
-    if len(name_components.columns) != 5:
-        raise ValueError(f"Job names must have 5 components:\n{name_components!r}")
-    name_components.columns = ["OS", "OS version", "environment", "label", "partition"]
+    if repo.endswith("/dask"):
+        # example name: "test (windows-latest, 3.9)" or "test (ubuntu-latest, 3.12, dask-expr)"
+        df_jobs = df_jobs[~df_jobs.name.str.contains("Event File")]
+        name_components = (
+            df_jobs.name.str.replace("(", ",")
+            .str.replace(")", ",")
+            .str.split(",", expand=True)
+            .apply(
+                lambda row: ",".join(
+                    (row[1].strip(), row[2].strip(), row[3].strip() or "-")
+                ),
+                axis=1,
+            )
+            .str.split(",", expand=True)
+        )
 
-    # See `Set $TEST_ID` step in `tests.yaml`
-    name_components["partition"] = name_components.partition.str.replace(" ", "")
+        # See `Set $TEST_ID` step in `tests.yaml`
+        name_components.columns = ["OS version", "environment", "option"]
+        df_jobs["suite_name"] = name_components.iloc[:, 0].str.cat(
+            name_components.iloc[:, 1:], sep="-"
+        )
+        df_jobs["suite_name"] = ("test-results-" + df_jobs.suite_name).str.replace(
+            "--", "-"
+        )
+    else:
+        name_components = df_jobs.name.str.split("-", expand=True).dropna()
+        if len(name_components.columns) != 5:
+            raise ValueError(f"Job names must have 5 components:\n{name_components!r}")
+        name_components.columns = [
+            "OS",
+            "OS version",
+            "environment",
+            "label",
+            "partition",
+        ]
 
-    df_jobs["suite_name"] = name_components.iloc[:, 0].str.cat(
-        name_components.iloc[:, 1:], sep="-"
-    )
+        # See `Set $TEST_ID` step in `tests.yaml`
+        name_components["partition"] = name_components.partition.str.replace(" ", "")
+
+        df_jobs["suite_name"] = name_components.iloc[:, 0].str.cat(
+            name_components.iloc[:, 1:], sep="-"
+        )
     return df_jobs
 
 
@@ -199,14 +231,14 @@ def get_artifacts_for_workflow_run(
     return artifacts
 
 
-def suite_from_name(name: str) -> str:
+def suite_from_name(name: str, n: int) -> str:
     """
     Get a test suite name from an artifact name. The artifact
     can have matrix partitions, pytest marks, etc. Basically,
     just lop off the front of the name to get the suite.
     """
     parts = name.split("-")
-    return "-".join(parts[:4])
+    return "-".join(parts[:n])
 
 
 def download_and_parse_artifact(
@@ -337,9 +369,14 @@ def download_and_parse_artifacts(
         print(f"Downloading and parsing {nartifacts} artifacts...")
 
         for r in runs:
-            jobs_df = get_jobs(r, session=session)
+            jobs_df = get_jobs(r, session=session, repo=repo)
             r["dfs"] = []
             for a in r["artifacts"]:
+                if repo.endswith("/dask") and not a["name"].startswith("test-results-"):
+                    continue
+                # TODO: only applies to milesgranger/dask from bad prior test
+                if a["name"] == "test-results-":
+                    continue
                 url = a["archive_download_url"]
                 df: pandas.DataFrame | None
                 xml = download_and_parse_artifact(url, session=session)
@@ -362,7 +399,9 @@ def download_and_parse_artifacts(
                 assert html_url is not None
                 df2 = df.assign(
                     name=a["name"],
-                    suite=suite_from_name(a["name"]),
+                    suite=suite_from_name(
+                        a["name"], -1 if repo.endswith("/dask") else 4
+                    ),
                     date=r["created_at"],
                     html_url=html_url,
                 )
@@ -373,6 +412,44 @@ def download_and_parse_artifacts(
                 ndownloaded += 1
                 if ndownloaded and not ndownloaded % 20:
                     print(f"{ndownloaded}... ", end="")
+
+
+def make_chart(name, df, times):
+    # Create an aggregated form of the suite with overall pass rate
+    # over the time in question.
+    df_agg = (
+        df[df.status != "x"]
+        .groupby("suite")
+        .size()
+        .truediv(df.groupby("suite").size(), fill_value=0)
+        .to_frame(name="Pass Rate")
+        .reset_index()
+    )
+
+    # Create a grid with hover tooltip for error messages
+    return altair.Chart(df).mark_rect(stroke="gray").encode(
+        x=altair.X("date:O", scale=altair.Scale(domain=sorted(list(times)))),
+        y=altair.Y("suite:N", title=None),
+        href=altair.Href("html_url:N"),
+        color=altair.Color(
+            "status:N",
+            scale=altair.Scale(
+                domain=list(COLORS.keys()),
+                range=list(COLORS.values()),
+            ),
+        ),
+        tooltip=["suite:N", "date:O", "status:N", "message:N", "html_url:N"],
+    ).properties(title=name) | altair.Chart(df_agg.assign(_="_")).mark_rect(
+        stroke="gray"
+    ).encode(
+        y=altair.Y("suite:N", title=None, axis=altair.Axis(labels=False)),
+        x=altair.X("_:N", title=None),
+        color=altair.Color(
+            "Pass Rate:Q",
+            scale=altair.Scale(range=[COLORS["x"], COLORS["✓"]], domain=[0.0, 1.0]),
+        ),
+        tooltip=["suite:N", "Pass Rate:Q"],
+    )
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -423,55 +500,15 @@ def main(argv: list[str] | None = None) -> None:
 
     print("Making chart...")
     altair.data_transformers.disable_max_rows()
-    charts = []
-    for name, df in overall.items():
-        # Don't show this suite if it has passed all tests recently.
-        if not len(df):
-            continue
 
-        # Create an aggregated form of the suite with overall pass rate
-        # over the time in question.
-        df_agg = (
-            df[df.status != "x"]
-            .groupby("suite")
-            .size()
-            .truediv(df.groupby("suite").size(), fill_value=0)
-            .to_frame(name="Pass Rate")
-            .reset_index()
-        )
-
-        # Create a grid with hover tooltip for error messages
-        charts.append(
-            altair.Chart(df)
-            .mark_rect(stroke="gray")
-            .encode(
-                x=altair.X("date:O", scale=altair.Scale(domain=sorted(list(times)))),
-                y=altair.Y("suite:N", title=None),
-                href=altair.Href("html_url:N"),
-                color=altair.Color(
-                    "status:N",
-                    scale=altair.Scale(
-                        domain=list(COLORS.keys()),
-                        range=list(COLORS.values()),
-                    ),
-                ),
-                tooltip=["suite:N", "date:O", "status:N", "message:N", "html_url:N"],
-            )
-            .properties(title=name)
-            | altair.Chart(df_agg.assign(_="_"))
-            .mark_rect(stroke="gray")
-            .encode(
-                y=altair.Y("suite:N", title=None, axis=altair.Axis(labels=False)),
-                x=altair.X("_:N", title=None),
-                color=altair.Color(
-                    "Pass Rate:Q",
-                    scale=altair.Scale(
-                        range=[COLORS["x"], COLORS["✓"]], domain=[0.0, 1.0]
-                    ),
-                ),
-                tooltip=["suite:N", "Pass Rate:Q"],
-            )
-        )
+    jobs = []
+    with ProcessPoolExecutor() as executor:
+        for name, df in overall.items():
+            # Don't show this suite if it has passed all tests recently.
+            if not len(df):
+                continue
+            jobs.append(executor.submit(make_chart, name, df, times))
+        charts = [job.result() for job in as_completed(jobs)]
 
     # Concat the sub-charts and output to file
     chart = (

--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -229,14 +229,16 @@ def get_artifacts_for_workflow_run(
     return artifacts
 
 
-def suite_from_name(name: str, n: int) -> str:
+def suite_from_name(name: str, n: int | None = None) -> str:
     """
     Get a test suite name from an artifact name. The artifact
     can have matrix partitions, pytest marks, etc. Basically,
     just lop off the front of the name to get the suite.
     """
-    parts = name.split("-")
-    return "-".join(parts[:n])
+    if n is not None:
+        parts = name.split("-")
+        return "-".join(parts[:n])
+    return name
 
 
 def download_and_parse_artifact(
@@ -393,7 +395,7 @@ def download_and_parse_artifacts(
                 df2 = df.assign(
                     name=a["name"],
                     suite=suite_from_name(
-                        a["name"], -1 if repo.endswith("/dask") else 4
+                        a["name"], None if repo.endswith("/dask") else 4
                     ),
                     date=r["created_at"],
                     html_url=html_url,


### PR DESCRIPTION
Part of https://github.com/dask/dask/issues/10732

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Adapts the `continuous_integration/scripts/test_report.py` to support test reporting added by https://github.com/dask/dask/pull/10769. Idea being to add a step later in dask/dask to fetch this script and run it over there.

Example for --repo dask/distributed --branch main (no changes)
![distributed-report](https://github.com/dask/distributed/assets/13764397/d88daa43-fe69-4f89-bb2e-e8f4325ae90d)

Example for --repo milesgranger/dask --branch failure-test
![dask-report](https://github.com/dask/distributed/assets/13764397/e9991f3d-e25b-4ae1-9ad0-06c137a5296e)


