### PR TITLE
Fix GPU Dashboard

### DIFF
--- a/distributed/dashboard/components/nvml.py
+++ b/distributed/dashboard/components/nvml.py
@@ -125,13 +125,11 @@ class GPUCurrentLoad(DashboardComponent):
 
         for idx, ws in enumerate(workers):
             try:
-                info = ws.extra["gpu"]
+                mem_used = ws.metrics["gpu_memory_used"]
+                mem_total = ws.metrics["gpu-memory-total"]
+                u = ws.metrics["gpu_utilization"]
             except KeyError:
                 continue
-            metrics = ws.metrics["gpu"]
-            u = metrics["utilization"]
-            mem_used = metrics["memory-used"]
-            mem_total = info["memory-total"]
             memory_max = max(memory_max, mem_total)
             memory_total += mem_total
             utilization.append(int(u))

--- a/distributed/system_monitor.py
+++ b/distributed/system_monitor.py
@@ -129,6 +129,7 @@ class SystemMonitor:
             gpu_extra = nvml.one_time()
             self.gpu_name = gpu_extra["name"]
             self.gpu_memory_total = gpu_extra["memory-total"]
+            self.quantities["gpu-memory-total"] = deque(maxlen=1)
             self.quantities["gpu_utilization"] = deque(maxlen=maxlen)
             self.quantities["gpu_memory_used"] = deque(maxlen=maxlen)
         else:
@@ -207,6 +208,7 @@ class SystemMonitor:
 
         if self.gpu_name:
             gpu_metrics = nvml.real_time()
+            result["gpu-memory-total"] = self.gpu_memory_total
             result["gpu_utilization"] = gpu_metrics["utilization"]
             result["gpu_memory_used"] = gpu_metrics["memory-used"]
 


### PR DESCRIPTION
Closes #8567 

In https://github.com/dask/distributed/pull/8399 we removed the GPU Executor which caused an outage in the GPU dashboard.  This was due to relyin on the ws.extra['gpu'] being populated by the executor.  The dashboard now relies on the system monitor for pulling and updating GPU memory/usage

@jacobtomlinson @charlesbluca  Can one of you review ? 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
