### PR TITLE
Add quotes to missing bokeh installation commands

### DIFF
--- a/distributed/http/scheduler/missing_bokeh.py
+++ b/distributed/http/scheduler/missing_bokeh.py
@@ -10,8 +10,8 @@ class MissingBokeh(RequestHandler):
     def get(self):
         self.write(
             f"<p>Dask needs {BOKEH_REQUIREMENT} for the dashboard.</p>"
-            f"<p>Install with conda: <code>conda install {BOKEH_REQUIREMENT}</code></p>"
-            f"<p>Install with pip: <code>pip install {BOKEH_REQUIREMENT}</code></p>"
+            f'<p>Install with conda: <code>conda install "{BOKEH_REQUIREMENT}"</code></p>'
+            f'<p>Install with pip: <code>pip install "{BOKEH_REQUIREMENT}"</code></p>'
         )
 
 


### PR DESCRIPTION
Adding quotes so terminals will accept this command when copy-pasted 

Closes https://github.com/dask/distributed/issues/8716