### PR TITLE
Use functools.cache instead of functools.lru_cache for url_escape & _expects_comm

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -121,7 +121,7 @@ tick_maximum_delay = parse_timedelta(
 LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 
 
-@functools.lru_cache
+@functools.cache
 def _expects_comm(func: Callable) -> bool:
     sig = inspect.signature(func)
     params = list(sig.parameters)

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1989,7 +1989,7 @@ class TupleComparable:
         return self.obj < other.obj
 
 
-@functools.lru_cache
+@functools.cache
 def url_escape(url, *args, **kwargs):
     """
     Escape a URL path segment. Cache results for better performance.


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8761
