### PR TITLE
Fix `test_quiet_client_close`

### DIFF
--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5223,7 +5223,7 @@ def test_quiet_client_close(loop):
             futures = c.map(slowinc, range(1000), delay=0.01)
             # Stop part-way
             s = c.cluster.scheduler
-            while sum(ts.state == "memory" for ts in s.tasks.values()) < 20:
+            while sum(ts.state == "memory" for ts in list(s.tasks.values())) < 20:
                 sleep(0.01)
         sleep(0.1)  # let things settle
 


### PR DESCRIPTION
`test_quiet_client_close` flakes with

```
___________________________ test_quiet_client_close ____________________________

loop = <tornado.platform.asyncio.AsyncIOMainLoop object at 0x7fdded804730>

    def test_quiet_client_close(loop):
        with captured_logger("distributed") as logger:
            with Client(
                loop=loop,
                processes=False,
                dashboard_address=":0",
                threads_per_worker=4,
            ) as c:
                futures = c.map(slowinc, range(1000), delay=0.01)
                # Stop part-way
                s = c.cluster.scheduler
>               while sum(ts.state == "memory" for ts in s.tasks.values()) < 20:

distributed/tests/test_client.py:5228: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <dict_valueiterator object at 0x7fddeadcd450>

>   while sum(ts.state == "memory" for ts in s.tasks.values()) < 20:
E   RuntimeError: dictionary changed size during iteration
```

(e.g., https://github.com/dask/distributed/actions/runs/9642304087/job/26589802148?pr=8705#step:20:1494)

This PR fixes that