### PR TITLE
Fix critical race condition in graceful shutdown

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7091,12 +7091,11 @@ class Scheduler(SchedulerState, ServerNode):
             If neither ``workers`` nor ``names`` are provided, we call
             ``workers_to_close`` which finds a good set.
         close_workers: bool (defaults to False)
-            Whether or not to actually close the worker explicitly from here.
-            Otherwise we expect some external job scheduler to finish off the
-            worker.
+            Whether to actually close the worker explicitly from here.
+            Otherwise, we expect some external job scheduler to finish off the worker.
         remove: bool (defaults to True)
-            Whether or not to remove the worker metadata immediately or else
-            wait for the worker to contact us.
+            Whether to remove the worker metadata immediately or else wait for the
+            worker to contact us.
 
             If close_workers=False and remove=False, this method just flushes the tasks
             in memory out of the workers and then returns.

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -269,14 +269,13 @@ def test_flight_cancelled_error(ws):
     assert not ws.tasks
 
 
-@gen_cluster(
-    client=True,
-    nthreads=[("", 1)],
-    # heartbeat will close a worker after remove_worker(close=False)
-    worker_kwargs={"heartbeat_interval": "100s"},
-)
+@gen_cluster(client=True, nthreads=[("", 1)])
 async def test_in_flight_lost_after_resumed(c, s, b):
-    async with BlockedGetData(s.address) as a:
+    async with BlockedGetData(
+        s.address,
+        # heartbeat will close a worker after remove_worker(close=False)
+        heartbeat_interval="100s",
+    ) as a:
         fut1 = c.submit(inc, 1, workers=[a.address], key="fut1")
         # Ensure fut1 is in memory but block any further execution afterwards to
         # ensure we control when the recomputation happens

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -169,7 +169,11 @@ async def test_flight_to_executing_via_cancelled_resumed(c, s, b):
         with lock:
             return x + 1
 
-    async with BrokenWorker(s.address) as a:
+    async with BrokenWorker(
+        s.address,
+        # heartbeat will close a worker after remove_worker(close=False)
+        heartbeat_interval="100s",
+    ) as a:
         await c.wait_for_workers(2)
         fut1 = c.submit(
             blockable_compute,
@@ -265,7 +269,12 @@ def test_flight_cancelled_error(ws):
     assert not ws.tasks
 
 
-@gen_cluster(client=True, nthreads=[("", 1)])
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)],
+    # heartbeat will close a worker after remove_worker(close=False)
+    worker_kwargs={"heartbeat_interval": "100s"},
+)
 async def test_in_flight_lost_after_resumed(c, s, b):
     async with BlockedGetData(s.address) as a:
         fut1 = c.submit(inc, 1, workers=[a.address], key="fut1")

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -956,3 +956,33 @@ async def test_nanny_plugin_register_nanny_killed(c, s, restart):
     finally:
         proc.kill()
     assert await register == {}
