### PR TITLE
[P2P] Log event during failure

### DIFF
--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -472,6 +472,7 @@ class SchedulerShuffleState(Generic[_T_partition_id]):
     run_spec: ShuffleRunSpec
     participating_workers: set[str]
     _archived_by: str | None = field(default=None, init=False)
+    _failed: bool = False
 
     @property
     def id(self) -> ShuffleId:

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -389,12 +389,15 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         if finish == "erred":
             ts = self.scheduler.tasks[key]
             for active_shuffle in self.active_shuffles.values():
+                if active_shuffle._failed:
+                    continue
                 barrier = self.scheduler.tasks[barrier_key(active_shuffle.id)]
                 if (
                     ts == barrier
                     or ts in barrier.dependents
                     or ts in barrier.dependencies
                 ):
+                    active_shuffle._failed = True
                     self.scheduler.log_event(
                         "p2p",
                         {

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -390,8 +390,12 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
             ts = self.scheduler.tasks[key]
             for active_shuffle in self.active_shuffles.values():
                 barrier = self.scheduler.tasks[barrier_key(active_shuffle.id)]
-                if ts == barrier or ts in barrier.dependents:
-                    self.log_event(
+                if (
+                    ts == barrier
+                    or ts in barrier.dependents
+                    or ts in barrier.dependencies
+                ):
+                    self.scheduler.log_event(
                         "p2p",
                         {
                             "action": "p2p-failed",

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -383,8 +383,24 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         **kwargs: Any,
     ) -> None:
         """Clean up scheduler and worker state once a shuffle becomes inactive."""
-        if finish not in ("released", "forgotten"):
+        if finish not in ("released", "erred", "forgotten"):
             return
+
+        if finish == "erred":
+            ts = self.scheduler.tasks[key]
+            for active_shuffle in self.active_shuffles.values():
+                barrier = self.scheduler.tasks[barrier_key(active_shuffle.id)]
+                if ts == barrier or ts in barrier.dependents:
+                    self.log_event(
+                        "p2p",
+                        {
+                            "action": "p2p-failed",
+                            "shuffle": active_shuffle.id,
+                            "stimulus": stimulus_id,
+                        },
+                    )
+                    return
+
         shuffle_id = id_from_key(key)
         if not shuffle_id:
             return

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -434,7 +434,34 @@ async def test_restarting_during_transfer_raises_killed_worker(c, s, a, b):
 
     with pytest.raises(KilledWorker):
         await out
+    assert any(event["action"] == "p2p-failed" for _, event in s.events["p2p"])
 
+    await c.close()
+    await check_worker_cleanup(a)
+    await check_worker_cleanup(b, closed=True)
+    await check_scheduler_cleanup(s)
+
+
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 2,
+    config={"distributed.scheduler.allowed-failures": 1},
+)
+async def test_restarting_does_not_log_p2p_failed(c, s, a, b):
+    df = dask.datasets.timeseries(
+        start="2000-01-01",
+        end="2000-03-01",
+        dtypes={"x": float, "y": float},
+        freq="10 s",
+    )
+    with dask.config.set({"dataframe.shuffle.method": "p2p"}):
+        out = df.shuffle("x")
+    out = c.compute(out.x.size)
+    await wait_for_tasks_in_state("shuffle-transfer", "memory", 1, b)
+    await b.close()
+
+    await out
+    assert not s.events["p2p"]
     await c.close()
     await check_worker_cleanup(a)
     await check_worker_cleanup(b, closed=True)
@@ -797,6 +824,7 @@ async def test_restarting_during_barrier_raises_killed_worker(c, s, a, b):
 
     with pytest.raises(KilledWorker):
         await out
+    assert any(event["action"] == "p2p-failed" for _, event in s.events["p2p"])
 
     alive_shuffle.block_inputs_done.set()
 
@@ -959,6 +987,7 @@ async def test_restarting_during_unpack_raises_killed_worker(c, s, a, b):
 
     with pytest.raises(KilledWorker):
         await out
+    assert any(event["action"] == "p2p-failed" for _, event in s.events["p2p"])
 
     await c.close()
     await check_worker_cleanup(a)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -434,7 +434,7 @@ async def test_restarting_during_transfer_raises_killed_worker(c, s, a, b):
 
     with pytest.raises(KilledWorker):
         await out
-    assert any(event["action"] == "p2p-failed" for _, event in s.events["p2p"])
+    assert sum(event["action"] == "p2p-failed" for _, event in s.events["p2p"]) == 1
 
     await c.close()
     await check_worker_cleanup(a)
@@ -824,7 +824,7 @@ async def test_restarting_during_barrier_raises_killed_worker(c, s, a, b):
 
     with pytest.raises(KilledWorker):
         await out
-    assert any(event["action"] == "p2p-failed" for _, event in s.events["p2p"])
+    assert sum(event["action"] == "p2p-failed" for _, event in s.events["p2p"]) == 1
 
     alive_shuffle.block_inputs_done.set()
 
@@ -987,7 +987,7 @@ async def test_restarting_during_unpack_raises_killed_worker(c, s, a, b):
 
     with pytest.raises(KilledWorker):
         await out
-    assert any(event["action"] == "p2p-failed" for _, event in s.events["p2p"])
+    assert sum(event["action"] == "p2p-failed" for _, event in s.events["p2p"]) == 1
 
     await c.close()
     await check_worker_cleanup(a)


### PR DESCRIPTION
Adds a log event if a P2P operation fails while it's active.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
