### PR TITLE
Remove `FutureWarning` in `test_task_state_instance_are_garbage_collected`

### DIFF
--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -922,7 +922,7 @@ async def test_task_state_instance_are_garbage_collected(c, s, a, b):
     f2 = c.submit(inc, red, pure=False)
 
     async def check(dask_worker):
-        while dask_worker.tasks:
+        while dask_worker.state.tasks:
             await asyncio.sleep(0.01)
         with profile.lock:
             gc.collect()

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -336,7 +336,7 @@ class TaskState:
         -----
         This class uses ``_to_dict_no_nest`` instead of ``_to_dict``.
         When a task references another task, just print the task repr. All tasks
-        should neatly appear under Worker.tasks. This also prevents a RecursionError
+        should neatly appear under Worker.state.tasks. This also prevents a RecursionError
         during particularly heavy loads, which have been observed to happen whenever
         there's an acyclic dependency chain of ~200+ tasks.
         """


### PR DESCRIPTION
Eliminates `FutureWarning` in the `check` function of `test_task_state_instance_are_garbage_collected`

(e.g., https://github.com/dask/distributed/actions/runs/9674342266/job/26689807388#step:20:4349)

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
