### PR TITLE
Fix too strict assertion in shuffle code for pandas subclasses

### DIFF
--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -322,7 +322,7 @@ def split_by_worker(
 
     # (cudf support) Avoid pd.Series
     constructor = df._constructor_sliced
-    worker_for = constructor(worker_for)
+    worker_for = constructor(worker_for)  # type: ignore
     df = df.merge(
         right=worker_for.cat.codes.rename("_worker"),
         left_on=column,

--- a/distributed/shuffle/_shuffle.py
+++ b/distributed/shuffle/_shuffle.py
@@ -322,7 +322,6 @@ def split_by_worker(
 
     # (cudf support) Avoid pd.Series
     constructor = df._constructor_sliced
-    assert isinstance(constructor, type)
     worker_for = constructor(worker_for)
     df = df.merge(
         right=worker_for.cat.codes.rename("_worker"),


### PR DESCRIPTION
I am testing the p2p shuffle in dask-geopandas (https://github.com/geopandas/dask-geopandas/pull/295), and this fix was needed to get it running.  
Pandas does not require that the `_constructor_sliced` attribute for subclasses is a class (type) itself, it should just be a callable to construct the subclassed Series object (that is also how it is used here: it's only used on the line below as a callable `worker_for = constructor(worker_for)`). So this assertion is wrong (and not necessary anyway IMO, if this attribute would do something wrong, that's a problem with the subclass in general)

I haven't added a test for now (it would require to add a dummy pandas / dask collection subclass boilerplate (given you don't want to depend on an external package like dask-geopandas I think), but that seems a bit much for this simple change).