### PR TITLE
Iterate over copy of `Server.digests_total_since_heartbeat` to avoid `RuntimeError`

### DIFF
--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -4,7 +4,7 @@ import copy
 import uuid
 import weakref
 from collections import defaultdict
-from collections.abc import Hashable, Iterable, Iterator
+from collections.abc import Hashable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from itertools import islice
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -655,18 +655,15 @@ class SpansWorkerExtension:
         self.worker = worker
         self.digests_total_since_heartbeat = {}
 
-    def collect_digests(self) -> None:
-        """Make a local copy of Worker.digests_total_since_heartbeat. We can't just
-        parse it directly in heartbeat() as the event loop may be yielded between its
-        call and `self.worker.digests_total_since_heartbeat.clear()`, causing the
-        scheduler to become misaligned with the workers.
-        """
+    def collect_digests(
+        self, digests_total_since_heartbeat: Mapping[Hashable, float]
+    ) -> None:
         # Note: this method may be called spuriously by Worker._register_with_scheduler,
         # but when it does it's guaranteed not to find any metrics
         assert not self.digests_total_since_heartbeat
         self.digests_total_since_heartbeat = {
             k: v
-            for k, v in self.worker.digests_total_since_heartbeat.items()
+            for k, v in digests_total_since_heartbeat.items()
             if isinstance(k, tuple) and k[0] in CONTEXTS_WITH_SPAN_ID
         }
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1037,15 +1037,16 @@ class Worker(BaseWorker, ServerNode):
             # Send metrics with disaggregated span_id
             spans_ext.collect_digests()
 
+        digests_total_since_heartbeat = self.digests_total_since_heartbeat.copy()
+        self.digests_total_since_heartbeat.clear()
+
         # Send metrics with squashed span_id
         # Don't cast int metrics to float
         digests: defaultdict[Hashable, float] = defaultdict(int)
-        for k, v in self.digests_total_since_heartbeat.items():
+        for k, v in digests_total_since_heartbeat.items():
             if isinstance(k, tuple) and k[0] in CONTEXTS_WITH_SPAN_ID:
                 k = k[:1] + k[2:]
             digests[k] += v
-
-        self.digests_total_since_heartbeat.clear()
 
         out: dict = dict(
             task_counts=self.state.task_counter.current_count(by_prefix=False),


### PR DESCRIPTION
Closes #8669

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
