### PR TITLE
pandas 2.2 vs. pyarrow 14: deprecated DatetimeTZBlock

### DIFF
--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1038,6 +1038,7 @@ async def test_heartbeat(c, s, a, b):
     await check_scheduler_cleanup(s)
 
 
+@pytest.mark.filterwarnings("ignore:DatetimeTZBlock")  # pandas >=2.2 vs. pyarrow <15
 def test_processing_chain(tmp_path):
     """
     This is a serial version of the entire compute chain


### PR DESCRIPTION
Fix test failure in `distributed/shuffle/tests/test_shuffle::test_processing_chain` with pandas 2.2

```
../../../../../miniforge3/envs/distributed39/lib/python3.9/site-packages/dask/dataframe/backends.py:243: in get_pandas_dataframe_from_pyarrow
    return table.to_pandas(types_mapper=types_mapper, **kwargs)
pyarrow/array.pxi:884: in pyarrow.lib._PandasConvertible.to_pandas
    ???
pyarrow/table.pxi:4192: in pyarrow.lib.Table._to_pandas
    ???
../../../../../miniforge3/envs/distributed39/lib/python3.9/site-packages/pyarrow/pandas_compat.py:776: in table_to_dataframe
    blocks = _table_to_blocks(options, table, categories, ext_columns_dtypes)
../../../../../miniforge3/envs/distributed39/lib/python3.9/site-packages/pyarrow/pandas_compat.py:1131: in _table_to_blocks
    return [_reconstruct_block(item, columns, extension_columns)
../../../../../miniforge3/envs/distributed39/lib/python3.9/site-packages/pyarrow/pandas_compat.py:1131: in <listcomp>
    return [_reconstruct_block(item, columns, extension_columns)
../../../../../miniforge3/envs/distributed39/lib/python3.9/site-packages/pyarrow/pandas_compat.py:722: in _reconstruct_block
    klass=_int.DatetimeTZBlock,

E           DeprecationWarning: DatetimeTZBlock is deprecated and will be removed in a future version. Use public APIs instead.
```
- xref https://github.com/pandas-dev/pandas/pull/55139