### PR TITLE
Fix flaky test_no_workers_timeout_queued

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2502,8 +2502,7 @@ async def test_no_workers_timeout_queued(c, s, a):
     """Don't trip no-workers-timeout when there are queued tasks AND processing tasks"""
     ev = Event()
     futures = [c.submit(lambda ev: ev.wait(), ev, pure=False) for _ in range(3)]
-    while not a.state.tasks:
-        await asyncio.sleep(0.01)
+    await async_poll_for(lambda: len(s.tasks) == 3 and a.state.tasks, timeout=5)
     assert s.queued or math.isinf(s.WORKER_SATURATION)
 
     s._check_no_workers()


### PR DESCRIPTION
e.g. https://github.com/dask/distributed/actions/runs/8008396520/job/21874748036?pr=8522

```

>       assert s.queued or math.isinf(s.WORKER_SATURATION)
E       AssertionError: assert (<HeapSet: 0 items> or False)
E        +  where <HeapSet: 0 items> = <Scheduler 'tcp://127.0.0.1:42673', workers: 1, cores: 1, tasks: 2>.queued
```
note how there are only 2 tasks on the scheduler. This test relies on all submit() calls to end up in the same batched message, which is what happens _most_ times.