### PR TITLE
use monotonic for deadline test

### DIFF
--- a/distributed/tests/test_deadline.py
+++ b/distributed/tests/test_deadline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from time import sleep
 
-from distributed.metrics import time
+from distributed.metrics import monotonic
 from distributed.utils import Deadline
 from distributed.utils_test import gen_test
 
@@ -36,21 +36,21 @@ def test_infinite_deadline():
 
 @gen_test()
 async def test_deadline_progress():
-    before_start = time()
+    before_start = monotonic()
     deadline = Deadline.after(100)
-    after_start = time()
+    after_start = monotonic()
 
-    assert before_start <= deadline.started_at <= after_start
-    assert deadline.started_at - time() <= deadline.remaining <= 100
+    assert before_start <= deadline.started_at_mono <= after_start
+    assert deadline.started_at_mono - monotonic() <= deadline.remaining <= 100
 
     await asyncio.sleep(0.1)
-    before_elapsed = time()
+    before_elapsed = monotonic()
     elapsed = deadline.elapsed
-    after_elapsed = time()
+    after_elapsed = monotonic()
     assert (
-        before_elapsed - deadline.started_at
+        before_elapsed - deadline.started_at_mono
         <= elapsed
-        <= after_elapsed - deadline.started_at
+        <= after_elapsed - deadline.started_at_mono
     )
 
 


### PR DESCRIPTION
This has been flaking here and there. With non-monotonic clocks this test is not guaranteed to pass without much more sleeping