### PR TITLE
Prevent typos in retire_workers parameters

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2727,6 +2727,18 @@ async def test_retire_names_str(c, s):
         assert len(b.data) == 10
 
 
+@gen_cluster(client=True)
+async def test_retire_workers_bad_params(c, s, a, b):
+    with pytest.raises(TypeError, match="mutually exclusive"):
+        await s.retire_workers([a.address], names=[a.name])
+    with pytest.raises(TypeError, match="mutually exclusive"):
+        await s.retire_workers([a.address], n=1)
+    with pytest.raises(TypeError, match="mutually exclusive"):
+        await s.retire_workers(names=[a.name], n=1)
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        await s.retire_workers(foo=1)
+
+
 @gen_cluster(
     client=True, config={"distributed.scheduler.default-task-durations": {"inc": 100}}
 )

--- a/distributed/tests/test_utils.py
+++ b/distributed/tests/test_utils.py
@@ -879,7 +879,10 @@ async def test_log_errors():
         pass
 
     # Use the logger of the caller module
-    with captured_logger("test_utils") as caplog:
+    with (
+        captured_logger("test_utils") as caplog,
+        captured_logger("distributed.utils") as caplog2,
+    ):
         # Context manager
         with log_errors():
             pass
@@ -906,6 +909,8 @@ async def test_log_errors():
             return 123
 
         assert _() == 123
+        with pytest.raises(TypeError):
+            _(bad=1)
 
         @log_errors
         def _():
@@ -1001,6 +1006,7 @@ async def test_log_errors():
         "err7",
         "err8",
     ]
+    assert "got an unexpected keyword argument 'bad'" in caplog2.getvalue()
 
 
 @pytest.mark.parametrize("unroll_stack,logger_name", [(0, "test_utils"), (1, "a.b.c")])

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -849,7 +849,7 @@ class _LogErrors:
             return
 
         stack = traceback.extract_tb(tb)
-        frame = stack[self.unroll_stack]
+        frame = stack[min(self.unroll_stack, len(stack) - 1)]
         modname = _getmodulename_with_path(frame.filename)
 
         try:


### PR DESCRIPTION
I lost count of how many times I typed `retire_workers(retire=False)` and dask quietly misbehaved because I should have typed `remove=False` instead