### PR TITLE
Expose paused and retired workers separately in prometheus

### DIFF
--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -48,9 +48,6 @@ class SchedulerMetricCollector(PrometheusCollector):
             - len(self.server.saturated),
         )
         worker_states.add_metric(["saturated"], len(self.server.saturated))
-        worker_states.add_metric(
-            ["paused_or_retiring"], len(self.server.workers) - len(self.server.running)
-        )
         paused_workers = len(
             [w for w in self.server.workers.values() if w.status == Status.paused]
         )

--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -7,6 +7,7 @@ import prometheus_client
 import toolz
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
 
+from distributed.core import Status
 from distributed.http.prometheus import PrometheusCollector
 from distributed.http.scheduler.prometheus.semaphore import SemaphoreMetricCollector
 from distributed.http.scheduler.prometheus.stealing import WorkStealingMetricCollector
@@ -50,6 +51,15 @@ class SchedulerMetricCollector(PrometheusCollector):
         worker_states.add_metric(
             ["paused_or_retiring"], len(self.server.workers) - len(self.server.running)
         )
+        paused_workers = len(
+            [w for w in self.server.workers.values() if w.status == Status.paused]
+        )
+        worker_states.add_metric(["paused"], paused_workers)
+        worker_states.add_metric(
+            ["retiring"],
+            len(self.server.workers) - paused_workers - len(self.server.running),
+        )
+
         yield worker_states
 
         if self.server.monitor.monitor_gil_contention:

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -281,7 +281,6 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
         "idle": 2,
         "partially_saturated": 0,
         "saturated": 0,
-        "paused_or_retiring": 0,
         "paused": 0,
         "retiring": 0,
     }
@@ -293,7 +292,6 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
         "idle": 1,
         "partially_saturated": 1,
         "saturated": 0,
-        "paused_or_retiring": 0,
         "paused": 0,
         "retiring": 0,
     }
@@ -307,7 +305,6 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
         "idle": 1,
         "partially_saturated": 0,
         "saturated": 1,
-        "paused_or_retiring": 0,
         "paused": 0,
         "retiring": 0,
     }
@@ -319,7 +316,6 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
         "idle": 1,
         "partially_saturated": 0,
         "saturated": 0,
-        "paused_or_retiring": 1,
         "paused": 1,
         "retiring": 0,
     }
@@ -332,7 +328,6 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
         "idle": 1,
         "partially_saturated": 0,
         "saturated": 0,
-        "paused_or_retiring": 1,
         "paused": 0,
         "retiring": 1,
     }


### PR DESCRIPTION
Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`


cc @ntabris for the grafana dashboards