+
+
+@pytest.mark.slow
+@gen_cluster(
+    client=True,
+    Worker=Nanny,
+    nthreads=[("", 1)],
+    worker_kwargs={"heartbeat_interval": "10ms"},
+)
+async def test_nanny_does_not_restart_worker_on_graceful_retirement(c, s, a):
+    """Tests https://github.com/dask/distributed/pull/8522
+
+    Some clusters (e.g. SpecCluster) implement downscaling by calling
+    `Scheduler.retire_workers()` without arguments, which defaults to
+     `remove=True, close_workers=False`.
+
+    and then use an external system to tear down the worker and the nanny. In these
+    cases, make sure that the worker doesn't kill itself and that the nanny doesn't
+    restart it after the heartbeat to the scheduler fails.
+    """
+    await s.retire_workers([a.worker_address], stimulus_id="test")
+    # On Linux, it takes ~3.5s for the nanny to resuscitate a worker
+    await asyncio.sleep(5)
+    assert not s.workers
+    events = [
+        ev
+        for _, ev in s.events["all"]
+        if isinstance(ev, dict) and ev.get("action") == "add-worker"
+    ]
+    assert len(events) == 1

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -62,6 +62,7 @@ from distributed.utils_test import (
     captured_logger,
     dec,
     div,
+    freeze_batched_send,
     freeze_data_fetching,
     gen_cluster,
     gen_test,

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -62,7 +62,6 @@ from distributed.utils_test import (
     captured_logger,
     dec,
     div,
-    freeze_batched_send,
     freeze_data_fetching,
     gen_cluster,
     gen_test,

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1766,88 +1766,27 @@ async def test_heartbeat_comm_closed(s, monkeypatch):
             assert w.status == Status.running
     logs = logger.getvalue()
     assert "Failed to communicate with scheduler during heartbeat" in logs
-    assert "Traceback" in logs
 
 
-@gen_cluster(nthreads=[("", 1)], worker_kwargs={"heartbeat_interval": "100s"})
-async def test_heartbeat_missing(s, a, monkeypatch):
-    async def missing_heartbeat_worker(*args, **kwargs):
-        return {"status": "missing"}
-
-    with captured_logger("distributed.worker", level=logging.WARNING) as wlogger:
-        monkeypatch.setattr(a.scheduler, "heartbeat_worker", missing_heartbeat_worker)
-        await a.heartbeat()
-        assert a.status == Status.closed
-        assert "Scheduler was unaware of this worker" in wlogger.getvalue()
-
-        while s.workers:
-            await asyncio.sleep(0.01)
-
-
-@gen_cluster(nthreads=[("", 1)], worker_kwargs={"heartbeat_interval": "100s"})
-async def test_heartbeat_missing_real_cluster(s, a):
-    # The idea here is to create a situation where `s.workers[a.address]`,
-    # doesn't exist, but the worker is not yet closed and can still heartbeat.
-    # Ideally, this state would be impossible, and this test would be removed,
-    # and the `status: missing` handling would be replaced with an assertion error.
-    # However, `Scheduler.remove_worker` and `Worker.close` both currently leave things
-    # in degenerate, half-closed states while they're running (and yielding control
-    # via `await`).
-    # When https://github.com/dask/distributed/issues/6390 is fixed, this should no
-    # longer be possible.
-
-    assumption_msg = "Test assumptions have changed. Race condition may have been fixed; this test may be removable."
-
-    with captured_logger(
-        "distributed.worker", level=logging.WARNING
-    ) as wlogger, captured_logger(
-        "distributed.scheduler", level=logging.WARNING
-    ) as slogger:
-        with freeze_batched_send(s.stream_comms[a.address]):
-            await s.remove_worker(a.address, stimulus_id="foo")
-            assert not s.workers
-
-            # The scheduler has removed the worker state, but the close message has
-            # not reached the worker yet.
-            assert a.status == Status.running, assumption_msg
-            assert a.periodic_callbacks["heartbeat"].is_running(), assumption_msg
-
-            # The heartbeat PeriodicCallback is still running, so one _could_ fire
-            # before the `op: close` message reaches the worker. We simulate that explicitly.
-            await a.heartbeat()
-
-            # The heartbeat receives a `status: missing` from the scheduler, so it
-            # closes the worker. Heartbeats aren't sent over batched comms, so
-            # `freeze_batched_send` doesn't affect them.
-            assert a.status == Status.closed
-
-            assert "Scheduler was unaware of this worker" in wlogger.getvalue()
-            assert "Received heartbeat from unregistered worker" in slogger.getvalue()
-
-        assert not s.workers
-
-
-@pytest.mark.slow
 @gen_cluster(
     client=True,
     nthreads=[("", 1)],
-    Worker=Nanny,
-    worker_kwargs={"heartbeat_interval": "1ms"},
+    worker_kwargs={"heartbeat_interval": "10ms"},
 )
-async def test_heartbeat_missing_restarts(c, s, n):
-    old_heartbeat_handler = s.handlers["heartbeat_worker"]
-    s.handlers["heartbeat_worker"] = lambda *args, **kwargs: {"status": "missing"}
+async def test_heartbeat_missing(c, s, a):
+    with (
+        captured_logger("distributed.scheduler", level=logging.WARNING) as slog,
+        captured_logger("distributed.worker", level=logging.INFO) as wlog,
+    ):
+        await s.remove_worker(a.address, close=False, stimulus_id="test")
+        while "Received heartbeat from unregistered worker" not in slog.getvalue():
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.2)
 
-    assert n.process
-    await n.process.stopped.wait()
-
-    assert not s.workers
-    s.handlers["heartbeat_worker"] = old_heartbeat_handler
-
-    await n.process.running.wait()
-    assert n.status == Status.running
-
-    await c.wait_for_workers(1)
+    assert slog.getvalue().count("Received heartbeat from unregistered worker") == 1
+    assert wlog.getvalue().count("Stopping heartbeat") == 1
+    assert a.status == Status.running
+    assert a.address not in s.workers
 
 
 @gen_cluster(nthreads=[])

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1292,7 +1292,6 @@ class Worker(BaseWorker, ServerNode):
             logger.warning("Failed to communicate with scheduler during heartbeat")
         except Exception:  # pragma: nocover
             logger.exception("Unexpected exception during heartbeat")
-            await self.close(reason="worker-heartbeat-exception")
             raise
 
     @fail_hard

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1292,6 +1292,7 @@ class Worker(BaseWorker, ServerNode):
             logger.warning("Failed to communicate with scheduler during heartbeat")
         except Exception:  # pragma: nocover
             logger.exception("Unexpected exception during heartbeat")
+            await self.close(reason="worker-heartbeat-exception")
             raise
 
     @fail_hard

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1265,44 +1265,33 @@ class Worker(BaseWorker, ServerNode):
                     if hasattr(extension, "heartbeat")
                 },
             )
