### PR TITLE
Revert "Bump actions/checkout from 4.1.2 to 4.1.3"

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     name: pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v4.1.2
       - uses: actions/setup-python@v5
         with:
           python-version: '3.9'

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build (and upload)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v4.1.2
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v4.1.2
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -120,7 +120,7 @@ jobs:
         shell: bash
 
       - name: Checkout source
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v4.1.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-gpuci.yaml
+++ b/.github/workflows/update-gpuci.yaml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'dask/distributed'
 
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v4.1.2
 
       - name: Parse current axis YAML
         id: rapids_current


### PR DESCRIPTION
Reverts dask/distributed#8628 to unblock CI until https://github.com/dask/distributed/issues/8636 has been fixed.