### PR TITLE
Eagerly update aggregate statistics for `TaskPrefix` instead of calculating them on-demand

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -3342,15 +3342,15 @@ class TaskProgress(DashboardComponent):
         }
 
         for tp in self.scheduler.task_prefixes.values():
-            active_states = tp.active_states
-            if any(active_states.get(s) for s in state.keys()):
-                state["memory"][tp.name] = active_states["memory"]
-                state["erred"][tp.name] = active_states["erred"]
-                state["released"][tp.name] = active_states["released"]
-                state["processing"][tp.name] = active_states["processing"]
-                state["waiting"][tp.name] = active_states["waiting"]
-                state["queued"][tp.name] = active_states["queued"]
-                state["no_worker"][tp.name] = active_states["no-worker"]
+            states = tp.states
+            if any(states.get(s) for s in state.keys()):
+                state["memory"][tp.name] = states["memory"]
+                state["erred"][tp.name] = states["erred"]
+                state["released"][tp.name] = states["released"]
+                state["processing"][tp.name] = states["processing"]
+                state["waiting"][tp.name] = states["waiting"]
+                state["queued"][tp.name] = states["queued"]
+                state["no_worker"][tp.name] = states["no-worker"]
 
         state["all"] = {k: sum(v[k] for v in state.values()) for k in state["memory"]}
 

--- a/distributed/diagnostics/tests/test_progress.py
+++ b/distributed/diagnostics/tests/test_progress.py
@@ -257,7 +257,7 @@ async def test_group_timing(c, s, a, b):
     assert s.task_groups.keys() == p.compute.keys()
     assert all(
         [
-            abs(s.task_groups[k].all_durations["compute"] - sum(v)) < 1.0e-12
+            abs(s.task_groups[k].all_durations["compute"] - sum(v)) < 1.0e-6 * len(v)
             for k, v in p.compute.items()
         ]
     )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -961,12 +961,15 @@ class TaskCollection:
         self._types[typename] += 1
 
     @property
-    def all_durations(self) -> dict[str, float]:
+    def all_durations(self) -> defaultdict[str, float]:
         """Cumulative duration of all completed actions of tasks belonging to this collection, by action"""
-        return {
-            action: duration_us / 1e6
-            for action, duration_us in self._all_durations_us.items()
-        }
+        return defaultdict(
+            float,
+            {
+                action: duration_us / 1e6
+                for action, duration_us in self._all_durations_us.items()
+            },
+        )
 
     @property
     def duration(self) -> float:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -7843,7 +7843,7 @@ class Scheduler(SchedulerState, ServerNode):
         state = {}
 
         for tp in self.task_prefixes.values():
-            active_states = tp.active_states
+            states = tp.states
             ss: list[TaskStateState] = [
                 "memory",
                 "erred",
@@ -7851,13 +7851,13 @@ class Scheduler(SchedulerState, ServerNode):
                 "processing",
                 "waiting",
             ]
-            if any(active_states.get(s) for s in ss):
+            if any(states.get(s) for s in ss):
                 state[tp.name] = {
-                    "memory": active_states["memory"],
-                    "erred": active_states["erred"],
-                    "released": active_states["released"],
-                    "processing": active_states["processing"],
-                    "waiting": active_states["waiting"],
+                    "memory": states["memory"],
+                    "erred": states["erred"],
+                    "released": states["released"],
+                    "processing": states["processing"],
+                    "waiting": states["waiting"],
                 }
 
         return state

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1146,11 +1146,16 @@ class TaskGroup(TaskCollection):
 
     def add(self, other: TaskState) -> None:
         super().add(other)
+        self.prefix.add(other)
         other.group = self
 
     def add_type(self, typename: str) -> None:
         super().add_type(typename)
         self.prefix.add_type(typename)
+
+    def transition(self, old: TaskStateState, new: TaskStateState) -> None:
+        super().transition(old, new)
+        self.prefix.transition(old, new)
 
     def update_nbytes(self, diff: int) -> None:
         super().update_nbytes(diff)
@@ -1467,7 +1472,6 @@ class TaskState:
         self.run_id = None
         self.group = group
         group.add(self)
-        group.prefix.add(self)
         TaskState._instances.add(self)
 
     def __hash__(self) -> int:
@@ -1488,7 +1492,6 @@ class TaskState:
     @state.setter
     def state(self, value: TaskStateState) -> None:
         self.group.transition(self._state, value)
-        self.prefix.transition(self._state, value)
         self._state = value
 
     def add_dependency(self, other: TaskState) -> None:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -923,6 +923,14 @@ class Computation:
 
 
 class TaskCollection:
+    """Abstract collection tracking all tasks
+
+    See Also
+    --------
+    TaskGroup
+    TaskPrefix
+    """
+
     #: The name of a collection of tasks.
     name: str
 
