### PR TITLE
TST: Fix wait condition on test_forget_errors

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2213,7 +2213,7 @@ async def test_forget_errors(c, s, a, b):
     x = c.submit(div, 1, 0)
     y = c.submit(inc, x)
     z = c.submit(inc, y)
-    await wait([y])
+    await wait([z])
 
     assert s.tasks[x.key].exception
     assert s.tasks[x.key].exception_blame


### PR DESCRIPTION
I've seen a random failure of the following form:
```
______________________________ test_forget_errors ______________________________
c = <Client: No scheduler connected>
s = <Scheduler 'tcp://127.0.0.1:43589', workers: 0, cores: 0, tasks: 0>
a = <Worker 'tcp://127.0.0.1:43115', name: 0, status: closed, stored: 0, running: 0/1, ready: 0, comm: 0, waiting: 0>
b = <Worker 'tcp://127.0.0.1:34315', name: 1, status: closed, stored: 0, running: 0/2, ready: 0, comm: 0, waiting: 0>
    @gen_cluster(client=True)
    async def test_forget_errors(c, s, a, b):
        x = c.submit(div, 1, 0)
        y = c.submit(inc, x)
        z = c.submit(inc, y)
        await wait([y])

        assert s.tasks[x.key].exception
        assert s.tasks[x.key].exception_blame
        assert s.tasks[y.key].exception_blame
>       assert s.tasks[z.key].exception_blame
E       KeyError: 'inc-ef245012eb716c6c34c6dc06d6dd7d8f'
.../distributed/tests/test_client.py:2221: KeyError
```
which I believe is because of waiting for `y` but looking at `z`'s key, which is a subsequent task.

And since the task flow is `x` → `y` → `z`, with an error in `x`, the reasoning for waiting for `y` instead of `x` seems like it should apply for waiting for `z` instead of `y`.

Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
