### PR TITLE
Scatter by worker instead of worker->nthreads

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2450,10 +2450,9 @@ class Client(SyncMethodMixin):
                     nthreads = await self.scheduler.ncores_running(workers=workers)
                 if not nthreads:  # pragma: no cover
                     raise ValueError("No valid workers found")
+                workers = list(nthreads.keys())
 
-                _, who_has, nbytes = await scatter_to_workers(
-                    nthreads, data2, rpc=self.rpc
-                )
+                _, who_has, nbytes = await scatter_to_workers(workers, data2, self.rpc)
 
                 await self.scheduler.update_data(
                     who_has=who_has, nbytes=nbytes, client=self.id

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6132,16 +6132,15 @@ class Scheduler(SchedulerState, ServerNode):
                 raise TimeoutError("No valid workers found")
             await asyncio.sleep(0.1)
 
-        nthreads = {ws.address: ws.nthreads for ws in wss}
-
         assert isinstance(data, dict)
 
-        keys, who_has, nbytes = await scatter_to_workers(nthreads, data, rpc=self.rpc)
+        workers = list(ws.address for ws in wss)
+        keys, who_has, nbytes = await scatter_to_workers(workers, data, rpc=self.rpc)
 
         self.update_data(who_has=who_has, nbytes=nbytes, client=client)
 
         if broadcast:
-            n = len(nthreads) if broadcast is True else broadcast
+            n = len(workers) if broadcast is True else broadcast
             await self.replicate(keys=keys, workers=workers, n=n)
 
         self.log_event(

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -151,18 +151,16 @@ class WrappedKey:
 _round_robin_counter = [0]
 
 
-async def scatter_to_workers(nthreads, data, rpc=rpc):
+async def scatter_to_workers(workers, data, rpc=rpc):
     """Scatter data directly to workers
 
     This distributes data in a round-robin fashion to a set of workers.
-    nthreads should be a dictionary mapping worker identities to numbers of cores.
 
     See scatter for parameter docstring
     """
-    assert isinstance(nthreads, dict)
     assert isinstance(data, dict)
 
-    workers = sorted(nthreads.keys())
+    workers = sorted(workers)
     names, data = list(zip(*data.items()))
 
     worker_iter = drop(_round_robin_counter[0] % len(workers), cycle(workers))

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -9,7 +9,7 @@ from functools import partial
 from itertools import cycle
 from typing import Any, TypeVar
 
-from tlz import concat, drop, groupby, merge
+from tlz import drop, groupby, merge
 
 import dask.config
 from dask.optimization import SubgraphCallable
@@ -154,16 +154,15 @@ _round_robin_counter = [0]
 async def scatter_to_workers(nthreads, data, rpc=rpc):
     """Scatter data directly to workers
 
-    This distributes data in a round-robin fashion to a set of workers based on
-    how many cores they have.  nthreads should be a dictionary mapping worker
-    identities to numbers of cores.
+    This distributes data in a round-robin fashion to a set of workers.
+    nthreads should be a dictionary mapping worker identities to numbers of cores.
 
     See scatter for parameter docstring
     """
     assert isinstance(nthreads, dict)
     assert isinstance(data, dict)
 
-    workers = list(concat([w] * nc for w, nc in nthreads.items()))
+    workers = sorted(nthreads.keys())
     names, data = list(zip(*data.items()))
 
     worker_iter = drop(_round_robin_counter[0] % len(workers), cycle(workers))


### PR DESCRIPTION
Closes #8586

Split into two commits right now,

- https://github.com/dask/distributed/pull/8590/commits/330a074e3deb3d619aa5c015f5499c2d00f555b8 Does the basic change of round robin by worker instead of by worker->nthreads.
- https://github.com/dask/distributed/pull/8590/commits/0d12629801a08d4e2851f68f19c38667aaeab760 Refactors `scatter_to_workers` to just require an iterable of workers, so callers aren't required to obtain a worker->nthreads mapping.

---

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
