### PR TITLE
Re-enable dask-expr reporting in test_report script

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -389,10 +389,6 @@ def download_and_parse_artifacts(
                 if a["name"].startswith("test-results") and repo.endswith("/dask"):
                     continue
 
-                # NOTE: Temporarily ignore reporting dask-expr related test cases
-                if "dask-expr" in a["name"]:
-                    continue
-
                 # Note: we assign a column with the workflow run timestamp rather
                 # than the artifact timestamp so that artifacts triggered under
                 # the same workflow run can be aligned according to the same trigger


### PR DESCRIPTION
Report dask-expr failures now.
xref https://github.com/dask/dask/pull/10829

Might actually want to wait on this for ~90 days since it'll still report a lot of failing tests in dask-expr until then?
https://github.com/dask/distributed/blob/33b2c72f583716a504808365d3701df639f78e68/.github/workflows/test-report.yaml#L51