### PR TITLE
Deprecations in scipy 1.12

### DIFF
--- a/distributed/protocol/scipy.py
+++ b/distributed/protocol/scipy.py
@@ -14,7 +14,7 @@ from distributed.protocol.serialize import (
 register_generic(scipy.sparse.spmatrix, "dask", dask_serialize, dask_deserialize)
 
 
-@dask_serialize.register(scipy.sparse.dok.dok_matrix)
+@dask_serialize.register(scipy.sparse.dok_matrix)
 def serialize_scipy_sparse_dok(x):
     coo_header, coo_frames = dask_serialize(x.tocoo())
 
@@ -24,7 +24,7 @@ def serialize_scipy_sparse_dok(x):
     return header, frames
 
 
-@dask_deserialize.register(scipy.sparse.dok.dok_matrix)
+@dask_deserialize.register(scipy.sparse.dok_matrix)
 def deserialize_scipy_sparse_dok(header, frames):
     coo_header = header["coo_header"]
     coo_frames = frames


### PR DESCRIPTION
Manually tested green vs. scipy 1.5.2 (minimum version stated in dask/dask install.rst)