### PR TITLE
profile._f_lineno: handle next_line being None in Python 3.13

### DIFF
--- a/distributed/profile.py
+++ b/distributed/profile.py
@@ -90,7 +90,8 @@ def _f_lineno(frame: FrameType) -> int:
         for start, next_line in dis.findlinestarts(code):
             if f_lasti < start:
                 return prev_line
-            prev_line = next_line
+            if next_line:
+                prev_line = next_line
 
         return prev_line
     except Exception:


### PR DESCRIPTION
In Python 3.13, it's possible for `dis.findlinestarts` to return a line number as `None`. We don't ever want to return `None` as the line number, so guard against this.

- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