@@ -995,10 +1003,6 @@ class TaskCollection:
 
 class TaskPrefix(TaskCollection):
     """Collection tracking all tasks within a prefix
-
-    # FIXME: This comment belongs to the TaskGroup
-    Keys often have a structure like ``("x-123", 0)``
-    A group takes the first section, like ``"x"``
 
     See Also
     --------
@@ -1097,9 +1101,6 @@ class TaskPrefix(TaskCollection):
 
 class TaskGroup(TaskCollection):
     """Collection tracking all tasks within a group
-
-    Keys often have a structure like ``("x-123", 0)``
-    A group takes the first section, like ``"x-123"``
 
     See also
     --------

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2814,12 +2814,14 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     )
 
     assert tg.prefix is tp
-    assert tp.groups == [tg]
-    assert tp.groups == tp.active
+    assert tp.groups == {tg}
+    with pytest.warns(FutureWarning, match="active"):
+        assert tp.groups == tp.active
     # these must be true since in this simple case there is a 1to1 mapping
     # between prefix and group
     assert tg.states == tp.states
-    assert tp.states == tp.active_states
+    with pytest.warns(FutureWarning, match="active_states"):
+        assert tp.states == tp.active_states
     assert tg.duration == tp.duration
     assert tg.all_durations == tp.all_durations
     assert tg.nbytes_total == tp.nbytes_total
@@ -2831,12 +2833,14 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
 
     tp = s.task_prefixes["add"]
     assert tg.prefix is tp
-    assert tp.groups == [tg]
-    assert tp.groups == tp.active
+    assert tp.groups == {tg}
+    with pytest.warns(FutureWarning, match="active"):
+        assert tp.groups == tp.active
     # these must be true since in this simple case there is a 1to1 mapping
     # between prefix and group
     assert tg.states == tp.states
-    assert tp.states == tp.active_states
+    with pytest.warns(FutureWarning, match="active_states"):
+        assert tp.states == tp.active_states
     assert tg.duration == tp.duration
     assert tg.all_durations == tp.all_durations
     assert tg.nbytes_total == tp.nbytes_total
@@ -2855,11 +2859,16 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     while len(s.tasks) > 3:
         await asyncio.sleep(0.01)
 
+    assert tg.prefix is tp
+    assert tp.groups == {tg}
+    with pytest.warns(FutureWarning, match="active"):
+        assert tp.groups == tp.active
     assert tg.states["forgotten"] == 4
     assert tg.states["released"] == 1
     assert sum(tg.states.values()) == 5
     assert tg.states == tp.states
-    assert tp.states == tp.active_states
+    with pytest.warns(FutureWarning, match="active_states"):
+        assert tp.states == tp.active_states
     assert tg.duration == tp.duration
     assert tg.all_durations == tp.all_durations
     assert tg.nbytes_total == tp.nbytes_total
@@ -2877,12 +2886,15 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert tg.stop < stop
     assert "compute" in tg.all_durations
 
+    assert tg.prefix is tp
     # these must be zero because we remove fully-forgotten task groups
     # from the prefixes
-    assert tp.groups == []
-    assert tp.groups == tp.active
+    assert tp.groups == set()
+    with pytest.warns(FutureWarning, match="active"):
+        assert tp.groups == tp.active
     assert all(count == 0 for count in tp.states.values())
-    assert tp.states == tp.active_states
+    with pytest.warns(FutureWarning, match="active_states"):
+        assert tp.states == tp.active_states
     assert tp.duration == 0
     assert tg.all_durations == tp.all_durations
     assert tp.nbytes_total == 0

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2794,7 +2794,7 @@ async def test_no_dangling_asyncio_tasks():
 
 
 @gen_cluster(client=True, Worker=NoSchedulerDelayWorker, config=NO_AMM)
-async def test_task_groups(c, s, a, b, no_time_resync):
+async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     start = time()
     da = pytest.importorskip("dask.array")
     x = da.arange(100, chunks=(20,))
@@ -2808,20 +2808,36 @@ async def test_task_groups(c, s, a, b, no_time_resync):
     repr(tp)
     assert tg.states["memory"] == 0
     assert tg.states["released"] == 5
-    assert tp.states["memory"] == 0
-    assert tp.states["released"] == 5
-    assert tp.groups == [tg]
-    assert tg.prefix is tp
-    # these must be true since in this simple case there is a 1to1 mapping
-    # between prefix and group
-    assert tg.duration == tp.duration
-    assert tg.nbytes_total == tp.nbytes_total
-    # It should map down to individual tasks
+    assert sum(tg.states.values()) == 5
     assert tg.nbytes_total == sum(
         ts.get_nbytes() for ts in s.tasks.values() if ts.group is tg
     )
