### PR TITLE
Ensure Lock will not lock up in case of worker failures

### DIFF
--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -6,6 +6,8 @@ from distributed.semaphore import Semaphore
 
 logger = logging.getLogger(__name__)
 
+_no_value = object()
+
 
 class Lock(Semaphore):
     """Distributed Centralized Lock
@@ -48,10 +50,20 @@ class Lock(Semaphore):
     def __init__(
         self,
         name=None,
+        client=_no_value,
         register=True,
         scheduler_rpc=None,
         loop=None,
     ):
+        if client is not _no_value:
+            import warnings
+
+            warnings.warn(
+                "The `client` parameter is deprecated. It is no longer necessary to pass a client to Lock.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         super().__init__(
             max_leases=1,
             name=name,

--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -1,79 +1,31 @@
 from __future__ import annotations
 
-import asyncio
 import logging
-import uuid
-from collections import defaultdict, deque
 
-from dask.utils import parse_timedelta
-
-from distributed.utils import TimeoutError, log_errors, wait_for
-from distributed.worker import get_client
+from distributed.semaphore import Semaphore
 
 logger = logging.getLogger(__name__)
 
 
-class LockExtension:
-    """An extension for the scheduler to manage Locks
-
-    This adds the following routes to the scheduler
-
-    *  lock_acquire
-    *  lock_release
-    """
-
-    def __init__(self, scheduler):
-        self.scheduler = scheduler
-        self.events = defaultdict(deque)
-        self.ids = dict()
-
-        self.scheduler.handlers.update(
-            {"lock_acquire": self.acquire, "lock_release": self.release}
-        )
-
-    @log_errors
-    async def acquire(self, name=None, id=None, timeout=None):
-        if isinstance(name, list):
-            name = tuple(name)
-        if name not in self.ids:
-            result = True
-        else:
-            while name in self.ids:
-                event = asyncio.Event()
-                self.events[name].append(event)
-                future = event.wait()
-                if timeout is not None:
-                    future = wait_for(future, timeout)
-                try:
-                    await future
-                except TimeoutError:
-                    result = False
-                    break
-                else:
-                    result = True
-                finally:
-                    event2 = self.events[name].popleft()
-                    assert event is event2
-        if result:
-            assert name not in self.ids
-            self.ids[name] = id
-        return result
-
-    @log_errors
-    def release(self, name=None, id=None):
-        if isinstance(name, list):
-            name = tuple(name)
-        if self.ids.get(name) != id:
-            raise ValueError("This lock has not yet been acquired")
-        del self.ids[name]
-        if self.events[name]:
-            self.scheduler.loop.add_callback(self.events[name][0].set)
-        else:
-            del self.events[name]
-
-
-class Lock:
+class Lock(Semaphore):
     """Distributed Centralized Lock
+
+    .. warning::
+
+        This is using the ``distributed.Semaphore`` as a backend, which is
+        susceptible to lease overbooking. For the Lock this means that if a
+        lease is timing out, two or more instances could acquire the lock at the
+        same time. To disable lease timeouts, set
+        ``distributed.scheduler.locks.lease-timeout`` to `inf`, e.g.
+
+        .. code-block:: python
+
+            with dask.config.set({"distributed.scheduler.locks.lease-timeout": "inf"}):
+                lock = Lock("x")
+                ...
+
+        Note, that without lease timeouts, the Lock may deadlock in case of
+        cluster downscaling or worker failures.
 
     Parameters
     ----------