-
             end = time()
             middle = (start + end) / 2
-
             self._update_latency(end - start)
 
             if response["status"] == "missing":
                 # Scheduler thought we left.
-                # Reconnection is not supported, so just shut down.
-
-                if self.status == Status.closing_gracefully:
-                    # Called Scheduler.retire_workers(remove=True, close_workers=False)
-                    # The worker will remain indefinitely in this state, unknown to the
-                    # scheduler, until something else shuts it down.
-                    # Stopping the heartbeat is just a nice-to-have to reduce
-                    # unnecessary warnings on the scheduler log.
-                    logger.info("Stopping heartbeat to the scheduler")
-                    self.periodic_callbacks["heartbeat"].stop()
-                else:
-                    logger.error(
-                        f"Scheduler was unaware of this worker {self.address!r}. "
-                        "Shutting down."
-                    )
-                    # Have the nanny restart us if possible
-                    await self.close(nanny=False, reason="worker-heartbeat-missing")
+                # This happens after one calls Scheduler.remove_worker(close=False).
+                # ***DO NOT call close()!***
+                # Read: https://github.com/dask/distributed/pull/8522
+                logger.info("Stopping heartbeat to the scheduler")
+                self.periodic_callbacks["heartbeat"].stop()
                 return
 
-            self.scheduler_delay = response["time"] - middle
             self.periodic_callbacks["heartbeat"].callback_time = (
                 response["heartbeat-interval"] * 1000
             )
+            self.scheduler_delay = response["time"] - middle
             self.bandwidth_workers.clear()
             self.bandwidth_types.clear()
+
         except OSError:
-            logger.exception("Failed to communicate with scheduler during heartbeat.")
-        except Exception:
-            logger.exception("Unexpected exception during heartbeat. Closing worker.")
-            await self.close(reason="worker-heartbeat-error")
+            # Hopefully a temporary network failure, or maybe the scheduler' CPU is at
+            # 100%. DO NOT call close() and try again later. Keep the worker alive for
+            # as long as the kernel keeps the batched comms TCP channel open.
+            logger.warning("Failed to communicate with scheduler during heartbeat")
+        except Exception:  # pragma: nocover
+            logger.exception("Unexpected exception during heartbeat")
             raise
 
     @fail_hard


