### PR TITLE
Bump ``pandas`` to 2.0 in mindeps build

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,12 +83,12 @@ jobs:
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7, pyarrow-hotfix]
+            extra_packages: [numpy=1.21, pandas=2.0, pyarrow=7, pyarrow-hotfix]
             partition: "ci1"
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
-            extra_packages: [numpy=1.21, pandas=1.3, pyarrow=7, pyarrow-hotfix]
+            extra_packages: [numpy=1.21, pandas=2.0, pyarrow=7, pyarrow-hotfix]
             partition: "not ci1"
 
           - os: ubuntu-latest

--- a/distributed/protocol/tests/test_highlevelgraph.py
+++ b/distributed/protocol/tests/test_highlevelgraph.py
@@ -6,12 +6,12 @@ import pytest
 
 np = pytest.importorskip("numpy")
 pd = pytest.importorskip("pandas")
+dd = pytest.importorskip("dask.dataframe")
+da = pytest.importorskip("dask.array")
 
 from numpy.testing import assert_array_equal
 
 import dask
-import dask.array as da
-import dask.dataframe as dd
 
 from distributed.diagnostics import SchedulerPlugin
 from distributed.utils_test import gen_cluster


### PR DESCRIPTION
`dask.dataframe` recently bumped it's minimum pandas version to 2.0. I noticed some related failures here (for example, [this CI build](https://github.com/dask/distributed/actions/runs/9780620167/job/27002715150?pr=8742)) in our `mindeps-pandas` CI build. 

This PR bumps the `pandas` in the mindeps build to 2.0