### PR TITLE
[WIP] do not initialize logging on import

### DIFF
--- a/distributed/config.py
+++ b/distributed/config.py
@@ -4,6 +4,7 @@ import asyncio
 import logging.config
 import os
 import sys
+import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -212,4 +213,13 @@ def get_loop_factory() -> Callable[[], asyncio.AbstractEventLoop] | None:
     )
 
 
-initialize_logging(dask.config.config)
+_LOGGING_CONFIGURED = False
+_LOG_CONFIGURE_LOCK = threading.Lock()
+
+
+def ensure_logging_configured() -> None:
+    global _LOGGING_CONFIGURED
+    with _LOG_CONFIGURE_LOCK:
+        if not _LOGGING_CONFIGURED:
+            _LOGGING_CONFIGURED = True
+            initialize_logging(dask.config.config)

--- a/distributed/core.py
+++ b/distributed/core.py
@@ -45,6 +45,7 @@ from distributed.comm import (
 )
 from distributed.comm.core import Listener
 from distributed.compatibility import PeriodicCallback
+from distributed.config import ensure_logging_configured
 from distributed.counter import Counter
 from distributed.diskutils import WorkDir, WorkSpace
 from distributed.metrics import context_meter, time
@@ -647,6 +648,7 @@ class Server:
 
     @final
     async def start(self):
+        ensure_logging_configured()
         async with self._startup_lock:
             if self.status == Status.failed:
                 assert self.__startup_exc is not None

--- a/distributed/deploy/cluster.py
+++ b/distributed/deploy/cluster.py
@@ -16,6 +16,7 @@ from dask.utils import _deprecated, format_bytes, parse_timedelta, typename
 from dask.widgets import get_template
 
 from distributed.compatibility import PeriodicCallback
+from distributed.config import ensure_logging_configured
 from distributed.core import Status
 from distributed.deploy.adaptive import Adaptive
 from distributed.metrics import time
@@ -67,6 +68,7 @@ class Cluster(SyncMethodMixin):
         name=None,
         scheduler_sync_interval=1,
     ):
+        ensure_logging_configured()
         self._loop_runner = LoopRunner(loop=loop, asynchronous=asynchronous)
         self.__asynchronous = asynchronous
 


### PR DESCRIPTION
Initializing logging on import has many unwanted side-effects.

Most importantly, it is very difficult to configure / overwrite anything unless the config file is overwritten directly. This should delay log configuration until it is needed. This allows code like this to work


```python
import logging

import dask
import dask.bag as db

from dask.distributed import Client

with dask.config.set({
    "logging": {
        "custom": "info",
        "distributed": "warning",  # Default is INFO which is a little verbose
    }
}):
    client = Client()

logger = logging.getLogger("custom")
logger.setLevel(logging.INFO)


def task(n: int):
    logger.info(f"Hello {n}")
    
bag = db.from_sequence([1,2,3])
bag.map(task).compute()
```

which just prints 

```
2024-05-06 12:55:07,779 - matt - INFO - Hello 1
2024-05-06 12:55:07,779 - matt - INFO - Hello 3
2024-05-06 12:55:07,779 - matt - INFO - Hello 2
```