### PR TITLE
Raise an error if compute on persisted collection with released futures

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4508,12 +4508,12 @@ class Scheduler(SchedulerState, ServerNode):
         dependencies: dict[Key, set[Key]],
         keys: set[Key],
     ) -> set[Key]:
-        n = 0
+        n = -1
         lost_keys = set()
         while len(dsk) != n:  # walk through new tasks, cancel any bad deps
             n = len(dsk)
             for k, deps in list(dependencies.items()):
-                if any(
+                if (k not in self.tasks and k not in dsk) or any(
                     dep not in self.tasks and dep not in dsk for dep in deps
                 ):  # bad key
                     lost_keys.add(k)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8472,6 +8472,7 @@ def _release_persisted(obj):
 
 @gen_cluster(client=True)
 async def test_release_persisted_collection(c, s, a, b):
+    np = pytest.importorskip("numpy")
     da = pytest.importorskip("dask.array")
 
     arr = c.persist(da.random.random((10,), chunks=(10,)))
@@ -8487,6 +8488,7 @@ async def test_release_persisted_collection(c, s, a, b):
 
 
 def test_release_persisted_collection_sync(c):
+    np = pytest.importorskip("numpy")
     da = pytest.importorskip("dask.array")
     arr = da.random.random((10,), chunks=(10,)).persist()
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8464,3 +8464,40 @@ async def test_scheduler_restart_exception_on_cancelled_futures(c, s, a, b):
 
     with pytest.raises(CancelledError, match="Scheduler has restarted"):
         await fut.result()
+
+
+def _release_persisted(obj):
+    return len([f.release() for f in futures_of(obj)])
+
+
+@gen_cluster(client=True)
+async def test_release_persisted_collection(c, s, a, b):
+    da = pytest.importorskip("dask.array")
+
+    arr = c.persist(da.random.random((10,), chunks=(10,)))
+
+    await wait(arr)
+
+    _release_persisted(arr)
+    while s.tasks:
+        await asyncio.sleep(0.01)
+
+    with pytest.raises(CancelledError):
+        await c.compute(arr)
+
+
+def test_release_persisted_collection_sync(c):
+    da = pytest.importorskip("dask.array")
+    arr = da.random.random((10,), chunks=(10,)).persist()
+
+    wait(arr)
+    _release_persisted(arr)
+
+    while c.run_on_scheduler(lambda dask_scheduler: len(dask_scheduler.tasks)) > 0:
+        sleep(0.01)
+
+    with pytest.raises(CancelledError):
+        # Note: dask.compute is actually calling client.get, i.e. what we are
+        # submitting to the scheduler is different to what we are in
+        # client.compute
+        arr.compute()


### PR DESCRIPTION
If the futures of a collection are released this can cause a deadlock in the scheduler since the lost keys are not properly detected