### PR TITLE
Skip `test_deadlock_dependency_of_queued_released` is queueing is disabled

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4650,6 +4650,10 @@ async def test_deadlock_resubmit_queued_tasks_fast(c, s, a, rootish):
     await c.gather(fut3)
 
 
+@pytest.mark.skipif(
+    not QUEUING_ON_BY_DEFAULT,
+    reason="The situation handled in this test requires queueing.",
+)
 @gen_cluster(client=True, nthreads=[("", 1)])
 async def test_deadlock_dependency_of_queued_released(c, s, a):
     @delayed


### PR DESCRIPTION
`test_deadlock_dependency_of_queued_released` fails on CI for `ubuntu-latest-3.9-no_queue` because it depends on queueing.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
