### PR TITLE
check for main module in reducer override

### DIFF
--- a/distributed/protocol/tests/test_pickle.py
+++ b/distributed/protocol/tests/test_pickle.py
@@ -20,7 +20,7 @@ from distributed.protocol.pickle import (
     loads,
 )
 from distributed.protocol.serialize import dask_deserialize, dask_serialize
-from distributed.utils_test import save_sys_modules
+from distributed.utils_test import popen, save_sys_modules
 
 
 class MemoryviewHolder:
@@ -278,3 +278,27 @@ def test_nopickle_nested():
     finally:
         del dask_serialize._lookup[NoPickle]
         del dask_deserialize._lookup[NoPickle]
+
+
+@pytest.mark.slow()
+def test_pickle_functions_in_main(tmp_path):
+    script = """
+import dask.dataframe as dd
+from dask.distributed import Client
+
+if __name__ == "__main__":
+    with Client(n_workers=1) as client:
+        ddf = dd.from_dict({"a": range(10)}, 1)
+        def func(df):
+            return (df + 5)
+        ddf.map_partitions(func).compute()
+        print("success")
+"""
+    with open(tmp_path / "script.py", mode="w") as f:
+        f.write(script)
+    with popen([sys.executable, tmp_path / "script.py"], capture_output=True) as proc:
+        out, _ = proc.communicate(timeout=60)
+
+    lines = out.decode("utf-8").split("\n")
+
+    assert "success" in lines


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8454

This rips out the entire "check in pickled result byte string" logic in favor of piggy backing on the `reducer_override` which we're already using anyhow.

For those who aren't familiar with this override: This is called for *every* object and allows us to override the pickle dispatch table.
So far, we've been only using this for objects that failed to pickle without custom logic so there may be a performance penalty involved  since we're now doing it for every object.

On the flip side, this removes the need to check the entire byte string for `b"__main__"` *and* the cloudpickle fallback is much more precise now. For instance, if one serializes a large graph where a single function would fail to pickle we'd now use cloudpickle only on this single function instead of the entire graph which in theory should be faster. 

I'll run some tests. If this doesn't work out because it's slower than main or causes other issues I will revert https://github.com/dask/distributed/pull/8443 (since it turns out we have to check for main in every byte string after all...)
