### PR TITLE
Add GitHub action to enforce `do not merge` label

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,17 @@
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+jobs:
+  do-not-merge:
+    if: ${{ contains(github.event.*.labels.*.name, 'do not merge') }}
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request is labeled as 'do not merge'"
+          echo "This workflow fails so that the pull request cannot be merged"
+          exit 1


### PR DESCRIPTION
We have the convention not to merge PRs flagged with `DNM` in the title. This PR makes this convention explicit by prohibiting merges of PRs that are labeled with the new `do not merge` label.

As an aside: We may want to add a repository for shared actions between multiple repositories to avoid copy+pasting code (https://bgenc.net/2023.02.18.github-actions-do-not-merge-label/).