### PR TITLE
Reduce task group count for partial P2P rechunks

### DIFF
--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -199,6 +199,14 @@ class _NDPartial(NamedTuple):
     #: to exclude from this partial.
     #: This corresponds to `left_start` of the subsequent partial.
     right_stops: NDIndex
+    #: Index of the partial among all partials.
+    #: This corresponds to the position of the partial in the n-dimensional grid of
+    #: partials representing the full rechunk.
+    ix: NDIndex
+
+
+def rechunk_name(token: str) -> str:
+    return f"rechunk-p2p-{token}"
 
 
 def rechunk_p2p(x: da.Array, chunks: ChunkedAxes) -> da.Array:
@@ -210,14 +218,14 @@ def rechunk_p2p(x: da.Array, chunks: ChunkedAxes) -> da.Array:
 
     dsk = {}
     token = tokenize(x, chunks)
-    name = f"rechunk-p2p-{token}"
     for ndpartial in _split_partials(x, chunks):
         if all(slc.stop == slc.start + 1 for slc in ndpartial.new):
             # Single output chunk
-            dsk.update(partial_concatenate(x, chunks, ndpartial, name))
+            dsk.update(partial_concatenate(x, chunks, ndpartial, token))
         else:
-            dsk.update(partial_rechunk(x, chunks, ndpartial, name))
+            dsk.update(partial_rechunk(x, chunks, ndpartial, token))
     layer = MaterializedLayer(dsk)
+    name = rechunk_name(token)
     graph = HighLevelGraph.from_collections(name, layer, dependencies=[x])
     arr = da.Array(graph, name, chunks, meta=x)
     return arr
@@ -228,9 +236,12 @@ def _split_partials(
 ) -> Generator[_NDPartial, None, None]:
     """Split the rechunking into partials that can be performed separately"""
     partials_per_axis = _split_partials_per_axis(x, chunks)
-    for partial_per_axis in product(*partials_per_axis):
+    indices_per_axis = (range(len(partials)) for partials in partials_per_axis)
+    for nindex, partial_per_axis in zip(
+        product(*indices_per_axis), product(*partials_per_axis)
+    ):
         old, new, left_starts, right_stops = zip(*partial_per_axis)
