### PR TITLE
Add close worker button to worker info page

### DIFF
--- a/distributed/http/scheduler/info.py
+++ b/distributed/http/scheduler/info.py
@@ -11,6 +11,7 @@ from tlz import first, merge
 from tornado import escape
 from tornado.websocket import WebSocketHandler
 
+import dask
 from dask.typing import Key
 from dask.utils import format_bytes, format_time
 
@@ -40,6 +41,8 @@ class Workers(RequestHandler):
             "workers.html",
             title="Workers",
             scheduler=self.server,
+            api_enabled="distributed.http.scheduler.api"
+            in dask.config.get("distributed.scheduler.http.routes"),
             **merge(
                 self.server.__dict__,
                 self.server.__pdict__,

--- a/distributed/http/templates/worker-table.html
+++ b/distributed/http/templates/worker-table.html
@@ -12,6 +12,7 @@
             <th> Services</th>
             <th> Logs </th>
             <th> Last seen </th>
+            <th>  </th>
         </tr>
     </thead>
     <tbody>
@@ -33,7 +34,37 @@
             {% end %}
             <td> <a href="../logs/{{ url_escape(ws.address) }}.html">logs</a></td>
             <td> {{ format_time(time() - ws.last_seen) }} </td>
+            <td>
+                <form action="" id="close-worker" method="post" name="asdf">
+                    <button class="button is-default" name="{{ws.address}}">Close</button>
+                </form>
+            </td>
         </tr>
         {% end %}
     </tbody>
 </table>
+
+<script>
+    const forms = document.querySelectorAll("#close-worker");
+    forms.forEach(p =>
+        p.addEventListener("submit", (event) => {
+        let submitter = event.submitter;
+        let handler = submitter.id;
+        event.preventDefault();
+        closeWorker(submitter.name);
+        })
+    );
+
+    async function closeWorker(address) {
+        try {
+            const response = await fetch("../../api/v1/retire_workers", {
+                method: "POST",
+                body: JSON.stringify({workers: [address]}),
+            });
+            console.log(await response.json());
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+</script>

--- a/distributed/http/templates/worker-table.html
+++ b/distributed/http/templates/worker-table.html
@@ -12,7 +12,10 @@
             <th> Services</th>
             <th> Logs </th>
             <th> Last seen </th>
+            {% if api_enabled %}
             <th>  </th>
+            {% else %}
+            {% end %}
         </tr>
     </thead>
     <tbody>
@@ -34,11 +37,14 @@
             {% end %}
             <td> <a href="../logs/{{ url_escape(ws.address) }}.html">logs</a></td>
             <td> {{ format_time(time() - ws.last_seen) }} </td>
+            {% if api_enabled %}
             <td>
                 <form action="" id="close-worker" method="post" name="asdf">
                     <button class="button is-default" name="{{ws.address}}">Close</button>
                 </form>
             </td>
+            {% else %}
+            {% end %}
         </tr>
         {% end %}
     </tbody>


### PR DESCRIPTION
A user recently mentioned that they saw workers on the `info/main/workers.html` page get into a bad state, turn red, and wised there was some way to be able to manually close workers that got into a bad state. This PR adds such a button (see attached screenshot)

<img width="1552" alt="Screenshot 2024-07-02 at 4 59 48 PM" src="https://github.com/dask/distributed/assets/11656932/561d6804-df11-4e74-9ef0-42b642da304a">

Note that this PR uses the scheduler API endpoint added in https://github.com/dask/distributed/pull/6270. It's turned off by default (xref https://github.com/dask/distributed/pull/6420) which significantly lowers the availability of these buttons (we only display the close buttons if this endpoint is explicitly enabled). I'm curious if folks have thoughts on a better mechanism to use that's always available, or if turning the scheduler API on by default makes sense. 