+
+    assert tg.prefix is tp
+    assert tp.groups == [tg]
+    # these must be true since in this simple case there is a 1to1 mapping
+    # between prefix and group
+    assert tg.states == tp.states
+    assert tp.states == tp.active_states
+    assert tg.duration == tp.duration
+    assert tg.all_durations == tp.all_durations
+    assert tg.nbytes_total == tp.nbytes_total
+
+    # It should map down to individual tasks
     tg = s.task_groups[y.name]
     assert tg.states["memory"] == 5
+    assert sum(tg.states.values()) == 5
+
+    tp = s.task_prefixes["add"]
+    assert tg.prefix is tp
+    assert tp.groups == [tg]
+    # these must be true since in this simple case there is a 1to1 mapping
+    # between prefix and group
+    assert tg.states == tp.states
+    assert tp.states == tp.active_states
+    assert tg.duration == tp.duration
+    assert tg.all_durations == tp.all_durations
+    assert tg.nbytes_total == tp.nbytes_total
 
     assert s.task_groups[y.name].dependencies == {s.task_groups[x.name]}
 
@@ -2830,16 +2846,43 @@ async def test_task_groups(c, s, a, b, no_time_resync):
     assert "array" in str(tg.types)
     assert "array" in str(tp.types)
 
+    z = y[:20].persist(optimize_graph=False)
+    z = await z
     del y
 
+    while len(s.tasks) > 3:
+        await asyncio.sleep(0.01)
+
+    assert tg.states["forgotten"] == 4
+    assert tg.states["released"] == 1
+    assert sum(tg.states.values()) == 5
+    assert tg.states == tp.states
+    assert tp.states == tp.active_states
+    assert tg.duration == tp.duration
+    assert tg.all_durations == tp.all_durations
+    assert tg.nbytes_total == tp.nbytes_total
+
+    del z
     while s.tasks:
         await asyncio.sleep(0.01)
+
+    assert tg.states["forgotten"] == 5
+    assert sum(tg.states.values()) == 5
 
     assert tg.states["forgotten"] == 5
     assert tg.name not in s.task_groups
     assert tg.start > start
     assert tg.stop < stop
     assert "compute" in tg.all_durations
+
+    # these must be zero because we remove fully-forgotten task groups
+    # from the prefixes
+    assert tp.groups == []
+    assert all(count == 0 for count in tp.states.values())
+    assert tp.states == tp.active_states
+    assert tp.duration == 0
+    assert tg.all_durations == tp.all_durations
+    assert tp.nbytes_total == 0
 
 
 @gen_cluster(client=True, nthreads=[("", 2)], Worker=NoSchedulerDelayWorker)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2825,6 +2825,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert tg.duration == tp.duration
     assert tg.all_durations == tp.all_durations
     assert tg.nbytes_total == tp.nbytes_total
+    assert tg.types == tp.types
 
     # It should map down to individual tasks
     tg = s.task_groups[y.name]
@@ -2844,6 +2845,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert tg.duration == tp.duration
     assert tg.all_durations == tp.all_durations
     assert tg.nbytes_total == tp.nbytes_total
+    assert tg.types == tp.types
 
     assert s.task_groups[y.name].dependencies == {s.task_groups[x.name]}
 
@@ -2872,6 +2874,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert tg.duration == tp.duration
     assert tg.all_durations == tp.all_durations
     assert tg.nbytes_total == tp.nbytes_total
+    assert tg.types == tp.types
 
     del z
     while s.tasks:
@@ -2887,6 +2890,8 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert "compute" in tg.all_durations
 
     assert tg.prefix is tp
+    # all_durations is cumulative
+    assert tg.all_durations == tp.all_durations
     # these must be zero because we remove fully-forgotten task groups
     # from the prefixes
     assert tp.groups == set()
@@ -2896,8 +2901,8 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     with pytest.warns(FutureWarning, match="active_states"):
         assert tp.states == tp.active_states
     assert tp.duration == 0
-    assert tg.all_durations == tp.all_durations
     assert tp.nbytes_total == 0
+    assert tp.types == set()
 
 
 @gen_cluster(client=True, nthreads=[("", 2)], Worker=NoSchedulerDelayWorker)

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2815,6 +2815,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
 
     assert tg.prefix is tp
     assert tp.groups == [tg]
+    assert tp.groups == tp.active
     # these must be true since in this simple case there is a 1to1 mapping
     # between prefix and group
     assert tg.states == tp.states
@@ -2831,6 +2832,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     tp = s.task_prefixes["add"]
     assert tg.prefix is tp
     assert tp.groups == [tg]
+    assert tp.groups == tp.active
     # these must be true since in this simple case there is a 1to1 mapping
     # between prefix and group
     assert tg.states == tp.states
@@ -2878,6 +2880,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     # these must be zero because we remove fully-forgotten task groups
     # from the prefixes
     assert tp.groups == []
+    assert tp.groups == tp.active
     assert all(count == 0 for count in tp.states.values())
     assert tp.states == tp.active_states
     assert tp.duration == 0


### PR DESCRIPTION
Closes #8680 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
