### PR TITLE
Avoid iteration error when getting module path

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -801,7 +801,7 @@ def _getmodulename_with_path(fname: str) -> str:
     except KeyError:
         pass
 
-    for modname, mod in sys.modules.items():
+    for modname, mod in sys.modules.copy().items():
         fname2 = getattr(mod, "__file__", None)
         if fname2:
             _getmodulename_with_path_map[fname2] = modname


### PR DESCRIPTION
While running `Client.restart()` as part of a Prefect workflow, I got the following error

```
12:47:35.902 | ERROR   | distributed.core - Exception while handling op restart
Traceback (most recent call last):
  File "/Users/james/projects/dask/distributed/distributed/utils.py", line 832, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/projects/dask/distributed/distributed/scheduler.py", line 6292, in restart
    raise TimeoutError(msg) from None
TimeoutError: Waited for 1 worker(s) to reconnect after restarting, but after 120s, only 0 have returned. Consider a longer timeout, or `wait_for_workers=False`.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/james/projects/dask/distributed/distributed/core.py", line 970, in _handle_comm
    result = await result
             ^^^^^^^^^^^^
  File "/Users/james/projects/dask/distributed/distributed/utils.py", line 831, in wrapper
    with self:
  File "/Users/james/projects/dask/distributed/distributed/utils.py", line 853, in __exit__
    modname = _getmodulename_with_path(frame.filename)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/james/projects/dask/distributed/distributed/utils.py", line 804, in _getmodulename_with_path
    for modname, mod in sys.modules.items():
RuntimeError: dictionary changed size during iteration
```

due to `sys.modules` changing.

This PR adds a `.copy()`, per the official Python docs https://docs.python.org/3/library/sys.html#sys.modules, to avoid this error. 