### PR TITLE
Ignore dask-expr in test_report.py script

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -389,6 +389,10 @@ def download_and_parse_artifacts(
                 if a["name"].startswith("test-results") and repo.endswith("/dask"):
                     continue
 
+                # NOTE: Temporarily ignore reporting dask-expr related test cases
+                if "dask-expr" in a["name"]:
+                    continue
+
                 # Note: we assign a column with the workflow run timestamp rather
                 # than the artifact timestamp so that artifacts triggered under
                 # the same workflow run can be aligned according to the same trigger


### PR DESCRIPTION
Until dask-expr isn't failing so many tests, current state isn't so helpful w/ so many charts being reported:
https://dask.github.io/dask/test_short_report.html

Example ran on dask/dask w/ the same flags as "test_short_report".

![visualization](https://github.com/dask/distributed/assets/13764397/275e9f0f-9d16-44c6-9d05-afa340507e87)
