### PR TITLE
Robuster deeply nested structures

### DIFF
--- a/distributed/protocol/serialize.py
+++ b/distributed/protocol/serialize.py
@@ -209,17 +209,20 @@ register_serialization_family("error", None, serialization_error_loads)
 
 
 def check_dask_serializable(x):
-    if type(x) in (list, set, tuple) and len(x):
-        return check_dask_serializable(next(iter(x)))
-    elif type(x) is dict and len(x):
-        return check_dask_serializable(next(iter(x.items()))[1])
-    else:
-        try:
-            dask_serialize.dispatch(type(x))
-            return True
-        except TypeError:
-            pass
-    return False
+    try:
+        if type(x) in (list, set, tuple) and len(x):
+            return check_dask_serializable(next(iter(x)))
+        elif type(x) is dict and len(x):
+            return check_dask_serializable(next(iter(x.items()))[1])
+        else:
+            try:
+                dask_serialize.dispatch(type(x))
+                return True
+            except TypeError:
+                pass
+        return False
+    except RecursionError:
+        return False
 
 
 def serialize(  # type: ignore[no-untyped-def]

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import sys
 
 import pytest
@@ -169,11 +170,13 @@ def test_deeply_nested_structures():
         return d
 
     msg = {}
-    for _ in range(4):
+    for _ in range(10):
         msg = gen_deeply_nested(sys.getrecursionlimit() // 2, msg=msg)
 
+    with pytest.raises(RecursionError):
+        copy.deepcopy(msg)
+
     with pytest.raises(TypeError, match="Could not serialize object"):
-        # Python3.12 this is very slow
         serialize(msg, on_error="raise")
 
     msg = gen_deeply_nested(sys.getrecursionlimit() // 2)

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -161,19 +161,21 @@ def test_sizeof_serialize(Wrapper, Wrapped):
 @pytest.mark.skipif(WINDOWS, reason="On windows this is triggering a stackoverflow")
 def test_deeply_nested_structures():
     # These kind of deeply nested structures are generated in our profiling code
-    def gen_deeply_nested(depth):
-        msg = {}
+    def gen_deeply_nested(depth, msg=None):
+        msg = msg or {}
         d = msg
         while depth:
             depth -= 1
             d["children"] = d = {}
         return msg
 
-    msg = gen_deeply_nested(sys.getrecursionlimit() - 100)
+    msg = {}
+    for _ in range(10):
+        msg = gen_deeply_nested(sys.getrecursionlimit() // 2, msg=msg)
     with pytest.raises(TypeError, match="Could not serialize object"):
         serialize(msg, on_error="raise")
 
-    msg = gen_deeply_nested(sys.getrecursionlimit() // 4)
+    msg = gen_deeply_nested(sys.getrecursionlimit() // 2)
     assert isinstance(serialize(msg), tuple)
 
 

--- a/distributed/protocol/tests/test_protocol.py
+++ b/distributed/protocol/tests/test_protocol.py
@@ -162,17 +162,18 @@ def test_sizeof_serialize(Wrapper, Wrapped):
 def test_deeply_nested_structures():
     # These kind of deeply nested structures are generated in our profiling code
     def gen_deeply_nested(depth, msg=None):
-        msg = msg or {}
-        d = msg
+        d = msg or {}
         while depth:
             depth -= 1
-            d["children"] = d = {}
-        return msg
+            d = {"children": d}
+        return d
 
     msg = {}
-    for _ in range(10):
+    for _ in range(4):
         msg = gen_deeply_nested(sys.getrecursionlimit() // 2, msg=msg)
+
     with pytest.raises(TypeError, match="Could not serialize object"):
+        # Python3.12 this is very slow
         serialize(msg, on_error="raise")
 
     msg = gen_deeply_nested(sys.getrecursionlimit() // 2)


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8700

The reason why I said that those tests are not great is because the thresholds were arbitrary and therefore dependent on CPython, pytest and dask code.

This changes the way the deeply nested structure is generated in a way that it generates a structure that is multiple times that of the recursion depth so every attempt to dive into this will inevitably fail with a recursion error.

<details>

This is no longer the case...

It works... but python3.12 is horribly slow. I haven't profiled this, yet. On py3.10 this runs in about 0.1s while on py3.12 this runs for 20-30s. This worries me for two reasons

1. I don't really want to have this test take up this much time. It's not _that_ valuable
2. More importantly, if this runs for so long, I'm worried that the profile thread also occasionally just gets stuck in this deep loop and eats up all the CPU time, congests the GIL, etc.

I haven't run any profiles yet (mostly because [pyspy doesn't work on python3.12](https://github.com/benfred/py-spy/pull/642)) but I welcome anybody else to peak into this

</details>