### PR TITLE
Test bokeh3.4 RC in tests

### DIFF
--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -1,13 +1,14 @@
 name: dask-distributed
 channels:
   - conda-forge
+  - bokeh/label/dev
   - defaults
 dependencies:
   - python=3.11
   - packaging
   - pip
   - asyncssh
-  - bokeh
+  - bokeh=3.4.0rc1
   - click
   - cloudpickle
   - coverage


### PR DESCRIPTION
Bokeh 3.4 has a new release candidate: [3.4.0rc1](https://anaconda.org/bokeh/bokeh/files?version=3.4.0rc1) . @bryevdv asked that we test before the upcoming release next week.
