### PR TITLE
Send log-event if worker is restarted because of memory pressure

### DIFF
--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -637,7 +637,7 @@ async def test_repeated_restarts(c, s, a, b):
         assert len(s.workers) == 2
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @gen_cluster(
     client=True,
     Worker=Nanny,

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -661,7 +661,7 @@ async def test_restart_memory(c, s, n):
         await asyncio.sleep(0.1)
 
     msgs = s.get_events("worker-restart-memory")
-    assert len(msgs) == 1
+    assert len(msgs)
     msg = msgs[0][1]
     assert isinstance(msg, dict)
     assert {"worker", "pid", "rss"}.issubset(set(msg))

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -637,7 +637,7 @@ async def test_repeated_restarts(c, s, a, b):
         assert len(s.workers) == 2
 
 
-@pytest.mark.slow
+# @pytest.mark.slow
 @gen_cluster(
     client=True,
     Worker=Nanny,
@@ -659,6 +659,10 @@ async def test_restart_memory(c, s, n):
 
     while not s.workers:
         await asyncio.sleep(0.1)
+
+    assert all(
+        "memory budget" in msg[1] for msg in s.get_events("worker-restart-memory")
+    )
 
 
 class BlockClose(WorkerPlugin):

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -660,9 +660,11 @@ async def test_restart_memory(c, s, n):
     while not s.workers:
         await asyncio.sleep(0.1)
 
-    assert all(
-        "memory budget" in msg[1] for msg in s.get_events("worker-restart-memory")
-    )
+    msgs = s.get_events("worker-restart-memory")
+    assert len(msgs) == 1
+    msg = msgs[0][1]
+    assert isinstance(msg, dict)
+    assert {"worker", "pid", "rss"}.issubset(set(msg))
 
 
 class BlockClose(WorkerPlugin):

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -424,6 +424,11 @@ class NannyMemoryManager:
             )
             nanny_logger.warning(msg)
             self._last_terminated_pid = process.pid
+            msg = {
+                "worker": nanny.worker_address,
+                 "pid": process.pid,
+                 "rss": memory,
+            }
             nanny.log_event("worker-restart-memory", msg)
             process.terminate()
         else:

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -424,12 +424,12 @@ class NannyMemoryManager:
             )
             nanny_logger.warning(msg)
             self._last_terminated_pid = process.pid
-            msg = {
+            event = {
                 "worker": nanny.worker_address,
                 "pid": process.pid,
                 "rss": memory,
             }
-            nanny.log_event("worker-restart-memory", msg)
+            nanny.log_event("worker-restart-memory", event)
             process.terminate()
         else:
             # We already sent SIGTERM to the worker, but the process is still alive

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -417,12 +417,14 @@ class NannyMemoryManager:
             return
 
         if self._last_terminated_pid != process.pid:
-            nanny_logger.warning(
+            msg = (
                 f"Worker {nanny.worker_address} (pid={process.pid}) exceeded "
                 f"{self.memory_terminate_fraction * 100:.0f}% memory budget. "
-                "Restarting...",
+                f"Restarting..."
             )
+            nanny_logger.warning(msg)
             self._last_terminated_pid = process.pid
+            nanny.log_event("worker-restart-memory", msg)
             process.terminate()
         else:
             # We already sent SIGTERM to the worker, but the process is still alive

--- a/distributed/worker_memory.py
+++ b/distributed/worker_memory.py
@@ -426,8 +426,8 @@ class NannyMemoryManager:
             self._last_terminated_pid = process.pid
             msg = {
                 "worker": nanny.worker_address,
-                 "pid": process.pid,
-                 "rss": memory,
+                "pid": process.pid,
+                "rss": memory,
             }
             nanny.log_event("worker-restart-memory", msg)
             process.terminate()


### PR DESCRIPTION
Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
