### PR TITLE
Update system monitor when polling Prometheus metrics

### DIFF
--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -22,6 +22,8 @@ class SchedulerMetricCollector(PrometheusCollector):
         self.subsystem = "scheduler"
 
     def collect(self) -> Iterator[GaugeMetricFamily | CounterMetricFamily]:
+        self.server.monitor.update()
+
         yield GaugeMetricFamily(
             self.build_name("clients"),
             "Number of clients connected",

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -32,6 +32,7 @@ class WorkerMetricCollector(PrometheusCollector):
             )
 
     def collect(self) -> Iterator[Metric]:
+        self.server.monitor.update()
         ws = self.server.state
 
         tasks = GaugeMetricFamily(


### PR DESCRIPTION
As mentioned in https://github.com/dask/distributed/issues/7767, the difference in the update timestamp of the system monitor and the polling timestamp of Prometheus skews rate calculations. While the suggested approach suggested in #7767 makes it conceptually impossible to introduce skew, it is also very unintuitive and unlikely to get rigorously followed by consumers. To reduce the effect of the skew to a minimum, this PR updates the system monitor when collecting Prometheus metrics.

Supersedes https://github.com/dask/distributed/pull/8744

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
