### PR TITLE
Upgrade to pytest 8

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4924,7 +4924,10 @@ class Client(SyncMethodMixin):
         )
 
     def register_scheduler_plugin(
-        self, plugin: SchedulerPlugin, name: str | None = None, idempotent: bool = False
+        self,
+        plugin: SchedulerPlugin,
+        name: str | None = None,
+        idempotent: bool | None = None,
     ):
         """
         Register a scheduler plugin.

--- a/distributed/deploy/tests/test_cluster.py
+++ b/distributed/deploy/tests/test_cluster.py
@@ -33,13 +33,6 @@ async def test_repr():
 
 
 @gen_test()
-async def test_logs_deprecated():
-    async with Cluster(asynchronous=True) as cluster:
-        with pytest.warns(FutureWarning, match="get_logs"):
-            cluster.logs()
-
-
-@gen_test()
 async def test_cluster_wait_for_worker():
     async with LocalCluster(n_workers=2, asynchronous=True) as cluster:
         assert len(cluster.scheduler.workers) == 2

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -1057,7 +1057,7 @@ async def test_threads_per_worker_set_to_0():
             n_workers=2, processes=False, threads_per_worker=0, asynchronous=True
         ) as cluster:
             assert len(cluster.workers) == 2
-            assert all(w.nthreads < CPU_COUNT for w in cluster.workers.values())
+            assert all(w.state.nthreads < CPU_COUNT for w in cluster.workers.values())
 
 
 @pytest.mark.parametrize("temporary", [True, False])

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -269,7 +269,7 @@ async def test_spec_process():
 
 
 @gen_test()
-async def test_logs():
+async def test_get_logs():
     worker = {"cls": Worker, "options": {"nthreads": 1}}
     async with SpecCluster(
         asynchronous=True, scheduler=scheduler, worker=worker
@@ -302,6 +302,14 @@ async def test_logs():
         w = toolz.first(cluster.scheduler.workers)
         logs = await cluster.get_logs(cluster=False, scheduler=False, workers=[w])
         assert set(logs) == {w}
+
+
+@gen_test()
+async def test_logs_deprecated():
+    async with SpecCluster(asynchronous=True, scheduler=scheduler) as cluster:
+        with pytest.warns(FutureWarning, match="get_logs"):
+            logs = await cluster.logs()
+    assert logs["Scheduler"]
 
 
 @gen_test()

--- a/distributed/diagnostics/tests/test_nanny_plugin.py
+++ b/distributed/diagnostics/tests/test_nanny_plugin.py
@@ -35,8 +35,12 @@ async def test_register_worker_plugin_typing_over_nanny_keyword(c, s, a):
 
     n_existing_plugins = len(a.plugins)
     assert not hasattr(a, "foo")
-    with pytest.warns(UserWarning, match="`NannyPlugin` as a worker plugin"):
+    with (
+        pytest.warns(UserWarning, match="`NannyPlugin` as a worker plugin"),
+        pytest.warns(DeprecationWarning, match="please use `Client.register_plugin`"),
+    ):
         await c.register_worker_plugin(DuckPlugin(), nanny=False)
+
     assert len(a.plugins) == n_existing_plugins + 1
     assert a.foo == 123
 
@@ -52,7 +56,10 @@ async def test_duck_typed_register_nanny_plugin_is_deprecated(c, s, a):
 
     n_existing_plugins = len(a.plugins)
     assert not hasattr(a, "foo")
-    with pytest.warns(DeprecationWarning, match="duck-typed.*NannyPlugin"):
+    with (
+        pytest.warns(DeprecationWarning, match="duck-typed.*NannyPlugin"),
+        pytest.warns(DeprecationWarning, match="please use `Client.register_plugin`"),
+    ):
         await c.register_worker_plugin(DuckPlugin(), nanny=True)
     assert len(a.plugins) == n_existing_plugins + 1
     assert a.foo == 123

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -603,7 +603,10 @@ async def test_scheduler_plugin_in_register_worker_plugin_overrides(c, s, a):
 
     n_existing_plugins = len(s.plugins)
     assert not hasattr(s, "foo")
-    with pytest.warns(UserWarning, match="`SchedulerPlugin` as a worker plugin"):
+    with (
+        pytest.warns(UserWarning, match="`SchedulerPlugin` as a worker plugin"),
+        pytest.warns(DeprecationWarning, match="use `Client.register_plugin` instead"),
+    ):
         await c.register_worker_plugin(DuckPlugin(), nanny=False)
     assert len(s.plugins) == n_existing_plugins + 1
     assert s.foo == 123
@@ -620,7 +623,10 @@ async def test_scheduler_plugin_in_register_worker_plugin_overrides_nanny(c, s, 
 
     n_existing_plugins = len(s.plugins)
     assert not hasattr(s, "foo")
-    with pytest.warns(UserWarning, match="`SchedulerPlugin` as a nanny plugin"):
+    with (
+        pytest.warns(UserWarning, match="`SchedulerPlugin` as a nanny plugin"),
+        pytest.warns(DeprecationWarning, match="use `Client.register_plugin` instead"),
+    ):
         await c.register_worker_plugin(DuckPlugin(), nanny=True)
     assert len(s.plugins) == n_existing_plugins + 1
     assert s.foo == 123

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -299,7 +299,10 @@ async def test_register_worker_plugin_typing_over_nanny_keyword(c, s, a):
 
     n_existing_plugins = len(a.plugins)
     assert not hasattr(a, "foo")
-    with pytest.warns(UserWarning, match="`WorkerPlugin` as a nanny plugin"):
+    with (
+        pytest.warns(UserWarning, match="`WorkerPlugin` as a nanny plugin"),
+        pytest.warns(DeprecationWarning, match="use `Client.register_plugin` instead"),
+    ):
         await c.register_worker_plugin(DuckPlugin(), nanny=True)
     assert len(a.plugins) == n_existing_plugins + 1
     assert a.foo == 123
@@ -316,7 +319,10 @@ async def test_duck_typed_register_worker_plugin_is_deprecated(c, s, a):
 
     n_existing_plugins = len(a.plugins)
     assert not hasattr(a, "foo")
-    with pytest.warns(DeprecationWarning, match="duck-typed.*WorkerPlugin"):
+    with (
+        pytest.warns(DeprecationWarning, match="duck-typed.*WorkerPlugin"),
+        pytest.warns(DeprecationWarning, match="use `Client.register_plugin` instead"),
+    ):
         await c.register_worker_plugin(DuckPlugin())
     assert len(a.plugins) == n_existing_plugins + 1
     assert a.foo == 123

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -219,7 +219,8 @@ async def test_close_async(c, s, a):
     while not semaphore_object.metrics["pending"]["t2"]:  # Wait for the pending lease
         await asyncio.sleep(0.01)
     with pytest.warns(
-        RuntimeWarning, match="Closing semaphore .* but there remain pending leases"
+        RuntimeWarning,
+        match=r"Closing semaphore .* but there remain (pending|unreleased) leases",
     ):
         await sem2.close()
 


### PR DESCRIPTION
Using `with pytest.warns()` to catch a warning no longer quietly suppresses unrelated warnings.