### PR TITLE
Fix flake in `test_deadline` caused by floating-point inaccuracy

### DIFF
--- a/distributed/tests/test_deadline.py
+++ b/distributed/tests/test_deadline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import asyncio
 from time import sleep
 
+import pytest
+
 from distributed.metrics import monotonic
 from distributed.utils import Deadline
 from distributed.utils_test import gen_test
@@ -11,10 +13,10 @@ from distributed.utils_test import gen_test
 def test_deadline():
     deadline = Deadline.after(5)
 
-    assert deadline.duration == 5
+    assert deadline.duration == pytest.approx(5)
     assert deadline.expired is False
     assert deadline.expires is True
-    assert deadline.expires_at_mono - deadline.started_at_mono == 5
+    assert deadline.expires_at_mono - deadline.started_at_mono == pytest.approx(5)
     assert 4 < deadline.expires_at - deadline.started_at < 6
     assert 0 <= deadline.elapsed <= 1
     assert 4 <= deadline.remaining <= 5


### PR DESCRIPTION
```
________________________________ test_deadline _________________________________

    def test_deadline():
        deadline = Deadline.after(5)
    
>       assert deadline.duration == 5
E       assert 4.999999999999886 == 5
E        +  where 4.999999999999886 = <distributed.utils.Deadline object at 0x7fca3025fc00>.duration

distributed/tests/test_deadline.py:14: AssertionError
```
https://github.com/dask/distributed/actions/runs/9646464590/job/26602958003#step:20:2501

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
