### PR TITLE
Better logging for worker removal

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1773,18 +1773,7 @@ class Client(SyncMethodMixin):
                 coro = wait_for(coro, timeout)
             return coro
 
-        if self._start_arg is None:
-            with suppress(AttributeError):
-                f = self.cluster.close()
-                if asyncio.iscoroutine(f):
-
-                    async def _():
-                        await f
-
-                    self.sync(_)
-
         sync(self.loop, self._close, fast=True, callback_timeout=timeout)
-
         assert self.status == "closed"
 
         if not is_python_shutting_down():

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1497,8 +1497,7 @@ class Client(SyncMethodMixin):
         await self._close(
             # if we're handling an exception, we assume that it's more
             # important to deliver that exception than shutdown gracefully.
-            fast=exc_type
-            is not None
+            fast=(exc_type is not None)
         )
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -1669,16 +1668,15 @@ class Client(SyncMethodMixin):
                 await wait_for(handle_report_task, 0 if fast else 2)
 
     @log_errors
-    async def _close(self, fast=False):
-        """
-        Send close signal and wait until scheduler completes
+    async def _close(self, fast: bool = False) -> None:
+        """Send close signal and wait until scheduler completes
 
         If fast is True, the client will close forcefully, by cancelling tasks
         the background _handle_report_task.
         """
-        # TODO: aclose more forcefully by aborting the RPC and cancelling all
+        # TODO: close more forcefully by aborting the RPC and cancelling all
         # background tasks.
-        # see https://trio.readthedocs.io/en/stable/reference-io.html#trio.aclose_forcefully
+        # See https://trio.readthedocs.io/en/stable/reference-io.html#trio.aclose_forcefully
         if self.status == "closed":
             return
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5196,7 +5196,10 @@ def test_quiet_client_close(loop):
             threads_per_worker=4,
         ) as c:
             futures = c.map(slowinc, range(1000), delay=0.01)
-            sleep(0.2)  # stop part-way
+            # Stop part-way
+            s = c.cluster.scheduler
+            while sum(ts.state == "memory" for ts in s.tasks.values()) < 20:
+                sleep(0.01)
         sleep(0.1)  # let things settle
 
     out = logger.getvalue()

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5196,7 +5196,7 @@ def test_quiet_client_close(loop):
             threads_per_worker=4,
         ) as c:
             futures = c.map(slowinc, range(1000), delay=0.01)
-            sleep(0.200)  # stop part-way
+            sleep(0.2)  # stop part-way
         sleep(0.1)  # let things settle
 
     out = logger.getvalue()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -3058,7 +3058,7 @@ class FlakyConnectionPool(ConnectionPool):
 
 
 @gen_cluster(client=True)
-async def test_gather_failing_cnn_recover(c, s, a, b):
+async def test_gather_failing_can_recover(c, s, a, b):
     x = await c.scatter({"x": 1}, workers=a.address)
     rpc = await FlakyConnectionPool(failing_connections=1)
     with mock.patch.object(s, "rpc", rpc), dask.config.set(

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3008,11 +3008,13 @@ async def test_log_remove_worker(c, s, a, b):
 
     assert log.getvalue().splitlines() == [
         # Successful graceful
+        f"Retire worker addresses ['{a.address}']",
         f"Retiring worker '{a.address}' (stimulus_id='graceful')",
         f"Remove worker <WorkerState '{a.address}', name: 0, status: "
         "closing_gracefully, memory: 2, processing: 1> (stimulus_id='graceful')",
         f"Retired worker '{a.address}' (stimulus_id='graceful')",
         # Aborted graceful
+        f"Retire worker addresses ['{b.address}']",
         f"Retiring worker '{b.address}' (stimulus_id='graceful_abort')",
         f"Could not retire worker '{b.address}': unique data could not be "
         "moved to any other worker (stimulus_id='graceful_abort')",


### PR DESCRIPTION
Improve all regular logger output as well as `Scheduler.events` around worker shutdown.

- print a WARNING when tasks are going to be recomputed due to worker failure
- print an ERROR when scattered data is lost due to worker failure
- Graceful worker retirement will now warn when it fails to retire a worker (as no other worker can accept its unique data)
- `Scheduler.events` now gives a more complete picture of graceful worker retirement as well as worker failure

@jrbourbeau best effort for 2024.2.1