### PR TITLE
Enable export substitution for _version.py

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+distributed/_version.py export-subst


### PR DESCRIPTION
I'm not sure why this was missed, but when you install versioneer, it adds these attributes so that things like version/commit hash/etc. are correct when you make a git archive. Without this substitution, `test_git_revision` fails because there is no revision info in the archive tarball.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
