### PR TITLE
Ignore ``dask-expr`` warning in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ filterwarnings = [
     # https://github.com/dask/dask/pull/10622
     '''ignore:Minimal version of pyarrow will soon be increased to 14.0.1''',
     '''ignore:the matrix subclass is not the recommended way''',
+    '''ignore:The current Dask DataFrame implementation is deprecated.*:DeprecationWarning''',
 ]
 minversion = "6"
 markers = [


### PR DESCRIPTION
This warning is making most of our CI jobs fail. This PR ignores the warning like we're doing over in `dask/dask`

xref https://github.com/dask/dask/issues/10917