### PR TITLE
Submit collections metadata to scheduler

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1958,7 +1958,7 @@ class Client(SyncMethodMixin):
             retries=retries,
             fifo_timeout=fifo_timeout,
             actors=actor,
-            span_metadata={"collections": [{"type": "Future"}]},
+            span_metadata=SpanMetadata(collections=[{"type": "Future"}]),
         )
 
         logger.debug("Submit %s(...), %s", funcname(func), key)
@@ -2165,7 +2165,7 @@ class Client(SyncMethodMixin):
             user_priority=priority,
             fifo_timeout=fifo_timeout,
             actors=actor,
-            span_metadata={"collections": [{"type": "Future"}]},
+            span_metadata=SpanMetadata(collections=[{"type": "Future"}]),
         )
         logger.debug("map(%s, ...)", funcname(func))
 
@@ -3270,7 +3270,7 @@ class Client(SyncMethodMixin):
             retries=retries,
             user_priority=priority,
             actors=actors,
-            span_metadata={"collections": [{"type": "low-level-graph"}]},
+            span_metadata=SpanMetadata(collections=[{"type": "low-level-graph"}]),
         )
         packed = pack_data(keys, futures)
         if sync:
@@ -3454,7 +3454,7 @@ class Client(SyncMethodMixin):
 
         variables = [a for a in collections if dask.is_dask_collection(a)]
         metadata = SpanMetadata(
-            {"collections": [get_collections_metadata(v) for v in variables]}
+            collections=[get_collections_metadata(v) for v in variables]
         )
 
         dsk = self.collections_to_dsk(variables, optimize_graph, **kwargs)
@@ -3582,7 +3582,7 @@ class Client(SyncMethodMixin):
 
         assert all(map(dask.is_dask_collection, collections))
         metadata = SpanMetadata(
-            {"collections": [get_collections_metadata(v) for v in collections]}
+            collections=[get_collections_metadata(v) for v in collections]
         )
         dsk = self.collections_to_dsk(collections, optimize_graph, **kwargs)
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3178,7 +3178,7 @@ class Client(SyncMethodMixin):
                     "actors": actors,
                     "code": ToPickle(computations),
                     "annotations": ToPickle(annotations),
-                    "span_metadata": ToPickle(span_metadata),
+                    "span_metadata": span_metadata,
                 }
             )
             return futures

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -3178,7 +3178,7 @@ class Client(SyncMethodMixin):
                     "actors": actors,
                     "code": ToPickle(computations),
                     "annotations": ToPickle(annotations),
-                    "span_metadata": span_metadata,
+                    "span_metadata": ToPickle(span_metadata),
                 }
             )
             return futures

--- a/distributed/recreate_tasks.py
+++ b/distributed/recreate_tasks.py
@@ -93,7 +93,7 @@ class ReplayTaskClient:
         Take raw components and resolve future dependencies.
         """
         function, args, kwargs, deps = raw_components
-        futures = self.client._graph_to_futures({}, deps)
+        futures = self.client._graph_to_futures({}, deps, span_metadata={})
         data = await self.client._gather(futures)
         args = pack_data(args, data)
         kwargs = pack_data(kwargs, data)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4683,6 +4683,8 @@ class Scheduler(SchedulerState, ServerNode):
         # FIXME: Apparently empty dicts arrive as a ToPickle object
         if isinstance(annotations, ToPickle):
             annotations = annotations.data  # type: ignore[unreachable]
+        if isinstance(span_metadata, ToPickle):
+            span_metadata = span_metadata.data  # type: ignore[unreachable]
         start = time()
         try:
             try:

--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -178,7 +178,6 @@ class Span:
             self._metadata = copy.deepcopy(metadata)
         else:
             self._metadata["collections"].extend(metadata["collections"])
-            print("fo")
 
     @property
     def annotation(self) -> dict[str, tuple[str, ...]] | None:

--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -118,7 +118,9 @@ class Span:
     #: stop
     enqueued: float
 
-    _code: dict
+    #: Source code snippets, if it was sent by the client.
+    #: We're using a dict without values as an insertion-sorted set.
+    _code: dict[tuple[SourceCode, ...], None]
     _metadata: SpanMetadata | None
 
     _cumulative_worker_metrics: defaultdict[tuple[Hashable, ...], float]

--- a/distributed/tests/test_dask_collections.py
+++ b/distributed/tests/test_dask_collections.py
@@ -252,26 +252,3 @@ def test_tuple_futures_arg(client, typ):
         ),
     )
     dd.assert_eq(df2.result().iloc[:0], make_time_dataframe().iloc[:0])
-
-
-from distributed import span
-
-
-@gen_cluster(client=True)
-async def test_collections_metadata(c, s, a, b):
-    df = pd.DataFrame(
-        {"x": np.random.random(1000), "y": np.random.random(1000)},
-        index=np.arange(1000),
-    )
-    ldf = dd.from_pandas(df, npartitions=10)
-
-    with span() as span_id:
-        await ldf.compute()
-
-    s.get_span(span_id)
-    ext = s.extensions["spans"]
-    span_ = ext.spans[span_id]
-    collections_meta = span_.metadata["collections"]
-    assert isinstance(collections_meta, list)
-    assert len(collections_meta) == 1
-    assert collections_meta[0]["type"] == type(ldf).__name__

--- a/distributed/tests/test_dask_collections.py
+++ b/distributed/tests/test_dask_collections.py
@@ -252,3 +252,26 @@ def test_tuple_futures_arg(client, typ):
         ),
     )
     dd.assert_eq(df2.result().iloc[:0], make_time_dataframe().iloc[:0])
+
+
+from distributed import span
+
+
+@gen_cluster(client=True)
+async def test_collections_metadata(c, s, a, b):
+    df = pd.DataFrame(
+        {"x": np.random.random(1000), "y": np.random.random(1000)},
+        index=np.arange(1000),
+    )
+    ldf = dd.from_pandas(df, npartitions=10)
+
+    with span() as span_id:
+        await ldf.compute()
+
+    s.get_span(span_id)
+    ext = s.extensions["spans"]
+    span_ = ext.spans[span_id]
+    collections_meta = span_.metadata["collections"]
+    assert isinstance(collections_meta, list)
+    assert len(collections_meta) == 1
+    assert collections_meta[0]["type"] == type(ldf).__name__

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1439,6 +1439,7 @@ async def test_update_graph_culls(s, a, b):
         client="client",
         internal_priority={k: 0 for k in "xyz"},
         submitting_task=None,
+        span_metadata={},
     )
     assert "z" not in s.tasks
 


### PR DESCRIPTION
We're already collecting client local context, e.g. with code. This is some extention to this that enriches span information with the API being used. In the future, this could be expanded with other information but for now I just included the type of collection we're submitting

cc @phofl 