### PR TITLE
Add no-clients-timeout option

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -91,6 +91,14 @@ properties:
 
               Works in conjunction with idle-timeout.
 
+          no-clients-timeout:
+            type:
+            - string
+            - "null"
+            description: |
+              Shut down the scheduler after this duration if no client heartbeats received,
+              and there are no running or queued tasks.
+
           work-stealing:
             type: boolean
             description: |

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -19,6 +19,7 @@ distributed:
     events-cleanup-delay: 1h
     idle-timeout: null       # Shut down after this duration, like "1h" or "30 minutes"
     no-workers-timeout: null # Shut down if there are tasks but no workers to process them
+    no-clients-timeout: null # Shut down after this duration of client inactivity, similar to idle-timeout
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-saturation: 1.1  # Send this fraction of nthreads root tasks to workers

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3582,6 +3582,8 @@ class Scheduler(SchedulerState, ServerNode):
     idle_timeout: float | None
     _no_workers_since: float | None  # Note: not None iff there are pending tasks
     no_workers_timeout: float | None
+    _no_clients_since: float
+    no_clients_timeout: float | None
 
     def __init__(
         self,
@@ -3597,6 +3599,7 @@ class Scheduler(SchedulerState, ServerNode):
         security=None,
         worker_ttl=None,
         idle_timeout=None,
+        no_clients_timeout=None,
         interface=None,
         host=None,
         port=0,
@@ -3656,6 +3659,11 @@ class Scheduler(SchedulerState, ServerNode):
             dask.config.get("distributed.scheduler.no-workers-timeout")
         )
         self._no_workers_since = None
+        self.no_clients_timeout = parse_timedelta(
+            no_clients_timeout
+            or dask.config.get("distributed.scheduler.no-clients-timeout")
+        )
+        self._no_clients_since = time()
 
         self.time_started = self.idle_since  # compatibility for dask-gateway
         self._replica_lock = RLock()
@@ -3933,6 +3941,9 @@ class Scheduler(SchedulerState, ServerNode):
 
         pc = PeriodicCallback(self._check_no_workers, 250)
         self.periodic_callbacks["no-workers-timeout"] = pc
+
+        pc = PeriodicCallback(self._check_no_clients, 250)
+        self.periodic_callbacks["no-clients-timeout"] = pc
 
         if extensions is None:
             extensions = DEFAULT_EXTENSIONS.copy()
@@ -8520,6 +8531,36 @@ class Scheduler(SchedulerState, ServerNode):
                 )
                 self._ongoing_background_tasks.call_soon(self.close)
         return self.idle_since
+
+    def _check_no_clients(self) -> None:
+        """Shut down the schedule if there are no running tasks / no tasks ready to
+        run, and there hasn't been any client connection for
+        `distributed.scheduler.no-workers-timeout`."""
+        if self.status in (Status.closing, Status.closed):
+            return  # pragma: nocover
+
+        if (
+            self.queued
+            or self.unrunnable
+            or any(ws.processing for ws in self.workers.values())
+        ):
+            return
+
+        if self.jupyter:
+            self._no_clients_since = max(
+                self._no_clients_since,
+                self._jupyter_server_application.web_app.last_activity().timestamp(),
+            )
+        if self.clients:
+            clients_hb = max(c.last_seen for c in self.clients.values())
+            self._no_clients_since = max(self._no_clients_since, clients_hb)
+
+        if (
+            self.no_clients_timeout
+            and time() > self._no_clients_since + self.no_clients_timeout
+        ):
+            logger.info("No tasks and no client heartbeat; shutting scheduler down")
+            self._ongoing_background_tasks.call_soon(self.close)
 
     def _check_no_workers(self) -> None:
         """Shut down the scheduler if there have been tasks ready to run which have


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/7959 .

I aimed for a minimalistic implementation, and named it consistently with the existing `no_workers_timeout`.
 - The original issue does not address whether to respect running/queued jobs or not, I chose to do so as it made more sense to me,
 - I consider activity from both clients and jupyter app, though not sure if the latter is explicitly necessary,
 - I do not support "state transition" (like the existing `check_idle` does) as it didn't seem necessary.

I still need to add tests -- but the implementation of functionality is ready for feedback.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
