### PR TITLE
[RFC] Decompose server class

### DIFF
--- a/distributed/_async_taskgroup.py
+++ b/distributed/_async_taskgroup.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, TypeVar
+
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
+
+    P = ParamSpec("P")
+    R = TypeVar("R")
+    T = TypeVar("T")
+    Coro = Coroutine[Any, Any, T]
+
+
+class _LoopBoundMixin:
+    """Backport of the private asyncio.mixins._LoopBoundMixin from 3.11"""
+
+    _global_lock = threading.Lock()
+
+    _loop = None
+
+    def _get_loop(self):
+        loop = asyncio.get_running_loop()
+
+        if self._loop is None:
+            with self._global_lock:
+                if self._loop is None:
+                    self._loop = loop
+        if loop is not self._loop:
+            raise RuntimeError(f"{self!r} is bound to a different event loop")
+        return loop
+
+
+class AsyncTaskGroupClosedError(RuntimeError):
+    pass
+
+
+def _delayed(corofunc: Callable[P, Coro[T]], delay: float) -> Callable[P, Coro[T]]:
+    """Decorator to delay the evaluation of a coroutine function by the given delay in seconds."""
+
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        await asyncio.sleep(delay)
+        return await corofunc(*args, **kwargs)
+
+    return wrapper
+
+
+class AsyncTaskGroup(_LoopBoundMixin):
+    """Collection tracking all currently running asynchronous tasks within a group"""
+
+    #: If True, the group is closed and does not allow adding new tasks.
+    closed: bool
+
+    def __init__(self) -> None:
+        self.closed = False
+        self._ongoing_tasks: set[asyncio.Task[None]] = set()
+
+    def call_soon(
+        self, afunc: Callable[P, Coro[None]], /, *args: P.args, **kwargs: P.kwargs
+    ) -> None:
+        """Schedule a coroutine function to be executed as an `asyncio.Task`.
+
+        The coroutine function `afunc` is scheduled with `args` arguments and `kwargs` keyword arguments
+        as an `asyncio.Task`.
+
+        Parameters
+        ----------
+        afunc
+            Coroutine function to schedule.
+        *args
+            Arguments to be passed to `afunc`.
+        **kwargs
+            Keyword arguments to be passed to `afunc`
+
+        Returns
+        -------
+            None
+
+        Raises
+        ------
+        AsyncTaskGroupClosedError
+            If the task group is closed.
+        """
+        if self.closed:  # Avoid creating a coroutine
+            raise AsyncTaskGroupClosedError(
+                "Cannot schedule a new coroutine function as the group is already closed."
+            )
+        task = self._get_loop().create_task(afunc(*args, **kwargs))
+        task.add_done_callback(self._ongoing_tasks.remove)
+        self._ongoing_tasks.add(task)
+        return None
+
+    def call_later(
+        self,
+        delay: float,
+        afunc: Callable[P, Coro[None]],
+        /,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> None:
+        """Schedule a coroutine function to be executed after `delay` seconds as an `asyncio.Task`.
+
+        The coroutine function `afunc` is scheduled with `args` arguments and `kwargs` keyword arguments
+        as an `asyncio.Task` that is executed after `delay` seconds.
+
+        Parameters
+        ----------
+        delay
+            Delay in seconds.
+        afunc
+            Coroutine function to schedule.
+        *args
+            Arguments to be passed to `afunc`.
+        **kwargs
+            Keyword arguments to be passed to `afunc`
+
+        Returns
+        -------
+            The None
+
+        Raises
+        ------
+        AsyncTaskGroupClosedError
+            If the task group is closed.
+        """
+        self.call_soon(_delayed(afunc, delay), *args, **kwargs)
+
+    def close(self) -> None:
+        """Closes the task group so that no new tasks can be scheduled.
+
+        Existing tasks continue to run.
+        """
+        self.closed = True
+
+    async def stop(self) -> None:
+        """Close the group and stop all currently running tasks.
+
+        Closes the task group and cancels all tasks. All tasks are cancelled
+        an additional time for each time this task is cancelled.
+        """
+        self.close()
+
+        current_task = asyncio.current_task(self._get_loop())
+        err = None
+        while tasks_to_stop := (self._ongoing_tasks - {current_task}):
+            for task in tasks_to_stop:
+                task.cancel()
+            try:
+                await asyncio.wait(tasks_to_stop)
+            except asyncio.CancelledError as e:
+                err = e
+
+        if err is not None:
+            raise err
+
+    def __len__(self):
+        return len(self._ongoing_tasks)

--- a/distributed/active_memory_manager.py
+++ b/distributed/active_memory_manager.py
@@ -110,7 +110,7 @@ class ActiveMemoryManagerExtension:
         self.measure = measure
 
         if register:
-            scheduler.handlers["amm_handler"] = self.amm_handler
+            scheduler.server.handlers["amm_handler"] = self.amm_handler
 
         if interval is None:
             interval = parse_timedelta(

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -49,7 +49,7 @@ from dask.utils import (
 )
 from dask.widgets import get_template
 
-from distributed.core import ErrorMessage, OKMessage, Server
+from distributed.core import OKMessage, Server
 from distributed.protocol.serialize import _is_dumpable
 from distributed.utils import Deadline, wait_for
 

--- a/distributed/event.py
+++ b/distributed/event.py
@@ -50,7 +50,7 @@ class EventExtension:
         # we can remove the event
         self._waiter_count = defaultdict(int)
 
-        self.scheduler.handlers.update(
+        self.scheduler.server.handlers.update(
             {
                 "event_wait": self.event_wait,
                 "event_set": self.event_set,

--- a/distributed/http/scheduler/json.py
+++ b/distributed/http/scheduler/json.py
@@ -55,7 +55,7 @@ class CountsJSON(RequestHandler):
 
 class IdentityJSON(RequestHandler):
     def get(self):
-        self.write(self.server.identity())
+        self.write(self.identity())
 
 
 class IndexJSON(RequestHandler):

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -27,7 +27,7 @@ class LockExtension:
         self.events = defaultdict(deque)
         self.ids = dict()
 
-        self.scheduler.handlers.update(
+        self.scheduler.server.handlers.update(
             {"lock_acquire": self.acquire, "lock_release": self.release}
         )
 

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -86,6 +86,8 @@ class Node:
 
     _event_finished: asyncio.Event
 
+    _is_finalizing: staticmethod[[], bool] = staticmethod(sys.is_finalizing)
+
     def __init__(
         self,
         local_directory=None,

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -1,32 +1,281 @@
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import ssl
+import sys
+import tempfile
+import threading
 import warnings
 import weakref
+from collections import defaultdict, deque
+from collections.abc import Container, Coroutine, Hashable
 from contextlib import suppress
+from functools import wraps
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, final
 
 import tlz
 from tornado.httpserver import HTTPServer
+from tornado.ioloop import IOLoop
 
 import dask
+from dask.utils import parse_timedelta
 
+from distributed import profile
+from distributed._async_taskgroup import AsyncTaskGroup
 from distributed.comm import get_address_host, get_tcp_server_addresses
-from distributed.core import Server
+from distributed.compatibility import PeriodicCallback
+from distributed.core import Server, Status
+from distributed.counter import Counter
+from distributed.diskutils import WorkDir, WorkSpace
 from distributed.http.routing import RoutingApplication
-from distributed.utils import DequeHandler, clean_dashboard_address
+from distributed.metrics import context_meter, time
+from distributed.system_monitor import SystemMonitor
+from distributed.utils import (
+    DequeHandler,
+    clean_dashboard_address,
+    import_file,
+    offload,
+    recursive_to_dict,
+    wait_for,
+    warn_on_duration,
+)
 from distributed.versions import get_versions
 
+if TYPE_CHECKING:
+    from typing_extensions import ParamSpec
 
-class ServerNode(Server):
-    """
-    Base class for server nodes in a distributed cluster.
-    """
+    from distributed.counter import Digest
 
-    # TODO factor out security, listening, services, etc. here
+    P = ParamSpec("P")
+    R = TypeVar("R")
+    T = TypeVar("T")
+    Coro = Coroutine[Any, Any, T]
 
-    # XXX avoid inheriting from Server? there is some large potential for confusion
-    # between base and derived attribute namespaces...
+
+logger = logging.getLogger(__name__)
+tick_maximum_delay = parse_timedelta(
+    dask.config.get("distributed.admin.tick.limit"), default="ms"
+)
+
+
+class Node:
+    _startup_lock: asyncio.Lock
+    __startup_exc: Exception | None
+    local_directory: str
+    monitor: SystemMonitor
+
+    periodic_callbacks: dict[str, PeriodicCallback]
+    digests: defaultdict[Hashable, Digest] | None
+    digests_total: defaultdict[Hashable, float]
+    digests_total_since_heartbeat: defaultdict[Hashable, float]
+    digests_max: defaultdict[Hashable, float]
+
+    _last_tick: float
+    _tick_counter: int
+    _last_tick_counter: int
+    _tick_interval: float
+    _tick_interval_observed: float
+
+    _original_local_dir: str
+    _updated_sys_path: bool
+    _workspace: WorkSpace
+    _workdir: None | WorkDir
+    _ongoing_background_tasks: AsyncTaskGroup
+
+    _event_finished: asyncio.Event
+
+    def __init__(
+        self,
+        local_directory=None,
+        needs_workdir=True,
+    ):
+        if local_directory is None:
+            local_directory = (
+                dask.config.get("temporary-directory") or tempfile.gettempdir()
+            )
+
+        if "dask-scratch-space" not in str(local_directory):
+            local_directory = os.path.join(local_directory, "dask-scratch-space")
+        self.monitor = SystemMonitor()
+
+        self._original_local_dir = local_directory
+        self._ongoing_background_tasks = AsyncTaskGroup()
+        with warn_on_duration(
+            "1s",
+            "Creating scratch directories is taking a surprisingly long time. ({duration:.2f}s) "
+            "This is often due to running workers on a network file system. "
+            "Consider specifying a local-directory to point workers to write "
+            "scratch data to a local disk.",
+        ):
+            self._workspace = WorkSpace(local_directory)
+
+            if not needs_workdir:  # eg. Nanny will not need a WorkDir
+                self._workdir = None
+                self.local_directory = self._workspace.base_dir
+            else:
+                name = type(self).__name__.lower()
+                self._workdir = self._workspace.new_work_dir(prefix=f"{name}-")
+                self.local_directory = self._workdir.dir_path
+
+        self._updated_sys_path = False
+        if self.local_directory not in sys.path:
+            sys.path.insert(0, self.local_directory)
+            self._updated_sys_path = True
+
+        self.io_loop = self.loop = IOLoop.current()
+
+        if not hasattr(self.io_loop, "profile"):
+            if dask.config.get("distributed.worker.profile.enabled"):
+                ref = weakref.ref(self.io_loop)
+
+                def stop() -> bool:
+                    loop = ref()
+                    return loop is None or loop.asyncio_loop.is_closed()
+
+                self.io_loop.profile = profile.watch(
+                    omit=("profile.py", "selectors.py"),
+                    interval=dask.config.get("distributed.worker.profile.interval"),
+                    cycle=dask.config.get("distributed.worker.profile.cycle"),
+                    stop=stop,
+                )
+            else:
+                self.io_loop.profile = deque()
+
+        self.periodic_callbacks = {}
+
+        # Statistics counters for various events
+        try:
+            from distributed.counter import Digest
+
+            self.digests = defaultdict(Digest)
+        except ImportError:
+            self.digests = None
+
+        # Also log cumulative totals (reset at server restart)
+        # and local maximums (reset by prometheus poll)
+        # Don't cast int metrics to float
+        self.digests_total = defaultdict(int)
+        self.digests_total_since_heartbeat = defaultdict(int)
+        self.digests_max = defaultdict(int)
+
+        self.counters = defaultdict(Counter)
+        pc = PeriodicCallback(self._shift_counters, 5000)
+        self.periodic_callbacks["shift_counters"] = pc
+
+        pc = PeriodicCallback(
+            self.monitor.update,
+            parse_timedelta(
+                dask.config.get("distributed.admin.system-monitor.interval")
+            )
+            * 1000,
+        )
+        self.periodic_callbacks["monitor"] = pc
+
+        self.__startup_exc = None
+        self._startup_lock = asyncio.Lock()
+
+        self._last_tick = time()
+        self._tick_counter = 0
+        self._last_tick_counter = 0
+        self._last_tick_cycle = time()
+        self._tick_interval = parse_timedelta(
+            dask.config.get("distributed.admin.tick.interval"), default="ms"
+        )
+        self._tick_interval_observed = self._tick_interval
+        self.periodic_callbacks["tick"] = PeriodicCallback(
+            self._measure_tick, self._tick_interval * 1000
+        )
+        self.periodic_callbacks["ticks"] = PeriodicCallback(
+            self._cycle_ticks,
+            parse_timedelta(dask.config.get("distributed.admin.tick.cycle")) * 1000,
+        )
+
+        self.thread_id = 0
+
+        def set_thread_ident():
+            self.thread_id = threading.get_ident()
+
+        self.io_loop.add_callback(set_thread_ident)
+        self.status = Status.init
+
+    def __await__(self):
+        async def _():
+            await self.start()
+            return self
+
+        return _().__await__()
+
+    async def __aenter__(self):
+        await self
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.close()
+
+    async def close(self, reason: str | None = None) -> None:
+        for pc in self.periodic_callbacks.values():
+            pc.stop()
+
+        self.monitor.close()
+        await self._ongoing_background_tasks.stop()
+        if self._workdir is not None:
+            self._workdir.release()
+
+        # Remove scratch directory from global sys.path
+        if self._updated_sys_path and sys.path[0] == self.local_directory:
+            sys.path.remove(self.local_directory)
+
+    async def upload_file(
+        self, filename: str, data: str | bytes, load: bool = True
+    ) -> dict[str, Any]:
+        out_filename = os.path.join(self.local_directory, filename)
+
+        def func(data):
+            if isinstance(data, str):
+                data = data.encode()
+            with open(out_filename, "wb") as f:
+                f.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            return data
+
+        if len(data) < 10000:
+            data = func(data)
+        else:
+            data = await offload(func, data)
+
+        if load:
+            try:
+                import_file(out_filename)
+            except Exception as e:
+                logger.exception(e)
+                raise e
+
+        return {"status": "OK", "nbytes": len(data)}
+
+    def _shift_counters(self):
+        for counter in self.counters.values():
+            counter.shift()
+        if self.digests is not None:
+            for digest in self.digests.values():
+                digest.shift()
+
+    def start_periodic_callbacks(self):
+        """Start Periodic Callbacks consistently
+
+        This starts all PeriodicCallbacks stored in self.periodic_callbacks if
+        they are not yet running. It does this safely by checking that it is using the
+        correct event loop.
+        """
+        if self.io_loop.asyncio_loop is not asyncio.get_running_loop():
+            raise RuntimeError(f"{self!r} is bound to a different event loop")
+
+        self._last_tick = time()
+        for pc in self.periodic_callbacks.values():
+            if not pc.is_running():
+                pc.start()
 
     def versions(self, packages=None):
         return get_versions(packages=packages)
@@ -184,3 +433,224 @@ class ServerNode(Server):
                     "Perhaps you already have a cluster running?\n"
                     f"Hosting the HTTP server on port {actual} instead"
                 )
+
+    def _measure_tick(self):
+        now = time()
+        tick_duration = now - self._last_tick
+        self._last_tick = now
+        self._tick_counter += 1
+        # This metric is exposed in Prometheus and is reset there during
+        # collection
+        if tick_duration > tick_maximum_delay:
+            logger.info(
+                "Event loop was unresponsive in %s for %.2fs.  "
+                "This is often caused by long-running GIL-holding "
+                "functions or moving large chunks of data. "
+                "This can cause timeouts and instability.",
+                type(self).__name__,
+                tick_duration,
+            )
+        self.digest_metric("tick-duration", tick_duration)
+
+    def _cycle_ticks(self):
+        if not self._tick_counter:
+            return
+        now = time()
+        last_tick_cycle, self._last_tick_cycle = self._last_tick_cycle, now
+        count = self._tick_counter - self._last_tick_counter
+        self._last_tick_counter = self._tick_counter
+        self._tick_interval_observed = (now - last_tick_cycle) / (count or 1)
+
+    def digest_metric(self, name: Hashable, value: float) -> None:
+        # Granular data (requires crick)
+        if self.digests is not None:
+            self.digests[name].add(value)
+        # Cumulative data (reset by server restart)
+        self.digests_total[name] += value
+        # Cumulative data sent to scheduler and reset on heartbeat
+        self.digests_total_since_heartbeat[name] += value
+        # Local maximums (reset by Prometheus poll)
+        self.digests_max[name] = max(self.digests_max[name], value)
+
+    @property
+    def status(self) -> Status:
+        try:
+            return self._status
+        except AttributeError:
+            return Status.undefined
+
+    @status.setter
+    def status(self, value: Status) -> None:
+        if not isinstance(value, Status):
+            raise TypeError(f"Expected Status; got {value!r}")
+        self._status = value
+
+    async def start_unsafe(self):
+        """Attempt to start the server. This is not idempotent and not protected against concurrent startup attempts.
+
+        This is intended to be overwritten or called by subclasses. For a safe
+        startup, please use ``Node.start`` instead.
+
+        If ``death_timeout`` is configured, we will require this coroutine to
+        finish before this timeout is reached. If the timeout is reached we will
+        close the instance and raise an ``asyncio.TimeoutError``
+        """
+        return self
+
+    @final
+    async def start(self):
+        async with self._startup_lock:
+            if self.status == Status.failed:
+                assert self.__startup_exc is not None
+                raise self.__startup_exc
+            elif self.status != Status.init:
+                return self
+            timeout = getattr(self, "death_timeout", None)
+
+            async def _close_on_failure(exc: Exception) -> None:
+                await self.close(reason=f"failure-to-start-{str(type(exc))}")
+                self.status = Status.failed
+                self.__startup_exc = exc
+
+            try:
+                await wait_for(self.start_unsafe(), timeout=timeout)
+            except asyncio.TimeoutError as exc:
+                await _close_on_failure(exc)
+                raise asyncio.TimeoutError(
+                    f"{type(self).__name__} start timed out after {timeout}s."
+                ) from exc
+            except Exception as exc:
+                await _close_on_failure(exc)
+                raise RuntimeError(f"{type(self).__name__} failed to start.") from exc
+            if self.status == Status.init:
+                self.status = Status.running
+        return self
+
+
+class ServerNode(Node):
+    def __init__(
+        self,
+        handlers,
+        blocked_handlers=None,
+        stream_handlers=None,
+        connection_limit=512,
+        deserialize=True,
+        serializers=None,
+        deserializers=None,
+        connection_args=None,
+        timeout=None,
+        local_directory=None,
+        needs_workdir=True,
+    ):
+        self._event_finished = asyncio.Event()
+
+        _handlers = {
+            "dump_state": self._to_dict,
+            "identity": self.identity,
+        }
+        if handlers:
+            _handlers.update(handlers)
+        import uuid
+
+        self.id = type(self).__name__ + "-" + str(uuid.uuid4())
+
+        if blocked_handlers is None:
+            blocked_handlers = dask.config.get(
+                "distributed.%s.blocked-handlers" % type(self).__name__.lower(), []
+            )
+        self.server = Server(
+            handlers=_handlers,
+            blocked_handlers=blocked_handlers,
+            stream_handlers=stream_handlers,
+            connection_limit=connection_limit,
+            deserialize=deserialize,
+            serializers=serializers,
+            deserializers=deserializers,
+            connection_args=connection_args,
+            timeout=timeout,
+        )
+        super().__init__(
+            local_directory=local_directory,
+            needs_workdir=needs_workdir,
+        )
+
+    def identity(self) -> dict[str, str]:
+        return {"type": type(self).__name__, "id": self.id}
+
+    @property
+    def port(self):
+        return self.server.port
+
+    @property
+    def listen_address(self):
+        return self.server.address
+
+    @property
+    def address(self):
+        return self.server.address
+
+    @property
+    def address_safe(self):
+        return self.server.address_safe
+
+    async def start_unsafe(self):
+        await self.server
+        await super().start_unsafe()
+        return self
+
+    async def finished(self) -> None:
+        """Wait until the server has finished"""
+        await self._event_finished.wait()
+
+    async def close(self, reason: str | None = None) -> None:
+        try:
+            # Close network connections and background tasks
+            await self.server.close()
+            await Node.close(self, reason=reason)
+            self.status = Status.closed
+        finally:
+            self._event_finished.set()
+
+    def _to_dict(self, *, exclude: Container[str] = ()) -> dict[str, Any]:
+        """Dictionary representation for debugging purposes.
+        Not type stable and not intended for roundtrips.
+
+        See also
+        --------
+        Server.identity
+        Client.dump_cluster_state
+        distributed.utils.recursive_to_dict
+        """
+        info: dict[str, Any] = self.identity()
+        extra = {
+            "address": self.server.address,
+            "status": self.status.name,
+            "thread_id": self.thread_id,
+        }
+        info.update(extra)
+        info = {k: v for k, v in info.items() if k not in exclude}
+        return recursive_to_dict(info, exclude=exclude)
+
+
+def context_meter_to_node_digest(digest_tag: str) -> Callable:
+    """Decorator for an async method of a Node subclass that calls
+    ``distributed.metrics.context_meter.meter`` and/or ``digest_metric``.
+    It routes the calls from ``context_meter.digest_metric(label, value, unit)`` to
+    ``Node.digest_metric((digest_tag, label, unit), value)``.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        async def wrapper(self: Node, *args: Any, **kwargs: Any) -> Any:
+            def metrics_callback(label: Hashable, value: float, unit: str) -> None:
+                if not isinstance(label, tuple):
+                    label = (label,)
+                name = (digest_tag, *label, unit)
+                self.digest_metric(name, value)
+
+            with context_meter.add_callback(metrics_callback, allow_offload=True):
+                return await func(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -15,7 +15,7 @@ import click
 
 from dask.utils import tmpfile
 
-from distributed.core import Server
+from distributed.node import ServerNode
 from distributed.utils import import_file
 
 if TYPE_CHECKING:
@@ -167,7 +167,7 @@ class Preload:
         Path of a directory where files should be copied
     """
 
-    dask_object: Server | Client
+    dask_object: ServerNode | Client
     name: str
     argv: list[str]
     file_dir: str | None
@@ -175,7 +175,7 @@ class Preload:
 
     def __init__(
         self,
-        dask_object: Server | Client,
+        dask_object: ServerNode | Client,
         name: str,
         argv: Iterable[str],
         file_dir: str | None,
@@ -250,7 +250,7 @@ class PreloadManager(Sequence[Preload]):
 
 
 def process_preloads(
-    dask_server: Server | Client,
+    dask_server: ServerNode | Client,
     preload: str | list[str],
     preload_argv: list[str] | list[list[str]],
     *,

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -33,8 +33,8 @@ class PublishExtension:
             "publish_flush_batched_send": self.flush_receive,
         }
 
-        self.scheduler.handlers.update(handlers)
-        self.scheduler.stream_handlers.update(stream_handlers)
+        self.scheduler.server.handlers.update(handlers)
+        self.scheduler.server.stream_handlers.update(stream_handlers)
         self._flush_received = defaultdict(asyncio.Event)
 
     def flush_receive(self, uid, **kwargs):

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -27,7 +27,7 @@ class PubSubSchedulerExtension:
 
         self.scheduler.handlers.update({"pubsub_add_publisher": self.add_publisher})
 
-        self.scheduler.stream_handlers.update(
+        self.scheduler.server.stream_handlers.update(
             {
                 "pubsub-add-subscriber": self.add_subscriber,
                 "pubsub-remove-publisher": self.remove_publisher,
@@ -122,7 +122,7 @@ class PubSubWorkerExtension:
 
     def __init__(self, worker):
         self.worker = worker
-        self.worker.stream_handlers.update(
+        self.worker.server.stream_handlers.update(
             {
                 "pubsub-add-subscriber": self.add_subscriber,
                 "pubsub-remove-subscriber": self.remove_subscriber,

--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -175,7 +175,7 @@ class PubSubClientExtension:
 
     def __init__(self, client):
         self.client = client
-        self.client._stream_handlers.update({"pubsub-msg": self.handle_message})
+        self.client.server.stream_handlers.update({"pubsub-msg": self.handle_message})
 
         self.subscribers = defaultdict(weakref.WeakSet)
 

--- a/distributed/queues.py
+++ b/distributed/queues.py
@@ -32,7 +32,7 @@ class QueueExtension:
         self.client_refcount = dict()
         self.future_refcount = defaultdict(int)
 
-        self.scheduler.handlers.update(
+        self.scheduler.server.handlers.update(
             {
                 "queue_create": self.create,
                 "queue_put": self.put,
@@ -41,7 +41,7 @@ class QueueExtension:
             }
         )
 
-        self.scheduler.stream_handlers.update(
+        self.scheduler.server.stream_handlers.update(
             {"queue-future-release": self.future_release, "queue_release": self.release}
         )
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6197,8 +6197,10 @@ class Scheduler(SchedulerState, ServerNode):
             await asyncio.sleep(0.1)
 
         assert isinstance(data, dict)
-
-        keys, who_has, nbytes = await scatter_to_workers(wss, data, rpc=self.server.rpc)
+        workers = list(ws.address for ws in wss)
+        keys, who_has, nbytes = await scatter_to_workers(
+            workers, data, rpc=self.server.rpc
+        )
 
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -50,7 +50,6 @@ from tlz import (
     valmap,
 )
 from tornado.ioloop import IOLoop
-from typing_extensions import Self
 
 import dask
 import dask.utils
@@ -6199,9 +6198,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         assert isinstance(data, dict)
 
-        keys, who_has, nbytes = await scatter_to_workers(
-            nthreads, data, rpc=self.server.rpc
-        )
+        keys, who_has, nbytes = await scatter_to_workers(wss, data, rpc=self.server.rpc)
 
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 

--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -406,7 +406,7 @@ def get_worker_plugin() -> ShuffleWorkerPlugin:
         return worker.plugins["shuffle"]  # type: ignore
     except KeyError as e:
         raise RuntimeError(
-            f"The worker {worker.address} does not have a P2P shuffle plugin."
+            f"The worker {worker.server.address} does not have a P2P shuffle plugin."
         ) from e
 
 

--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -789,7 +789,7 @@ class ArrayRechunkSpec(ShuffleSpec[NDIndex]):
             ),
             executor=plugin._executor,
             local_address=plugin.worker.address,
-            rpc=plugin.worker.rpc,
+            rpc=plugin.worker.server.rpc,
             digest_metric=plugin.worker.digest_metric,
             scheduler=plugin.worker.scheduler,
             memory_limiter_disk=plugin.memory_limiter_disk,

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -594,8 +594,8 @@ class DataFrameShuffleSpec(ShuffleSpec[int]):
                 f"shuffle-{self.id}-{run_id}",
             ),
             executor=plugin._executor,
-            local_address=plugin.worker.address,
-            rpc=plugin.worker.rpc,
+            local_address=plugin.worker.server.address,
+            rpc=plugin.worker.server.rpc,
             digest_metric=plugin.worker.digest_metric,
             scheduler=plugin.worker.scheduler,
             memory_limiter_disk=plugin.memory_limiter_disk

--- a/distributed/shuffle/_worker_plugin.py
+++ b/distributed/shuffle/_worker_plugin.py
@@ -189,13 +189,13 @@ class _ShuffleRunManager:
         if spec is None:
             response = await self._plugin.worker.scheduler.shuffle_get(
                 id=shuffle_id,
-                worker=self._plugin.worker.address,
+                worker=self._plugin.worker.server.address,
             )
         else:
             response = await self._plugin.worker.scheduler.shuffle_get_or_create(
                 spec=ToPickle(spec),
                 key=key,
-                worker=self._plugin.worker.address,
+                worker=self._plugin.worker.server.address,
             )
 
         status = response["status"]
@@ -277,9 +277,9 @@ class ShuffleWorkerPlugin(WorkerPlugin):
 
     def setup(self, worker: Worker) -> None:
         # Attach to worker
-        worker.handlers["shuffle_receive"] = self.shuffle_receive
-        worker.handlers["shuffle_inputs_done"] = self.shuffle_inputs_done
-        worker.stream_handlers["shuffle-fail"] = self.shuffle_fail
+        worker.server.handlers["shuffle_receive"] = self.shuffle_receive
+        worker.server.handlers["shuffle_inputs_done"] = self.shuffle_inputs_done
+        worker.server.stream_handlers["shuffle-fail"] = self.shuffle_fail
         worker.extensions["shuffle"] = self
 
         # Initialize
@@ -295,10 +295,10 @@ class ShuffleWorkerPlugin(WorkerPlugin):
         self._executor = ThreadPoolExecutor(self.worker.state.nthreads)
 
     def __str__(self) -> str:
-        return f"ShuffleWorkerPlugin on {self.worker.address}"
+        return f"ShuffleWorkerPlugin on {self.worker}"
 
     def __repr__(self) -> str:
-        return f"<ShuffleWorkerPlugin, worker={self.worker.address_safe!r}, closed={self.closed}>"
+        return f"<ShuffleWorkerPlugin, worker={self.worker!r}, closed={self.closed}>"
 
     # Handlers
     ##########

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -116,7 +116,7 @@ class WorkStealing(SchedulerPlugin):
             "request_cost_total": defaultdict(int),
         }
         self._request_counter = 0
-        self.scheduler.stream_handlers["steal-response"] = self.move_task_confirm
+        self.scheduler.server.stream_handlers["steal-response"] = self.move_task_confirm
 
     async def start(self, scheduler: Any = None) -> None:
         """Start the background coroutine to balance the tasks on the cluster.

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -4025,7 +4025,7 @@ async def test_get_versions_async(c, s, a, b):
 
 @gen_cluster(client=True, config={"distributed.comm.timeouts.connect": "200ms"})
 async def test_get_versions_rpc_error(c, s, a, b):
-    a.stop()
+    a.server.stop()
     v = await c.get_versions()
     assert v.keys() == {"scheduler", "client", "workers"}
     assert v["workers"].keys() == {b.address}

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -78,7 +78,6 @@ async def test_nanny_process_failure(c, s):
     assert not os.path.exists(second_dir)
     assert not os.path.exists(first_dir)
     assert first_dir != n.worker_dir
-    s.stop()
 
 
 @gen_cluster(nthreads=[])
@@ -202,10 +201,9 @@ async def test_worker_uses_same_host_as_nanny(c, s):
 @gen_test()
 async def test_scheduler_file():
     with tmpfile() as fn:
-        s = await Scheduler(scheduler_file=fn, dashboard_address=":0")
-        async with Nanny(scheduler_file=fn) as n:
-            assert set(s.workers) == {n.worker_address}
-        s.stop()
+        async with Scheduler(scheduler_file=fn, dashboard_address=":0") as s:
+            async with Nanny(scheduler_file=fn) as n:
+                assert set(s.workers) == {n.worker_address}
 
 
 @pytest.mark.xfail(

--- a/distributed/tests/test_node.py
+++ b/distributed/tests/test_node.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+
+import pytest
+
+from distributed.core import Status
+from distributed.node import Node
+from distributed.utils_test import captured_logger, gen_cluster, gen_test
+
+
+@gen_test(config={"distributed.admin.system-monitor.gil.enabled": True})
+async def test_server_close_stops_gil_monitoring():
+    pytest.importorskip("gilknocker")
+
+    node = Node()
+    assert node.monitor._gilknocker.is_running
+    await node.close()
+    assert not node.monitor._gilknocker.is_running
+
+
+@gen_test()
+async def test_server_sys_path_local_directory_cleanup(tmp_path, monkeypatch):
+    local_directory = str(tmp_path / "dask-scratch-space")
+
+    # Ensure `local_directory` is removed from `sys.path` as part of the
+    # `Server` shutdown process
+    assert not any(i.startswith(local_directory) for i in sys.path)
+    async with Node(local_directory=local_directory):
+        assert sys.path[0].startswith(local_directory)
+    assert not any(i.startswith(local_directory) for i in sys.path)
+
+    # Ensure `local_directory` isn't removed from `sys.path` if it
+    # was already there before the `Server` started
+    monkeypatch.setattr("sys.path", [local_directory] + sys.path)
+    assert sys.path[0].startswith(local_directory)
+    # NOTE: `needs_workdir=False` is needed to make sure the same path added
+    # to `sys.path` above is used by the `Server` (a subdirectory is created
+    # by default).
+    async with Node(local_directory=local_directory, needs_workdir=False):
+        assert sys.path[0].startswith(local_directory)
+    assert sys.path[0].startswith(local_directory)
+
+
+@gen_test()
+async def test_server_status_is_always_enum():
+    """Assignments with strings is forbidden"""
+    server = Node()
+    assert isinstance(server.status, Status)
+    assert server.status != Status.stopped
+    server.status = Status.stopped
+    assert server.status == Status.stopped
+    with pytest.raises(TypeError):
+        server.status = "running"
+
+
+@gen_test()
+async def test_server_assign_assign_enum_is_quiet():
+    """That would be the default in user code"""
+    node = Node()
+    node.status = Status.running
+
+
+@gen_test()
+async def test_server_status_compare_enum_is_quiet():
+    """That would be the default in user code"""
+    node = Node()
+    # Note: We only want to assert that this comparison does not
+    # raise an error/warning. We do not want to assert its result.
+    node.status == Status.running  # noqa: B015
+
+
+@gen_cluster(config={"distributed.admin.tick.interval": "20 ms"})
+async def test_ticks(s, a, b):
+    pytest.importorskip("crick")
+    await asyncio.sleep(0.1)
+    c = s.digests["tick-duration"]
+    assert c.size()
+    assert 0.01 < c.components[0].quantile(0.5) < 0.5
+
+
+@gen_cluster(config={"distributed.admin.tick.interval": "20 ms"})
+async def test_tick_logging(s, a, b):
+    pytest.importorskip("crick")
+    from distributed import node
+
+    old = node.tick_maximum_delay
+    node.tick_maximum_delay = 0.001
+    try:
+        with captured_logger("distributed.core") as sio:
+            await asyncio.sleep(0.1)
+
+        text = sio.getvalue()
+        assert "unresponsive" in text
+        assert "Scheduler" in text or "Worker" in text
+    finally:
+        node.tick_maximum_delay = old
+
+
+@gen_cluster()
+async def test_thread_id(s, a, b):
+    assert s.thread_id == a.thread_id == b.thread_id == threading.get_ident()

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -796,7 +796,7 @@ async def start_cluster(
     ):
         await asyncio.sleep(0.01)
         if time() > start + 30:
-            await asyncio.gather(*(w.close(timeout=1) for w in workers))
+            await asyncio.gather(*(w.close() for w in workers))
             await s.close()
             check_invalid_worker_transitions(s)
             check_invalid_task_states(s)
@@ -857,7 +857,6 @@ async def end_cluster(s, workers):
 
     await asyncio.gather(*(end_worker(w) for w in workers))
     await s.close()  # wait until scheduler stops completely
-    s.stop()
     check_invalid_worker_transitions(s)
     check_invalid_task_states(s)
     check_worker_fail_hard(s)

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -39,8 +39,10 @@ class VariableExtension:
             {"variable_set": self.set, "variable_get": self.get}
         )
 
-        self.scheduler.stream_handlers["variable-future-release"] = self.future_release
-        self.scheduler.stream_handlers["variable_delete"] = self.delete
+        self.scheduler.server.stream_handlers[
+            "variable-future-release"
+        ] = self.future_release
+        self.scheduler.server.stream_handlers["variable_delete"] = self.delete
 
     async def set(self, name=None, key=None, data=None, client=None):
         if key is not None:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -43,7 +43,6 @@ from typing import (
 
 from tlz import keymap, pluck
 from tornado.ioloop import IOLoop
-from typing_extensions import Self
 
 import dask
 from dask.core import istask
@@ -153,7 +152,7 @@ from distributed.worker_state_machine import (
 
 if TYPE_CHECKING:
     # FIXME import from typing (needs Python >=3.10)
-    from typing_extensions import ParamSpec
+    from typing_extensions import ParamSpec, Self
 
     # Circular imports
     from distributed.client import Client


### PR DESCRIPTION
I was thinking a little more about how https://github.com/dask/distributed/pull/8430 could be used and ended up wanting to use this for the client as well.

(This is also loosely motivated by https://github.com/dask-contrib/dask-expr/pull/765 where I suggested to move the key generation / tokenization from client to scheduler where the ordered sendrcv of https://github.com/dask/distributed/pull/8430 would be nice)

The client unfortunately re-implements the RPC stream handler of the server base class making it hard to reuse the ordered sendrcv without a lot of code duplication.

This PR suggests a refactoring where I propose to move from inheritance to composition regarding the `Server` networking and RPC logic. The current `Server` base class is mixing a lot of application logic with networking logic which in the past frequently caused issues during teardown so separation of those concerns is long overdue.

The `Server` as proposed in this PR should likely rather be called `RPCServer` or `RPCSomethingElse` since it doesn't actually implement a traditional server<->client model but I'm trying to not get hung up on naming at this point.

With this decomposition I was then able to use the slimmed down `Server` in the client as well which opens up the reuse of smth like #8430 
This refactoring is not really done but if we go down this road, the universally used `ConnectionPool` and `stream_comms` would basically blend into this single object which would support three ways to communicate

1. One way communication, send only, ordered / multiplexed (what we currently do with BatchedSend)
2. Two way send_recv, not ordered, dedicated channel (what is currently the PooledRPCCall)
3. Two way send_decv, ordered, multiplexed (this is new)


State of this PR: Mostly working but still a couple of failing tests. From what I saw nothing insurmountable.

There are two commits
- https://github.com/dask/distributed/pull/8468/commits/efb904580c1d29628bff605fb8ff651da9979b20 which decomposes the Server class and refactors a couple of modules
- https://github.com/dask/distributed/pull/8468/commits/395fcc234c09da7b7c76b9e5a18f8dc60a0af12f which applies this decomposition to the Client

I think I'm mostly interested in feedback about the first one since that may have merit without the introduction of new features