### PR TITLE
Add Prometheus gauge for task groups

### DIFF
--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -102,6 +102,12 @@ class SchedulerMetricCollector(PrometheusCollector):
                 tasks.add_metric([state], task_counter.get(state, 0.0))
         yield tasks
 
+        yield GaugeMetricFamily(
+            self.build_name("task_groups"),
+            "Number of task groups known by scheduler",
+            value=len(self.server.task_groups),
+        )
+
         time_spent_compute_tasks = CounterMetricFamily(
             self.build_name("tasks_compute"),
             "Total amount of compute time spent in each prefix",

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -121,6 +122,7 @@ async def test_prometheus(c, s, a, b):
         "dask_scheduler_tasks_output_bytes",
         "dask_scheduler_tasks_compute_seconds",
         "dask_scheduler_tasks_transfer_seconds",
+        "dask_scheduler_task_groups",
         "dask_scheduler_prefix_state_totals",
         "dask_scheduler_tick_count",
         "dask_scheduler_tick_duration_maximum_seconds",
@@ -215,6 +217,67 @@ async def test_prometheus_collect_task_states(c, s, a, b):
     assert active_metrics.keys() == expected
     assert sum(active_metrics.values()) == 0.0
     assert sum(forgotten_tasks) == 0.0
+
+
+@gen_cluster(client=True)
+async def test_prometheus_collect_task_groups(c, s, a, b):
+    pytest.importorskip("prometheus_client")
+
+    async def fetch_task_groups_metric():
+        families = await fetch_metrics(s.http_server.port, prefix="dask_scheduler_")
+        return families["dask_scheduler_task_groups"]
+
+    assert not s.task_groups
+    metric = await fetch_task_groups_metric()
+    assert len(metric.samples) == 1
+    assert metric.samples[0].value == 0
+
+    # submit a task which should show up in the prometheus scraping
+    def block(x: Any, in_event: Event, block_event: Event) -> Any:
+        in_event.set()
+        block_event.wait()
+        return x
+
+    in_event = Event()
+    block_event = Event()
+
+    future = c.submit(block, 1, in_event, block_event, key=("block-first", 1))
+
+    await in_event.wait()
+    assert len(s.task_groups) == 1
+    metric = await fetch_task_groups_metric()
+    assert len(metric.samples) == 1
+    assert metric.samples[0].value == 1
+
+    in_event_2 = Event()
+    block_event_2 = Event()
+
+    future2 = c.submit(block, 2, in_event_2, block_event_2, key=("block-second", 2))
+
+    await in_event_2.wait()
+    assert len(s.task_groups) == 2
+    metric = await fetch_task_groups_metric()
+    assert len(metric.samples) == 1
+    assert metric.samples[0].value == 2
+
+    await block_event.set()
+    res = await c.gather(future)
+    assert res == 1
+
+    await block_event_2.set()
+    res2 = await c.gather(future2)
+    assert res2 == 2
+
+    future.release()
+    future2.release()
+
+    while s.task_groups:
+        await asyncio.sleep(0.001)
+
+    assert not s.task_groups
+    metric = await fetch_task_groups_metric()
+    assert len(metric.samples) == 1
+    assert metric.samples[0].value == 0
 
 
 @gen_cluster(client=True, clean_kwargs={"threads": False})

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -62,6 +62,8 @@ dask_scheduler_tasks_output_bytes
     Note that when a task output is transferred between worker, you'll typically end up
     with a duplicate, so this measure is going to be lower than the actual cluster-wide
     managed memory. See also ``dask_worker_memory_bytes``, which does count duplicates.
+dask_scheduler_task_groups
+    Number of task groups known by scheduler
 dask_scheduler_prefix_state_totals_total
     Accumulated count of task prefix in each state
 dask_scheduler_tick_count_total


### PR DESCRIPTION
As mentioned in #8656, a large number of task groups can cause significant strain on the scheduler. This PR adds a gauge to the Prometheus metric to monitor this. 