### PR TITLE
Log task state in "Compute Failed" message

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -174,6 +174,7 @@ async def test_worker_bad_args(c, s, a, b):
     assert any("1 / 0" in line for line in pluck(3, traceback.extract_tb(tb)) if line)
     assert "Compute Failed" in hdlr.messages["warning"][0]
     assert y.key in hdlr.messages["warning"][0]
+    assert "executing" in hdlr.messages["warning"][0]
     logger.setLevel(old_level)
 
     # Now we check that both workers are still alive.

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2344,11 +2344,13 @@ class Worker(BaseWorker, ServerNode):
                 logger.warning(
                     "Compute Failed\n"
                     "Key:       %s\n"
+                    "State:     %s\n"
                     "Function:  %s\n"
                     "args:      %s\n"
                     "kwargs:    %s\n"
                     "Exception: %r\n",
                     key,
+                    ts.state,
                     str(funcname(function))[:1000],
                     convert_args_to_str(args2, max_len=1000),
                     convert_kwargs_to_str(kwargs2, max_len=1000),


### PR DESCRIPTION
Addendum to #8664, adds more information to log message

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
