### PR TITLE
Deprecate `Pub` and `Sub`

### DIFF
--- a/distributed/pubsub.py
+++ b/distributed/pubsub.py
@@ -6,7 +6,7 @@ import threading
 import weakref
 from collections import defaultdict, deque
 
-from dask.utils import parse_timedelta
+from dask.utils import _deprecated, parse_timedelta
 
 from distributed.core import CommClosedError
 from distributed.metrics import time
@@ -198,6 +198,7 @@ class PubSubClientExtension:
                 self.client.scheduler_comm.send(msg)
 
 
+@_deprecated(use_instead="Client.log_event() or Worker.log_event()")
 class Pub:
     """Publish data with Publish-Subscribe pattern
 
@@ -354,6 +355,7 @@ class Pub:
     __str__ = __repr__
 
 
+@_deprecated(use_instead="Client.subscribe_topic()")
 class Sub:
     """Subscribe to a Publish/Subscribe topic
 

--- a/distributed/tests/test_pubsub.py
+++ b/distributed/tests/test_pubsub.py
@@ -23,8 +23,10 @@ async def test_speed(c, s, a, b):
     """
 
     def pingpong(a, b, start=False, n=1000, msg=1):
-        sub = Sub(a)
-        pub = Pub(b)
+        with pytest.warns(FutureWarning, match="deprecated"):
+            sub = Sub(a)
+        with pytest.warns(FutureWarning, match="deprecated"):
+            pub = Pub(b)
 
         while not pub.subscribers:
             sleep(0.01)
@@ -56,8 +58,10 @@ async def test_speed(c, s, a, b):
 async def test_client(c, s):
     with pytest.raises(ValueError, match="No worker found"):
         get_worker()
-    sub = Sub("a")
-    pub = Pub("a")
+    with pytest.warns(FutureWarning, match="deprecated"):
+        sub = Sub("a")
+    with pytest.warns(FutureWarning, match="deprecated"):
+        pub = Pub("a")
 
     sps = s.extensions["pubsub"]
     cps = c.extensions["pubsub"]
@@ -75,10 +79,12 @@ async def test_client(c, s):
 
 @gen_cluster(client=True)
 async def test_client_worker(c, s, a, b):
-    sub = Sub("a", client=c, worker=None)
+    with pytest.warns(FutureWarning, match="deprecated"):
+        sub = Sub("a", client=c, worker=None)
 
     def f(x):
-        pub = Pub("a")
+        with pytest.warns(FutureWarning, match="deprecated"):
+            pub = Pub("a")
         pub.put(x)
 
     futures = c.map(f, range(10))
@@ -120,7 +126,8 @@ async def test_client_worker(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_timeouts(c, s, a, b):
-    sub = Sub("a", client=c, worker=None)
+    with pytest.warns(FutureWarning, match="deprecated"):
+        sub = Sub("a", client=c, worker=None)
     start = time()
     with pytest.raises(TimeoutError):
         await sub.get(timeout="100ms")
@@ -132,8 +139,10 @@ async def test_timeouts(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_repr(c, s, a, b):
-    pub = Pub("my-topic")
-    sub = Sub("my-topic")
+    with pytest.warns(FutureWarning, match="deprecated"):
+        pub = Pub("my-topic")
+    with pytest.warns(FutureWarning, match="deprecated"):
+        sub = Sub("my-topic")
     assert "my-topic" in str(pub)
     assert "Pub" in str(pub)
     assert "my-topic" in str(sub)
@@ -144,7 +153,8 @@ async def test_repr(c, s, a, b):
 @gen_cluster(client=True)
 async def test_basic(c, s, a, b):
     async def publish():
-        pub = Pub("a")
+        with pytest.warns(FutureWarning, match="deprecated"):
+            pub = Pub("a")
 
         i = 0
         while True:
@@ -153,7 +163,8 @@ async def test_basic(c, s, a, b):
             i += 1
 
     def f(_):
-        sub = Sub("a")
+        with pytest.warns(FutureWarning, match="deprecated"):
+            sub = Sub("a")
         return list(toolz.take(5, sub))
 
     asyncio.ensure_future(c.run(publish, workers=[a.address]))


### PR DESCRIPTION
As mentioned in #8685, the pub/sub mechanism is prone to race conditions and can bring down stream-based connections. This PR deprecates the `Pub` and `Sub` classes as user-facing entrypoints into the mechanism as a first step to removing pub/sub.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
