### PR TITLE
Fix ``assert_eq`` import from ``cudf``

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -198,7 +198,7 @@ async def test_ping_pong_cudf(ucx_loop, g):
     # *** ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.11'
     # not found (required by python3.7/site-packages/pyarrow/../../../libarrow.so.12)
     cudf = pytest.importorskip("cudf")
-    from cudf.testing._utils import assert_eq
+    from cudf.testing import assert_eq
 
     cudf_obj = g(cudf)
 


### PR DESCRIPTION
gpuCI is failing with errors like this

```
13:20:30 ________________________ test_ping_pong_cudf[<lambda>8] ________________________
13:20:30 

13:20:30 ucx_loop = <_UnixSelectorEventLoop running=False closed=False debug=False>
13:20:30 g = <function <lambda> at 0x7f708ff1a660>
13:20:30 

13:20:30     @pytest.mark.parametrize(
13:20:30         "g",
13:20:30         [
13:20:30             lambda cudf: cudf.Series([1, 2, 3]),
13:20:30             lambda cudf: cudf.Series([], dtype=object),
13:20:30             lambda cudf: cudf.DataFrame([], dtype=object),
13:20:30             lambda cudf: cudf.DataFrame([1]).head(0),
13:20:30             lambda cudf: cudf.DataFrame([1.0]).head(0),
13:20:30             lambda cudf: cudf.DataFrame({"a": []}),
13:20:30             lambda cudf: cudf.DataFrame({"a": ["a"]}).head(0),
13:20:30             lambda cudf: cudf.DataFrame({"a": [1.0]}).head(0),
13:20:30             lambda cudf: cudf.DataFrame({"a": [1]}).head(0),
13:20:30             lambda cudf: cudf.DataFrame({"a": [1, 2, None], "b": [1.0, 2.0, None]}),
13:20:30             lambda cudf: cudf.DataFrame({"a": ["Check", "str"], "b": ["Sup", "port"]}),
13:20:30         ],
13:20:30     )
13:20:30     @gen_test()
13:20:30     async def test_ping_pong_cudf(ucx_loop, g):
13:20:30         # if this test appears after cupy an import error arises
13:20:30         # *** ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.11'
13:20:30         # not found (required by python3.7/site-packages/pyarrow/../../../libarrow.so.12)
13:20:30         cudf = pytest.importorskip("cudf")
13:20:30 >       from cudf.testing._utils import assert_eq
13:20:30 E       ImportError: cannot import name 'assert_eq' from 'cudf.testing._utils' (/opt/conda/envs/dask/lib/python3.11/site-packages/cudf/testing/_utils.py)
13:20:30 

13:20:30 distributed/comm/tests/test_ucx.py:201: ImportError
```

Based on https://github.com/rapidsai/cudf/pull/16063 I think we should use `from cudf.testing import assert_eq`. Though I'm not really sure -- let's see if this helps CI. 

cc @rjzamora @wence- @charlesbluca for visibility 