-        yield _NDPartial(old, new, left_starts, right_stops)
+        yield _NDPartial(old, new, left_starts, right_stops, nindex)
 
 
 def _split_partials_per_axis(
@@ -311,7 +322,7 @@ def partial_concatenate(
     x: da.Array,
     chunks: ChunkedAxes,
     ndpartial: _NDPartial,
-    name: str,
+    token: str,
 ) -> dict[Key, Any]:
     import numpy as np
 
@@ -320,8 +331,7 @@ def partial_concatenate(
 
     dsk: dict[Key, Any] = {}
 
-    partial_token = tokenize(x, chunks, ndpartial.new)
-    slice_name = f"rechunk-slice-{partial_token}"
+    slice_name = f"rechunk-slice-{token}"
     old_offset = tuple(slice_.start for slice_ in ndpartial.old)
 
     shape = tuple(slice_.stop - slice_.start for slice_ in ndpartial.old)
@@ -340,8 +350,9 @@ def partial_concatenate(
             axis[index] for index, axis in zip(old_global_index, x.chunks)
         )
         if _slicing_is_necessary(ndslice, original_shape):
-            rec_cat_arg[old_partial_index] = (slice_name,) + old_global_index
-            dsk[(slice_name,) + old_global_index] = (
+            key = (slice_name,) + ndpartial.ix + old_global_index
+            rec_cat_arg[old_partial_index] = key
+            dsk[key] = (
                 getitem,
                 (x.name,) + old_global_index,
                 ndslice,
@@ -349,7 +360,7 @@ def partial_concatenate(
         else:
             rec_cat_arg[old_partial_index] = (x.name,) + old_global_index
     global_index = tuple(int(slice_.start) for slice_ in ndpartial.new)
-    dsk[(name,) + global_index] = (
+    dsk[(rechunk_name(token),) + global_index] = (
         concatenate3,
         rec_cat_arg.tolist(),
     )
@@ -381,7 +392,7 @@ def partial_rechunk(
     x: da.Array,
     chunks: ChunkedAxes,
     ndpartial: _NDPartial,
-    name: str,
+    token: str,
 ) -> dict[Key, Any]:
     from dask.array.chunk import getitem
 
@@ -389,10 +400,10 @@ def partial_rechunk(
 
     old_partial_offset = tuple(slice_.start for slice_ in ndpartial.old)
 
-    partial_token = tokenize(x, chunks, ndpartial.new)
+    partial_token = tokenize(token, ndpartial.ix)
     _barrier_key = barrier_key(ShuffleId(partial_token))
-    slice_name = f"rechunk-slice-{partial_token}"
-    transfer_name = f"rechunk-transfer-{partial_token}"
+    slice_name = f"rechunk-slice-{token}"
+    transfer_name = f"rechunk-transfer-{token}"
     disk: bool = dask.config.get("distributed.p2p.disk")
 
     ndim = len(x.shape)
@@ -414,19 +425,21 @@ def partial_rechunk(
             axis[index] for index, axis in zip(global_index, x.chunks)
         )
         if _slicing_is_necessary(ndslice, original_shape):
-            input_task = (slice_name,) + global_index
-            dsk[(slice_name,) + global_index] = (
+            key = (slice_name,) + ndpartial.ix + global_index
+            input_key = (slice_name,) + ndpartial.ix + global_index
+            dsk[key] = (
                 getitem,
                 (x.name,) + global_index,
                 ndslice,
             )
         else:
-            input_task = (x.name,) + global_index
+            input_key = (x.name,) + global_index
 
-        transfer_keys.append((transfer_name,) + global_index)
-        dsk[(transfer_name,) + global_index] = (
+        key = (transfer_name,) + ndpartial.ix + global_index
+        transfer_keys.append(key)
+        dsk[key] = (
             rechunk_transfer,
-            input_task,
+            input_key,
             partial_token,
             partial_index,
             partial_new,
@@ -439,7 +452,7 @@ def partial_rechunk(
     new_partial_offset = tuple(axis.start for axis in ndpartial.new)
     for partial_index in _partial_ndindex(ndpartial.new):
         global_index = _global_index(partial_index, new_partial_offset)
-        dsk[(name,) + global_index] = (
+        dsk[(rechunk_name(token),) + global_index] = (
             rechunk_unpack,
             partial_token,
             partial_index,

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -12,6 +12,7 @@ np = pytest.importorskip("numpy")
 da = pytest.importorskip("dask.array")
 
 from concurrent.futures import ThreadPoolExecutor
+from itertools import product
 
 from tornado.ioloop import IOLoop
 
@@ -33,7 +34,7 @@ from distributed.shuffle._rechunk import (
     split_axes,
 )
 from distributed.shuffle.tests.utils import AbstractShuffleTestPool
-from distributed.utils_test import gen_cluster, gen_test
+from distributed.utils_test import async_poll_for, gen_cluster, gen_test
 
 NUMPY_GE_124 = parse_version(np.__version__) >= parse_version("1.24")
 
@@ -83,9 +84,6 @@ class ArrayRechunkTestPool(AbstractShuffleTestPool):
         )
         self.shuffles[name] = s
         return s
-
-
-from itertools import product
 
 
 @pytest.mark.parametrize("n_workers", [1, 10])
@@ -1259,8 +1257,6 @@ def test_pick_worker_homogeneous_distribution(nworkers):
     config={"distributed.scheduler.active-memory-manager.start": False},
 )
 async def test_partial_rechunk_homogeneous_distribution(c, s, *workers):
-    da = pytest.importorskip("dask.array")
-
     # This rechunk operation can be split into 10 independent shuffles with 4 output
     # chunks each. This is less than the number of workers, so we are at risk of
     # choosing the same 4 output workers in each separate shuffle.
@@ -1275,3 +1271,43 @@ async def test_partial_rechunk_homogeneous_distribution(c, s, *workers):
     nchunks = [len(w.data.keys() & out_keys) for w in workers]
     # There are 40 output chunks and 5 workers. Expect exactly 8 chunks per worker.
     assert nchunks == [8, 8, 8, 8, 8]
+
+
+@gen_cluster(client=True, nthreads=[], config={"optimization.fuse.active": False})
+async def test_partial_rechunk_taskgroups(c, s):
+    arr = da.random.random((40, 40), chunks=(4, 4))
+    arr = arr.rechunk((1, -1), method="p2p")
+
+    _ = c.compute(arr)
+    await async_poll_for(
+        lambda: any(
+            isinstance(task, str) and task.startswith("shuffle-barrier")
+            for task in s.tasks
+        ),
+        timeout=5,
+    )
+    # Ensure that independent partial rechunks do not blow up the number of task groups
+    assert (
+        sum(
+            1
+            for task in s.task_groups
+            if isinstance(task, str) and task.startswith("rechunk-transfer")
+        )
+        == 1
+    )
+    assert (
+        sum(
+            1
+            for task in s.task_groups
+            if isinstance(task, str) and task.startswith("shuffle-barrier")
+        )
+        == 1
+    )
+    assert (
+        sum(
+            1
+            for task in s.task_groups
+            if isinstance(task, str) and task.startswith("rechunk-p2p")
+        )
+        == 1
+    )


### PR DESCRIPTION
Previously, independent partials of a P2P rechunk would create their own independent task groups. This could lead to an explosion of the task group count and slow down the scheduler. This PR fixes that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
