### PR TITLE
More useful warning if a plugin type is provided instead of instance

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -4899,6 +4899,8 @@ class Client(SyncMethodMixin):
         name: str,
         idempotent: bool,
     ):
+        if isinstance(plugin, type):
+            raise TypeError("Please provide an instance of a plugin, not a type.")
         raise TypeError(
             "Registering duck-typed plugins is not allowed. Please inherit from "
             "NannyPlugin, WorkerPlugin, or SchedulerPlugin to create a plugin."

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7001,7 +7001,7 @@ async def test_register_worker_plugin_instance_required(c, s, a, b):
     class MyPlugin(WorkerPlugin):
         ...
 
-    with pytest.raises(ValueError, match="instance"):
+    with pytest.raises(TypeError, match="instance"):
         await c.register_plugin(MyPlugin)
 
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -6997,6 +6997,15 @@ async def test_get_task_metadata_multiple(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_register_worker_plugin_instance_required(c, s, a, b):
+    class MyPlugin(WorkerPlugin):
+        ...
+
+    with pytest.raises(ValueError, match="instance"):
+        await c.register_plugin(MyPlugin)
+
+
+@gen_cluster(client=True)
 async def test_register_worker_plugin_exception(c, s, a, b):
     class MyPlugin(WorkerPlugin):
         def setup(self, worker=None):


### PR DESCRIPTION
The `Registering duck-typed plugins is not allowed. ` warning is confusing if the user accidentally provides the plugin type (which was accepted API in an earlier version)