### PR DESCRIPTION
# Executive summary
Coiled, as well as other dask clusters that can dynamically shrink down while there's data on the cluster, can accidentally lose vital data when shrinking. This will cause large parts of a computation to restart from scratch; scattered data will be lost forever, causing any computation that relies on it to fail.

# Impact
Any cluster that calls `SpecCluster.scale` to shrink down while there is data on the workers; e.g.
1. because the computation is finished, but the client didn't retrieve the output yet
2. because the computation features an initial highly parallel phase followed by a long sequential "tail" that can't saturate the workers.

# Use case
Coiled is a cloud cluster which, to my understanding, handles scaling down as follows:

1. it receives instruction to scale down, either manually or from adaptive
3. it chooses workers to shut down
4. it calls `Scheduler.retire_workers(addresses, close_workers=False, remove=True)`
5. this in turn triggers graceful worker retirement, a.k.a. AMM RetireWorkers, which changes the workers to `status=closing_gracefully` and copies over to other workers all unique data they contain. The recipient workers must have `status=running`.
6. once a worker being retired no longer contains any unique data AMM RetireWorkers ends and `Scheduler.retire_workers` calls `Scheduler.remove_worker(close=False)`
7. a bespoke SchedulerPlugin installed by the cloud manager, or any other kind of event listener on the scheduler, is informed that the worker has been removed from the scheduler
8. the cloud manager notices that the worker is on the list that itself asked to retire on step 3, so it shuts down the EC2/GCP/whatever instance running the worker.

This PR fixes a critical race condition that happens if there's a few seconds delay between steps 6 and 7:

6.1. the worker, which is still in `status=closing_gracefully`, heartbeats the scheduler
6.2 the scheduler responds `{status: missing}`: "I don't know you and I have no memory of you".
6.3 the worker interprets this as an irrecoverable desync (e.g. the scheduler process may have been restarted), so it shuts itself down
6.4 the nanny notices the worker process died and restarts it
6.5 a new worker from the same host connects to the scheduler, with `status=running`
6.6 this brand new worker is noticed and immediately used by Active Memory Manager (AMM), which in the meantime is evacuating data from _other_ workers on the cluster (AMM reconsiders the list of recipients every 2 seconds).
6.7 AMM instructs the new worker process to gather some data from other workers being retired
6.8 the new worker obliges and acquires a replica of the data
6.9 the other workers are removed from the cluster. The born-again worker now is the sole holder of important task outputs, or even worse scattered data

...and now we go back to step 7 from the bullet points above. The cloud manager finally reacts to the _old_ worker being removed from the cluster, and implements the shutdown of the EC2 instance where the _new_ worker is holding precious data.
All computed tasks on it are lost and need to be recomputed.
All scattered data on it is lost and cannot be recovered without the client sending it again explicitly.


### Aside
Note that the above process is not the only way to retire a worker.
One could alternatively call  `Scheduler.retire_workers(addresses, close_workers=True, remove=True)`. This would safely shut down the worker process and send _the nanny_ to `status=close_gracefully`, which will prevent it from restarting the worker process.
I'm not too happy that there are multiple ways to shut down a worker; I guess this has to do with the possibility that one may not use a nanny at all and use a different, bespoke watchdog instead.

# Reproducer
```python
import coiled

@coiled.function()
def foo(x):
    import time
    time.sleep(30)
    return x+1


X = foo.map(range(2000))
```
The above code starts 344 workers and, once there are 2000 tasks in memory, shrinks down to 1 worker, moving all the task outputs (None's) to the only survivor.
It never finishes because of the above race condition. Halfway through the cluster shrink down, tasks in memory are lost and are shunted back to queued state, which causes the cluster to enlarge again.

The issue disappears when the peak number of workers gets lower; this happens if you send either less than 2000 tasks or spend less than 30s per task. I could only reproduce it with `cluster.adapt(minimum=1, maximum=500)`; for some reason I failed to reproduce it when manually scaling down with `cluster.scale(1)`.

@ntabris 
@jrbourbeau best effort for 2024.2.1