### PR TITLE
Don't raise `AttributeError` in `Future.__del__` if Python is shutting down.

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -107,7 +107,7 @@ def _():
     Note
     ----
     This function must be registered with atexit *after* any class that invokes
-    ``dstributed.utils.is_python_shutting_down`` has been defined. This way it
+    ``distributed.utils.is_python_shutting_down`` has been defined. This way it
     will be called before the ``__del__`` method of those classes.
 
     See Also

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -507,7 +507,7 @@ class Future(WrappedKey):
         except AttributeError:
             # Occasionally we see this error when shutting down the client
             # https://github.com/dask/distributed/issues/4305
-            if not sys.is_finalizing():
+            if not is_python_shutting_down():
                 raise
         except RuntimeError:  # closed event loop
             pass


### PR DESCRIPTION
I don't have a reproducer, but seen this pop up in logs.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