@@ -93,28 +45,20 @@ class Lock:
     >>> lock.release()  # doctest: +SKIP
     """
 
-    def __init__(self, name=None, client=None):
-        self._client = client
-        self.name = name or "lock-" + uuid.uuid4().hex
-        self.id = uuid.uuid4().hex
-        self._locked = False
-
-    @property
-    def client(self):
-        if not self._client:
-            try:
-                self._client = get_client()
-            except ValueError:
-                pass
-        return self._client
-
-    def _verify_running(self):
-        if not self.client:
-            raise RuntimeError(
-                f"{type(self)} object not properly initialized. This can happen"
-                " if the object is being deserialized outside of the context of"
-                " a Client or Worker."
-            )
+    def __init__(
+        self,
+        name=None,
+        register=True,
+        scheduler_rpc=None,
+        loop=None,
+    ):
+        super().__init__(
+            max_leases=1,
+            name=name,
+            register=register,
+            scheduler_rpc=scheduler_rpc,
+            loop=loop,
+        )
 
     def acquire(self, blocking=True, timeout=None):
         """Acquire the lock
@@ -139,50 +83,21 @@ class Lock:
         -------
         True or False whether or not it successfully acquired the lock
         """
-        self._verify_running()
-        timeout = parse_timedelta(timeout)
-
         if not blocking:
             if timeout is not None:
                 raise ValueError("can't specify a timeout for a non-blocking call")
             timeout = 0
+        return super().acquire(timeout=timeout)
 
-        result = self.client.sync(
-            self.client.scheduler.lock_acquire,
-            name=self.name,
-            id=self.id,
-            timeout=timeout,
-        )
-        self._locked = True
-        return result
-
-    def release(self):
-        """Release the lock if already acquired"""
-        self._verify_running()
-        if not self.locked():
-            raise ValueError("Lock is not yet acquired")
-        result = self.client.sync(
-            self.client.scheduler.lock_release, name=self.name, id=self.id
-        )
-        self._locked = False
-        return result
+    async def _locked(self):
+        val = await self.scheduler.semaphore_value(name=self.name)
+        return val == 1
 
     def locked(self):
-        return self._locked
+        return self.sync(self._locked)
 
-    def __enter__(self):
-        self.acquire()
-        return self
+    def __getstate__(self):
+        return self.name
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.release()
-
-    async def __aenter__(self):
-        await self.acquire()
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.release()
-
-    def __reduce__(self):
-        return (Lock, (self.name,))
+    def __setstate__(self, state):
+        self.__init__(name=state, register=False)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -101,7 +101,6 @@ from distributed.diagnostics.memory_sampler import MemorySamplerExtension
 from distributed.diagnostics.plugin import SchedulerPlugin, _get_plugin_name
 from distributed.event import EventExtension
 from distributed.http import get_handlers
-from distributed.lock import LockExtension
 from distributed.metrics import time
 from distributed.multi_lock import MultiLockExtension
 from distributed.node import ServerNode
@@ -179,7 +178,6 @@ DEFAULT_DATA_SIZE = parse_bytes(
 STIMULUS_ID_UNSET = "<stimulus_id unset>"
 
 DEFAULT_EXTENSIONS = {
-    "locks": LockExtension,
     "multi_locks": MultiLockExtension,
     "publish": PublishExtension,
     "replay-tasks": ReplayTaskScheduler,

--- a/distributed/semaphore.py
+++ b/distributed/semaphore.py
@@ -40,7 +40,7 @@ class SemaphoreExtension:
         self.max_leases = dict()
         # {semaphore_name: {lease_id: lease_last_seen_timestamp}}
         self.leases = defaultdict(dict)
-
+        self.lease_timeouts = dict()
         self.scheduler.handlers.update(
             {
                 "semaphore_register": self.create,
@@ -70,20 +70,18 @@ class SemaphoreExtension:
             self._check_lease_timeout, validation_callback_time * 1000
         )
         pc.start()
-        self.lease_timeout = parse_timedelta(
-            dask.config.get("distributed.scheduler.locks.lease-timeout"), default="s"
-        )
 
     def get_value(self, name=None):
         return len(self.leases[name])
 
     # `comm` here is required by the handler interface
-    def create(self, name=None, max_leases=None):
+    def create(self, name, max_leases, lease_timeout):
         # We use `self.max_leases` as the point of truth to find out if a semaphore with a specific
         # `name` has been created.
         if name not in self.max_leases:
             assert isinstance(max_leases, int), max_leases
             self.max_leases[name] = max_leases
+            self.lease_timeouts[name] = lease_timeout
         else:
             if max_leases != self.max_leases[name]:
                 raise ValueError(
@@ -128,7 +126,7 @@ class SemaphoreExtension:
     @log_errors
     async def acquire(self, name=None, timeout=None, lease_id=None):
         if not self._semaphore_exists(name):
-            raise RuntimeError(f"Semaphore `{name}` not known or already closed.")
+            raise RuntimeError(f"Semaphore or Lock `{name}` not known.")
 
         if isinstance(name, list):
             name = tuple(name)
@@ -176,7 +174,7 @@ class SemaphoreExtension:
     def release(self, name=None, lease_id=None):
         if not self._semaphore_exists(name):
             logger.warning(
-                f"Tried to release semaphore `{name}` but it is not known or already closed."
+                f"Tried to release Lock or Semaphore `{name}` but it is not known."
             )
             return
         if isinstance(name, list):
@@ -185,9 +183,9 @@ class SemaphoreExtension:
             self._release_value(name, lease_id)
         else:
             logger.warning(
-                "Tried to release semaphore but it was already released: "
+                f"Tried to release Lock or Semaphore but it was already released: "
                 f"{name=}, {lease_id=}. "
-                "This can happen if the semaphore timed out before."
+                f"This can happen if the Lock or Semaphore timed out before."
             )
 
     def _release_value(self, name, lease_id):
@@ -201,23 +199,24 @@ class SemaphoreExtension:
         now = time()
         semaphore_names = list(self.leases.keys())
         for name in semaphore_names:
-            ids = list(self.leases[name])
-            logger.debug(
-                "Validating leases for %s at time %s. Currently known %s",
-                name,
-                now,
-                self.leases[name],
-            )
-            for _id in ids:
-                time_since_refresh = now - self.leases[name][_id]
-                if time_since_refresh > self.lease_timeout:
-                    logger.debug(
-                        "Lease %s for %s timed out after %ss.",
-                        _id,
-                        name,
-                        time_since_refresh,
-                    )
-                    self._release_value(name=name, lease_id=_id)
+            if lease_timeout := self.lease_timeouts.get(name):
+                ids = list(self.leases[name])
+                logger.debug(
+                    "Validating leases for %s at time %s. Currently known %s",
+                    name,
+                    now,
+                    self.leases[name],
+                )
+                for _id in ids:
+                    time_since_refresh = now - self.leases[name][_id]
+                    if time_since_refresh > lease_timeout:
+                        logger.debug(
+                            "Lease %s for %s timed out after %ss.",
+                            _id,
+                            name,
+                            time_since_refresh,
+                        )
+                        self._release_value(name=name, lease_id=_id)
 
     @log_errors
     def close(self, name=None):
@@ -226,6 +225,7 @@ class SemaphoreExtension:
             return
 
         del self.max_leases[name]
+        del self.lease_timeouts[name]
         if name in self.events:
             del self.events[name]
         if name in self.leases:
@@ -320,14 +320,6 @@ class Semaphore(SyncMethodMixin):
     -----
     If a client attempts to release the semaphore but doesn't have a lease acquired, this will raise an exception.
 
-
-    When a semaphore is closed, if, for that closed semaphore, a client attempts to:
-
-    - Acquire a lease: an exception will be raised.
-    - Release: a warning will be logged.
-    - Close: nothing will happen.
-
-
     dask executes functions by default assuming they are pure, when using semaphore acquire/releases inside
     such a function, it must be noted that there *are* in fact side-effects, thus, the function can no longer be
     considered pure. If this is not taken into account, this may lead to unexpected behavior.
@@ -352,28 +344,28 @@ class Semaphore(SyncMethodMixin):
 
         self.refresh_leases = True
 
-        self._registered = None
+        self._do_register = None
         if register:
-            self._registered = self.register()
+            self._do_register = register
 
         # this should give ample time to refresh without introducing another
         # config parameter since this *must* be smaller than the timeout anyhow
-        refresh_leases_interval = (
-            parse_timedelta(
+        lease_timeout = dask.config.get("distributed.scheduler.locks.lease-timeout")
+        if lease_timeout != "inf":
+            lease_timeout = parse_timedelta(
                 dask.config.get("distributed.scheduler.locks.lease-timeout"),
                 default="s",
             )
-            / 5
-        )
-        pc = PeriodicCallback(
-            self._refresh_leases, callback_time=refresh_leases_interval * 1000
-        )
-        self.refresh_callback = pc
+            refresh_leases_interval = lease_timeout / 5
+            pc = PeriodicCallback(
+                self._refresh_leases, callback_time=refresh_leases_interval * 1000
+            )
+            self.refresh_callback = pc
 
-        # Need to start the callback using IOLoop.add_callback to ensure that the
-        # PC uses the correct event loop.
-        if self.loop is not None:
-            self.loop.add_callback(pc.start)
+            # Need to start the callback using IOLoop.add_callback to ensure that the
+            # PC uses the correct event loop.
+            if self.loop is not None:
+                self.loop.add_callback(pc.start)
 
     @property
     def scheduler(self):
@@ -407,10 +399,17 @@ class Semaphore(SyncMethodMixin):
             )
 
     async def _register(self):
+        lease_timeout = dask.config.get("distributed.scheduler.locks.lease-timeout")
+
+        if lease_timeout == "inf":
+            lease_timeout = None
+        else:
+            lease_timeout = parse_timedelta(lease_timeout, "s")
         await retry_operation(
             self.scheduler.semaphore_register,
             name=self.name,
             max_leases=self.max_leases,
+            lease_timeout=lease_timeout,
             operation=f"semaphore register id={self.id} name={self.name}",
         )
 
@@ -419,8 +418,8 @@ class Semaphore(SyncMethodMixin):
 
     def __await__(self):
         async def create_semaphore():
-            if self._registered:
-                await self._registered
+            if self._do_register:
+                await self._register()
             return self
 
         return create_semaphore().__await__()
@@ -442,6 +441,7 @@ class Semaphore(SyncMethodMixin):
             )
 
     async def _acquire(self, timeout=None):
+        await self
         lease_id = uuid.uuid4().hex
         logger.debug(
             "%s requests lease for %s with ID %s", self.id, self.name, lease_id
@@ -527,6 +527,7 @@ class Semaphore(SyncMethodMixin):
         return self.sync(self.scheduler.semaphore_value, name=self.name)
 
     def __enter__(self):
+        self.register()
         self._verify_running()
         self.acquire()
         return self
@@ -535,6 +536,7 @@ class Semaphore(SyncMethodMixin):
         self.release()
 
     async def __aenter__(self):
+        await self
         self._verify_running()
         await self.acquire()
         return self


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/2362

This replaces the Lock implementation with the Semaphore. The caveat is that the Lock no longer strictly guarantees that there are never two threads acquiring the lock since the resilience of the Semaphore is timeout based.

In hindsight, the Semaphore should likely have used a plugin based approach that invalidates the leases a worker holds once it is removed but this could be added later. 
To still be able to enforce strictness on the lock, I allowed to disable the lease validation logic by setting `dask.config.set({"distributed.scheduler.locks.lease-timeout": "inf"})` which I think is a compromise

There is one minor breakage around what happens if a semaphore is "closed". The new implementation will just reset the state. This is necessary to allow patterns like...


```python

    def f(x):
        with Lock("x"):
           ...

    futures = c.map(f, range(20))
```

where the lock is not initialized ahead of time. I think this is a fair compromise.