### PR TITLE
More robust bokeh test_shuffling

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -1350,8 +1350,8 @@ async def test_shuffling(c, s, a, b):
     start = time()
     while not ss.source.data["comm_written"]:
         ss.update()
-        await asyncio.sleep(0)
-        assert time() < start + 5
+        await asyncio.sleep(0.05)
+        assert time() < start + 10
     await df2
 
 


### PR DESCRIPTION
This has been failing quite reliably on osx py3.12 but I don't see a reason why. This is relaxing stress on the event loop and is extending the deadline