### PR TITLE
Fix cleanup iteration in save_sys_modules

### DIFF
--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -1628,12 +1628,11 @@ def save_sys_modules():
     try:
         yield
     finally:
-        for i, elem in enumerate(sys.path):
+        for i, elem in reversed(list(enumerate(sys.path))):
             if elem not in old_path:
                 del sys.path[i]
-        for elem in sys.modules.keys():
-            if elem not in old_modules:
-                del sys.modules[elem]
+        for elem in sys.modules.keys() - old_modules.keys():
+            del sys.modules[elem]
 
 
 @contextmanager


### PR DESCRIPTION
When iterating `sys.path`, then if you delete index `i`, all elements >`i` will now be one less than what was put into `enumerate`. So we should remove elements in reverse to prevent indices getting out of sync.

When iterating `sys.modules`, then modifying it _may_ break the `.keys()` iterator, so work on a copy of the necessary keys.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
