### PR TITLE
Automate GitHub Releases when new tags are pushed

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,13 @@
+# These will be overridden by the publish workflow and set to the new tag
+name-template: 'Next Release'
+tag-template: 'next'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+template: |
+  ## Changes
+
+  $CHANGES  
+
+  See the [Changelog](https://docs.dask.org/en/stable/changelog.html) for more information.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,15 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to get tag history
+      - name: Check if release commit
+        id: check_release_commit
+        run: git describe --exact-match --tags $(git rev-parse HEAD)
+        continue-on-error: true
+      - uses: release-drafter/release-drafter@v6
+        if: steps.check_release_commit.outcome != 'success'
         with:
           disable-autolabeler: true
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    if: github.repository == 'dask/distributed'
+    permissions:
+      # Write permission is required to create a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,33 @@
+name: Release Publisher
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish_release:
+    if: github.repository == 'dask/distributed'
+    permissions:
+      # Write permission is required to publish a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version env
+        # Use a little bit of bash to extract the tag name from the GitHub ref
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+          # Override the Release name/tag/version with the actual tag name
+          name: ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+          # Publish the Release
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In https://github.com/dask/dask/pull/11057 I added some GitHub Actions workflows to automatically create [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) when a new tag is pushed. Releases are just a page linked to a git tag with a title, some markdown text containing release notes and optional build artifacts for download.

We don't make use of the build artifact distribution in the Python community because we have PyPI and Conda Forge, but some users have expressed interest in having GitHub Releases as they show up in feeds, can be subscribed to, and generally make it easier to discover new releases in the GitHub ecosystem. See https://github.com/dask/dask/issues/10956.

In this PR I've added the same GitHub Actions here which will automatically create a GitHub Release when a new tag is pushed. The release notes will be populated with the titles of all the PRs that went into the release, and have a link to the main Dask changelog at the bottom.

My goal here is to give value to the users who want Releases, but without adding any burden to the maintainer making the release. So this is pretty much set and forget once merged.

I've also created a [Release for 2024.4.2 here manually](https://github.com/dask/distributed/releases/tag/2024.4.2) because the Action needs at least one existing release as a frame of reference to calculate the changelog. We can manually clean this up after the next release.