### PR TITLE
Reduce noise from erring tasks that are not supposed to be running

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2371,7 +2371,7 @@ class Worker(BaseWorker, ServerNode):
             #   _prepare_args_for_execution() to raise KeyError;
             # - A dependency was unspilled but failed to deserialize due to a bug in
             #   user-defined or third party classes.
-            if ts.state in ("executing", "long-running", "resumed"):
+            if ts.state in ("executing", "long-running"):
                 logger.error(
                     f"Exception during execution of task {key!r}",
                     exc_info=True,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2354,6 +2354,7 @@ class Worker(BaseWorker, ServerNode):
                     convert_kwargs_to_str(kwargs2, max_len=1000),
                     result["exception_text"],
                 )
+
             return ExecuteFailureEvent.from_exception(
                 result,
                 key=key,


### PR DESCRIPTION
Cancelled tasks emit error logs even though they're not supposed to be running anymore which can become noisy in P2P's consistency mechanism. This PR fixes that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
