### PR TITLE
Ensure inproc properly emulates serialization protocol

### DIFF
--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -13,7 +13,7 @@ from tornado.ioloop import IOLoop
 
 from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend, backends
-from distributed.protocol import nested_deserialize
+from distributed.protocol.serialize import _nested_deserialize
 from distributed.utils import get_ip, is_python_shutting_down
 
 logger = logging.getLogger(__name__)
@@ -218,8 +218,7 @@ class InProc(Comm):
             self._finalizer.detach()
             raise CommClosedError()
 
-        if self.deserialize:
-            msg = nested_deserialize(msg)
+        msg = _nested_deserialize(msg, self.deserialize)
         return msg
 
     async def write(self, msg, serializers=None, on_error=None):

--- a/distributed/protocol/__init__.py
+++ b/distributed/protocol/__init__.py
@@ -6,8 +6,10 @@ from functools import partial
 from distributed.protocol.core import decompress, dumps, loads, maybe_compress, msgpack
 from distributed.protocol.cuda import cuda_deserialize, cuda_serialize
 from distributed.protocol.serialize import (
+    Pickled,
     Serialize,
     Serialized,
+    ToPickle,
     dask_deserialize,
     dask_serialize,
     deserialize,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4676,9 +4676,6 @@ class Scheduler(SchedulerState, ServerNode):
         annotations: dict | None = None,
         stimulus_id: str | None = None,
     ) -> None:
-        # FIXME: Apparently empty dicts arrive as a ToPickle object
-        if isinstance(annotations, ToPickle):
-            annotations = annotations.data  # type: ignore[unreachable]
         start = time()
         try:
             try:

--- a/distributed/shuffle/tests/utils.py
+++ b/distributed/shuffle/tests/utils.py
@@ -22,7 +22,7 @@ class PooledRPCShuffle(PooledRPCCall):
 
     def __getattr__(self, key):
         async def _(**kwargs):
-            from distributed.protocol.serialize import nested_deserialize
+            from distributed.protocol.serialize import _nested_deserialize
 
             method_name = key.replace("shuffle_", "")
             kwargs.pop("shuffle_id", None)
@@ -30,7 +30,7 @@ class PooledRPCShuffle(PooledRPCCall):
             # TODO: This is a bit awkward. At some point the arguments are
             # already getting wrapped with a `Serialize`. We only want to unwrap
             # here.
-            kwargs = nested_deserialize(kwargs)
+            kwargs = _nested_deserialize(kwargs)
             meth = getattr(self.shuffle, method_name)
             return await meth(**kwargs)
 


### PR DESCRIPTION
Ran into this again in https://github.com/dask/distributed/pull/8612. Quite annoyingly, the InProc comm is not actually serializing stuff but is just emulating the behavior of the serialization protocol. This is nice because it should make our tests faster but it doesn't reflect reality since the ToPickle functionality is actually implemented on the serialization side, i.e. if we never serialize, the object stays untouched.

I could see how this fix also slows down the testsuite but I don't think we should just ignore this.