### PR TITLE
Weigh gilknocker Prometheus metric by duration

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3911,7 +3911,6 @@ class Contention(DashboardComponent):
     @log_errors
     def update(self):
         s = self.scheduler
-        monitor_gil = s.monitor.monitor_gil_contention
 
         self.data["values"] = [
             s._tick_interval_observed,
@@ -3919,11 +3918,13 @@ class Contention(DashboardComponent):
             sum(w.metrics["event_loop_interval"] for w in s.workers.values())
             / (len(s.workers) or 1),
             self.gil_contention_workers,
-        ][:: 1 if monitor_gil else 2]
+        ][:: 1 if s.monitor.monitor_gil_contention else 2]
 
         # Format event loop as time and GIL (if configured) as %
         self.data["text"] = [
-            f"{x * 100:.1f}%" if i % 2 and monitor_gil else format_time(x)
+            f"{x * 100:.1f}%"
+            if i % 2 and s.monitor.monitor_gil_contention
+            else format_time(x)
             for i, x in enumerate(self.data["values"])
         ]
         update(self.source, self.data)

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -56,7 +56,8 @@ class SchedulerMetricCollector(PrometheusCollector):
             yield CounterMetricFamily(
                 self.build_name("gil_contention"),
                 "GIL contention metric",
-                value=self.server.monitor._cumulative_gil_contention,
+                value=self.server.monitor.cumulative_gil_contention,
+                unit="seconds",
             )
 
         yield CounterMetricFamily(

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -132,7 +132,7 @@ async def test_prometheus(c, s, a, b):
     except ImportError:
         pass  # pragma: nocover
     else:
-        expected_metrics.add("dask_scheduler_gil_contention")
+        expected_metrics.add("dask_scheduler_gil_contention_seconds")
 
     assert set(active_metrics.keys()) == expected_metrics
     assert active_metrics["dask_scheduler_clients"].samples[0].value == 1.0

--- a/distributed/http/tests/test_core.py
+++ b/distributed/http/tests/test_core.py
@@ -73,8 +73,8 @@ async def test_prometheus_api_doc(c, s, a, _):
         gil_metrics = set()  # Already in worker_metrics
     except ImportError:
         gil_metrics = {
-            "dask_scheduler_gil_contention_total",
-            "dask_worker_gil_contention_total",
+            "dask_scheduler_gil_contention_seconds_total",
+            "dask_worker_gil_contention_seconds_total",
         }
 
     implemented = scheduler_metrics | worker_metrics | crick_metrics | gil_metrics

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -63,7 +63,8 @@ class WorkerMetricCollector(PrometheusCollector):
             yield CounterMetricFamily(
                 self.build_name("gil_contention"),
                 "GIL contention metric",
-                value=self.server.monitor._cumulative_gil_contention,
+                value=self.server.monitor.cumulative_gil_contention,
+                unit="seconds",
             )
 
         yield GaugeMetricFamily(

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -59,7 +59,7 @@ async def test_prometheus(c, s, a):
     except ImportError:
         pass  # pragma: nocover
     else:
-        expected_metrics.add("dask_worker_gil_contention_total")
+        expected_metrics.add("dask_worker_gil_contention_seconds_total")
 
     try:
         import crick  # noqa: F401

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -27,7 +27,7 @@ dask_scheduler_clients
 dask_scheduler_desired_workers
     Number of workers scheduler needs for task graph
 dask_scheduler_gil_contention_seconds_total
-    Value representing cumulative total of _potential_ GIL contention,
+    Value representing cumulative total of *potential* GIL contention,
     in the form of cumulative seconds during which a thread held the GIL locked.
     Other threads may or may not have been actually trying to acquire the GIL in the
     meantime.
@@ -131,7 +131,7 @@ dask_worker_tasks
 dask_worker_threads
     Number of worker threads
 dask_worker_gil_contention_seconds_total
-    Value representing cumulative total of _potential_ GIL contention,
+    Value representing cumulative total of *potential* GIL contention,
     in the form of cumulative seconds during which a thread held the GIL locked.
     Other threads may or may not have been actually trying to acquire the GIL in the
     meantime.

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -26,9 +26,11 @@ dask_scheduler_clients
     Number of clients connected
 dask_scheduler_desired_workers
     Number of workers scheduler needs for task graph
-dask_scheduler_gil_contention_total
-    Value representing cumulative total of GIL contention,
-    in the form of summed percentages.
+dask_scheduler_gil_contention_seconds_total
+    Value representing cumulative total of _potential_ GIL contention,
+    in the form of cumulative seconds during which a thread held the GIL locked.
+    Other threads may or may not have been actually trying to acquire the GIL in the
+    meantime.
 
     .. note::
        Requires ``gilknocker`` to be installed, and 
@@ -128,9 +130,11 @@ dask_worker_tasks
     Number of tasks at worker
 dask_worker_threads
     Number of worker threads
-dask_worker_gil_contention_total
-    Value representing cumulative total GIL contention on worker,
-    in the form of summed percentages.
+dask_worker_gil_contention_seconds_total
+    Value representing cumulative total of _potential_ GIL contention,
+    in the form of cumulative seconds during which a thread held the GIL locked.
+    Other threads may or may not have been actually trying to acquire the GIL in the
+    meantime.
 
     .. note::
        Requires ``gilknocker`` to be installed, and

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -28,7 +28,7 @@ dask_scheduler_desired_workers
     Number of workers scheduler needs for task graph
 dask_scheduler_gil_contention_seconds_total
     Value representing cumulative total of *potential* GIL contention,
-    in the form of cumulative seconds during which a thread held the GIL locked.
+    in the form of cumulative seconds during which any thread held the GIL locked.
     Other threads may or may not have been actually trying to acquire the GIL in the
     meantime.
 
@@ -132,7 +132,7 @@ dask_worker_threads
     Number of worker threads
 dask_worker_gil_contention_seconds_total
     Value representing cumulative total of *potential* GIL contention,
-    in the form of cumulative seconds during which a thread held the GIL locked.
+    in the form of cumulative seconds during which any thread held the GIL locked.
     Other threads may or may not have been actually trying to acquire the GIL in the
     meantime.
 


### PR DESCRIPTION
- Blocked by #8560
- Closes #8557
- Renames prometheus metrics:

| main | this PR |
| --- | --- |
| dask_scheduler_gil_contention_total | dask_scheduler_gil_contention_seconds_total |
| dask_worker_gil_contention_total | dask_worker_gil_contention_seconds_total |

stress test from #8557:
## BEFORE
![Screenshot from 2024-03-06 15-17-22](https://github.com/dask/distributed/assets/6213168/803d9f10-61dc-4506-aea7-8d98a9d24e38)

## AFTER
![Screenshot from 2024-03-07 16-25-14](https://github.com/dask/distributed/assets/6213168/aab6ee17-cb51-4791-bc53-ee5f48ba75d2)

CC @ntabris @milesgranger 