### PR TITLE
Don't crash when getting computation code in pathological cases

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3095,8 +3095,12 @@ class Client(SyncMethodMixin):
                 module_name = fr.f_back.f_globals["__name__"]  # type: ignore
                 if module_name == "__channelexec__":
                     break  # execnet; pytest-xdist  # pragma: nocover
+                try:
+                    module_name = sys.modules[module_name].__name__
+                except KeyError:
+                    # Ignore pathological cases where the module name isn't in `sys.modules`
+                    break
                 # Ignore IPython related wrapping functions to user code
-                module_name = sys.modules[module_name].__name__
                 if module_name.endswith("interactiveshell"):
                     break
 


### PR DESCRIPTION
I was trying to run a distributed computation inside a Prefect flow and our computation code sniffing logic failed with

```python
Encountered exception during execution:
Traceback (most recent call last):
  File "/Users/james/mambaforge/envs/etl-tcph/lib/python3.11/site-packages/prefect/engine.py", line 840, in orchestrate_flow_run
    result = await flow_call.aresult()
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/etl-tcph/lib/python3.11/site-packages/prefect/_internal/concurrency/calls.py", line 291, in aresult
    return await asyncio.wrap_future(self.future)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/etl-tcph/lib/python3.11/site-packages/prefect/_internal/concurrency/calls.py", line 315, in _run_sync
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/projects/coiled/etl-tpch/generate_data.py", line 285, in generate_data
    generate(
  File "/Users/james/projects/coiled/etl-tpch/generate_data.py", line 77, in generate
    jobs = client.map(_tpch_data_gen, range(0, scale), **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/etl-tcph/lib/python3.11/site-packages/distributed/client.py", line 2167, in map
    futures = self._graph_to_futures(
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/etl-tcph/lib/python3.11/site-packages/distributed/client.py", line 3168, in _graph_to_futures
    computations = self._get_computation_code(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/mambaforge/envs/etl-tcph/lib/python3.11/site-packages/distributed/client.py", line 3099, in _get_computation_code
    module_name = sys.modules[module_name].__name__
                  ~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: '__prefect_loader__'
```

Prefect seems to be doing something strange with module names (xref https://github.com/PrefectHQ/prefect/issues/5984, https://github.com/PrefectHQ/prefect/issues/6629, https://github.com/PrefectHQ/prefect/issues/6762). I don't fully understand the situation (my guess is Prefect is trying to be overly cleaver), but I've also run into the same error in another non-Prefect situation recently (unfortunately I don't recall any of the details). 

This PR proposes our code sniffing logic just ignore any code frames where the module name isn't in `sys.modules`. That seems better than failing the entire computation. 

FWIW the changes here result in the Dask computation inside a Prefect flow to work and the resulting computation code actually looks like exactly what I'd expect (I suspect the frames we're now ignoring were internal to Prefect, which I don't think Dask users would want in this situation anyways). 