### PR TITLE
Avoid multiple WorkerState sphinx error

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -21,9 +21,12 @@ from distributed.protocol.pickle import dumps
 
 if TYPE_CHECKING:
     # circular imports
+    # Needed to avoid Sphinx WARNING: more than one target found for cross-reference
+    # 'WorkerState'"
+    # https://github.com/agronholm/sphinx-autodoc-typehints#dealing-with-circular-imports
+    from distributed import scheduler as scheduler_module
     from distributed.scheduler import Scheduler
     from distributed.scheduler import TaskStateState as SchedulerTaskStateState
-    from distributed.scheduler import WorkerState
     from distributed.worker import Worker
     from distributed.worker_state_machine import TaskStateState as WorkerTaskStateState
 
@@ -207,8 +210,8 @@ class SchedulerPlugin:
         """Run when a client disconnects"""
 
     def valid_workers_downscaling(
-        self, scheduler: Scheduler, workers: list[WorkerState]
-    ) -> list[WorkerState]:
+        self, scheduler: Scheduler, workers: list[scheduler_module.WorkerState]
+    ) -> list[scheduler_module.WorkerState]:
         """Determine which workers can be removed from the cluster
 
         This method is called when the scheduler is about to downscale the cluster


### PR DESCRIPTION
Currently our docs build is failing with 

```
/home/docs/checkouts/readthedocs.org/user_builds/distributed/envs/8638/lib/python3.11/site-packages/distributed/diagnostics/plugin.py:docstring of 
distributed.diagnostics.plugin.SchedulerPlugin.valid_workers_downscaling:: WARNING: more than
one target found for cross-reference 'WorkerState': distributed.scheduler.WorkerState, distributed.worker_state_machine.WorkerState
```

This PR avoid that error by using the same workaround as 

https://github.com/dask/distributed/blob/d5edb4e536c9acc4998f803aacc0dd0188af21ce/distributed/active_memory_manager.py#L19-L23

