### PR TITLE
pandas 2.2.0: Deprecated frequency alias `M` in favor of `ME`

### DIFF
--- a/distributed/tests/test_dask_collections.py
+++ b/distributed/tests/test_dask_collections.py
@@ -145,7 +145,7 @@ def test_dataframe_set_index_sync(wait, client):
         start="2000",
         end="2001",
         dtypes={"value": float, "name": str, "id": int},
-        freq="2H",
+        freq="2h",
         partition_freq=f"1{partition_freq_unit}",
         seed=1,
     )

--- a/distributed/tests/test_dask_collections.py
+++ b/distributed/tests/test_dask_collections.py
@@ -144,7 +144,7 @@ def test_dataframe_set_index_sync(wait, client):
         end="2001",
         dtypes={"value": float, "name": str, "id": int},
         freq="2H",
-        partition_freq="1M",
+        partition_freq="1ME",
         seed=1,
     )
     df = df.persist()

--- a/distributed/tests/test_dask_collections.py
+++ b/distributed/tests/test_dask_collections.py
@@ -11,6 +11,7 @@ from pandas.testing import assert_frame_equal, assert_index_equal, assert_series
 import dask
 import dask.bag as db
 import dask.dataframe as dd
+from dask.dataframe._compat import PANDAS_GE_220
 
 from distributed.client import wait
 from distributed.nanny import Nanny
@@ -139,12 +140,13 @@ async def test_bag_groupby_key_hashing(c, s, a, b):
 
 @pytest.mark.parametrize("wait", [wait, lambda x: None])
 def test_dataframe_set_index_sync(wait, client):
+    partition_freq_unit = "ME" if PANDAS_GE_220 else "M"
     df = dask.datasets.timeseries(
         start="2000",
         end="2001",
         dtypes={"value": float, "name": str, "id": int},
         freq="2H",
-        partition_freq="1ME",
+        partition_freq=f"1{partition_freq_unit}",
         seed=1,
     )
     df = df.persist()


### PR DESCRIPTION
https://pandas.pydata.org/docs/whatsnew/v2.2.0.html#deprecate-aliases-m-q-y-etc-in-favour-of-me-qe-ye-etc-for-offsets

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
