### PR TITLE
Make `decide_worker` and `rootish` logic private

### DIFF
--- a/docs/source/scheduling-policies.rst
+++ b/docs/source/scheduling-policies.rst
@@ -130,11 +130,11 @@ functions in ``scheduler.py``.
 
 .. autosummary:: decide_worker
 
-.. autosummary:: Scheduler.decide_worker_non_rootish
+.. autosummary:: Scheduler._decide_worker_non_rootish
 
-.. autosummary:: Scheduler.decide_worker_rootish_queuing_disabled
+.. autosummary:: Scheduler._decide_worker_rootish_queuing_disabled
 
-.. autosummary:: Scheduler.decide_worker_rootish_queuing_enabled
+.. autosummary:: Scheduler._decide_worker_rootish_queuing_enabled
 
 .. autosummary:: Scheduler.worker_objective
 


### PR DESCRIPTION
Baby-steps toward #8190 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
