### PR TITLE
Shuffle use pyarrow more broadly

### DIFF
--- a/distributed/shuffle/_disk.py
+++ b/distributed/shuffle/_disk.py
@@ -8,6 +8,8 @@ from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
 from typing import Any
 
+import pyarrow as pa
+from packaging.version import parse as parse_version
 from toolz import concat
 
 from distributed.metrics import context_meter, thread_time
@@ -16,6 +18,12 @@ from distributed.shuffle._exceptions import DataUnavailable
 from distributed.shuffle._limiter import ResourceLimiter
 from distributed.shuffle._pickle import pickle_bytelist
 from distributed.utils import Deadline, empty_context, log_errors, nbytes
+
+if parse_version(pa.__version__) >= parse_version("15.0.0"):
+    # Only >15 support append mode
+    open_file = pa.OSFile
+else:
+    open_file = open
 
 
 class ReadWriteLock:
@@ -177,7 +185,7 @@ class DiskShardsBuffer(ShardsBuffer):
             if self._closed:
                 raise RuntimeError("Already closed")
 
-            with open(self.directory / str(id), mode="ab") as f:
+            with open_file(str(self.directory / str(id)), mode="ab") as f:
                 f.writelines(frames)
 
         context_meter.digest_metric("disk-write", 1, "count")

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -367,9 +367,9 @@ def split_by_partition(
     Split data into many arrow batches, partitioned by final partition
     """
     import numpy as np
+    import pyarrow as pa
 
-    partitions = t.select([column]).to_pandas()[column].unique()
-    partitions.sort()
+    partitions = np.array(pa.compute.unique(t[column]).sort())
     t = t.sort_by(column)
 
     partition = np.asarray(t[column])


### PR DESCRIPTION
These are a couple of very minor fixes that in my very limited small scale testing turned out to speed up things. 

I can speak at least to the `unique` computation that I saw this flare up in profiles as well and benchmarking this on toy examples shows that this is about 20x faster than on main but that depends of course on the kind of data so in general this is likely not as impactful