### PR TITLE
Include type in failed ``sizeof`` warning

### DIFF
--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 
 from dask.sizeof import sizeof
-from dask.utils import format_bytes
+from dask.utils import format_bytes, typename
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +17,8 @@ def safe_sizeof(obj: object, default_size: float = 1e6) -> int:
         return sizeof(obj)
     except Exception:
         logger.warning(
-            f"Sizeof calculation failed. Defaulting to {format_bytes(int(default_size))}",
+            f"Sizeof calculation for object of type '{typename(obj)}' failed. "
+            f"Defaulting to {format_bytes(int(default_size))}",
             exc_info=True,
         )
         return int(default_size)

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -24,7 +24,7 @@ def test_safe_sizeof_logs_on_failure():
     with captured_logger("distributed.sizeof") as logs:
         assert safe_sizeof(foo) == 1e6
 
-    assert "Sizeof calculation failed. Defaulting to 0.95 MiB" in logs.getvalue()
+    assert f"Sizeof calculation for object of type 'test_sizeof.BadlySized' failed. Defaulting to 0.95 MiB" in logs.getvalue()
 
     # Can provide custom `default_size`
     with captured_logger("distributed.sizeof") as logs:

--- a/distributed/tests/test_sizeof.py
+++ b/distributed/tests/test_sizeof.py
@@ -24,7 +24,10 @@ def test_safe_sizeof_logs_on_failure():
     with captured_logger("distributed.sizeof") as logs:
         assert safe_sizeof(foo) == 1e6
 
-    assert f"Sizeof calculation for object of type 'test_sizeof.BadlySized' failed. Defaulting to 0.95 MiB" in logs.getvalue()
+    assert (
+        "Sizeof calculation for object of type 'test_sizeof.BadlySized' failed. Defaulting to 0.95 MiB"
+        in logs.getvalue()
+    )
 
     # Can provide custom `default_size`
     with captured_logger("distributed.sizeof") as logs:


### PR DESCRIPTION
Including this information will help when debugging failing `sizeof` calls. 

xref https://github.com/dask/distributed/issues/8578

EDIT: Actually, this isn't that useful in the specific case I'm looking at (the type is `dict`), but still could be nice to add 