### PR TITLE
Allow large graph warning threshold to be configured

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -41,6 +41,7 @@ from dask.utils import (
     ensure_dict,
     format_bytes,
     funcname,
+    parse_bytes,
     parse_timedelta,
     shorten_traceback,
     typename,
@@ -3162,7 +3163,9 @@ class Client(SyncMethodMixin):
             header, frames = serialize(ToPickle(dsk), on_error="raise")
 
             pickled_size = sum(map(nbytes, [header] + frames))
-            if pickled_size > 10_000_000:
+            if pickled_size > parse_bytes(
+                dask.config.get("distributed.admin.large-graph-warning-threshold")
+            ):
                 warnings.warn(
                     f"Sending large graph of size {format_bytes(pickled_size)}.\n"
                     "This may cause some slowdown.\n"

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -1103,6 +1103,12 @@ properties:
         description: |
           Options for logs, event loops, and so on
         properties:
+          large-graph-warning-threshold:
+            type: string
+            description: |
+              Threshold in bytes for when a warning is raised about a large
+              submitted task graph.
+              Default is 10MB.
           tick:
             type: object
             description: |

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -323,6 +323,7 @@ distributed:
   ##################
 
   admin:
+    large-graph-warning-threshold: 10MB  # Threshold for warning on large graph
     tick:
       interval: 20ms  # time between event loop health checks
       limit: 3s       # time allowed before triggering a warning

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5971,7 +5971,6 @@ async def test_config_scheduler_address(s, a, b):
     assert sio.getvalue() == f"Config value `scheduler-address` found: {s.address}\n"
 
 
-@pytest.mark.filterwarnings("error:Sending large graph of size")
 @gen_cluster(client=True, nthreads=[])
 async def test_warn_when_submitting_large_values(c, s):
     with pytest.warns(UserWarning, match="Sending large graph of size"):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5971,9 +5971,12 @@ async def test_config_scheduler_address(s, a, b):
     assert sio.getvalue() == f"Config value `scheduler-address` found: {s.address}\n"
 
 
+@pytest.mark.filterwarnings("error:Sending large graph of size")
 @gen_cluster(client=True, nthreads=[])
 async def test_warn_when_submitting_large_values(c, s):
     with pytest.warns(UserWarning, match="Sending large graph of size"):
+        future = c.submit(lambda x: x + 1, b"0" * 10_000_000)
+    with dask.config.set({"distributed.admin.large-graph-warning-threshold": "1GB"}):
         future = c.submit(lambda x: x + 1, b"0" * 10_000_000)
 
 


### PR DESCRIPTION
This allows the warning threshold to be configured. Some users just can't avoid this and the 10MB threshold is sometimes a little strict.