### PR TITLE
Remove `is_python_shutting_down`

### DIFF
--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -97,27 +97,6 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-_python_shutting_down = False
-
-
-@atexit.register
-def _():
-    """Set a global when Python shuts down.
-
-    Note
-    ----
-    This function must be registered with atexit *after* any class that invokes
-    ``distributed.utils.is_python_shutting_down`` has been defined. This way it
-    will be called before the ``__del__`` method of those classes.
-
-    See Also
-    --------
-    distributed.utils.is_python_shutting_down
-    """
-    global _python_shutting_down
-    _python_shutting_down = True
-
-
 __all__ = [
     "Actor",
     "ActorFuture",

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -4,6 +4,7 @@ import asyncio
 import itertools
 import logging
 import os
+import sys
 import threading
 import weakref
 from collections import deque, namedtuple
@@ -14,7 +15,7 @@ from tornado.ioloop import IOLoop
 from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend, backends
 from distributed.protocol import nested_deserialize
-from distributed.utils import get_ip, is_python_shutting_down
+from distributed.utils import get_ip
 
 logger = logging.getLogger(__name__)
 
@@ -187,9 +188,13 @@ class InProc(Comm):
         r = repr(self)
 
         def finalize(
-            read_q=self._read_q, write_q=self._write_q, write_loop=self._write_loop, r=r
+            read_q=self._read_q,
+            write_q=self._write_q,
+            write_loop=self._write_loop,
+            is_finalizing=sys.is_finalizing,
+            r=r,
         ):
-            if read_q.peek(None) is _EOF or is_python_shutting_down():
+            if read_q.peek(None) is _EOF or is_finalizing():
                 return
             logger.warning(f"Closing dangling queue in {r}")
             write_loop.add_callback(write_q.put_nowait, _EOF)

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -179,7 +179,7 @@ class InProc(Comm):
         self._write_q = write_q
         self._write_loop = write_loop
         self._closed = False
-
+        self._sys_is_finalizing = staticmethod(sys.is_finalizing)
         self._finalizer = weakref.finalize(self, self._get_finalizer())
         self._finalizer.atexit = False
         self._initialized = True
@@ -191,7 +191,7 @@ class InProc(Comm):
             read_q=self._read_q,
             write_q=self._write_q,
             write_loop=self._write_loop,
-            is_finalizing=sys.is_finalizing,
+            is_finalizing=self._sys_is_finalizing,
             r=r,
         ):
             if read_q.peek(None) is _EOF or is_finalizing():

--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -179,7 +179,7 @@ class InProc(Comm):
         self._write_q = write_q
         self._write_loop = write_loop
         self._closed = False
-        self._sys_is_finalizing = staticmethod(sys.is_finalizing)
+
         self._finalizer = weakref.finalize(self, self._get_finalizer())
         self._finalizer.atexit = False
         self._initialized = True
@@ -191,7 +191,7 @@ class InProc(Comm):
             read_q=self._read_q,
             write_q=self._write_q,
             write_loop=self._write_loop,
-            is_finalizing=self._sys_is_finalizing,
+            is_finalizing=sys.is_finalizing,
             r=r,
         ):
             if read_q.peek(None) is _EOF or is_finalizing():

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -118,7 +118,6 @@ from distributed.utils import (
     TimeoutError,
     format_dashboard_link,
     get_fileno_limit,
-    is_python_shutting_down,
     key_split_group,
     log_errors,
     offload,
@@ -5607,7 +5606,7 @@ class Scheduler(SchedulerState, ServerNode):
             if not comm.closed():
                 self.client_comms[client].send({"op": "stream-closed"})
             try:
-                if not is_python_shutting_down():
+                if not self._is_finalizing():
                     await self.client_comms[client].close()
                     del self.client_comms[client]
                     if self.status == Status.running:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1826,19 +1826,6 @@ def recursive_to_dict(
         tok.var.reset(tok)
 
 
-def is_python_shutting_down() -> bool:
-    """Is the interpreter shutting down now?
-
-    This is a variant of ``sys.is_finalizing`` which can return True inside the ``__del__``
-    method of classes defined inside the distributed package.
-    """
-    # This import must remain local for the global variable to be
-    # properly evaluated
-    from distributed import _python_shutting_down
-
-    return _python_shutting_down
-
-
 class Deadline:
     """Utility class tracking a deadline and the progress toward it"""
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -101,7 +101,6 @@ from distributed.utils import (
     get_ip,
     has_arg,
     in_async_call,
-    is_python_shutting_down,
     iscoroutinefunction,
     json_load_robust,
     log_errors,
@@ -1632,7 +1631,7 @@ class Worker(BaseWorker, ServerNode):
             # weird deadlocks particularly if the task that is executing in
             # the thread is waiting for a server reply, e.g. when using
             # worker clients, semaphores, etc.
-            if is_python_shutting_down():
+            if self._is_finalizing():
                 # If we're shutting down there is no need to wait for daemon
                 # threads to finish
                 _close(executor=executor, wait=False)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1633,7 +1633,9 @@ class Worker(BaseWorker, ServerNode):
             # weird deadlocks particularly if the task that is executing in
             # the thread is waiting for a server reply, e.g. when using
             # worker clients, semaphores, etc.
-            if self._is_finalizing():
+
+            # Are we shutting down the process?
+            if self._is_finalizing() or not threading.main_thread().is_alive():
                 # If we're shutting down there is no need to wait for daemon
                 # threads to finish
                 _close(executor=executor, wait=False)
@@ -1642,7 +1644,7 @@ class Worker(BaseWorker, ServerNode):
                     await asyncio.to_thread(
                         _close, executor=executor, wait=executor_wait
                     )
-                except RuntimeError:  # Are we shutting down the process?
+                except RuntimeError:
                     logger.error(
                         "Could not close executor %r by dispatching to thread. Trying synchronously.",
                         executor,


### PR DESCRIPTION
This PR binds `sys.is_finalizing` to make sure that it's always available during interpreter shutdown and removes the (to the best of my knowledge superfluous) `is_python_shutting_down`.

This handles errors during shutdown like 
```
Exception ignored in: <function Future.__del__ at 0x6f23b140ccc0>
Traceback (most recent call last):
  File "/usr/local/python/python3/std/lib64/python3.11/site-packages/distributed/client.py", line 510, in __del__
TypeError: 'NoneType' object is not callable
```

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
