### PR TITLE
Avoid false positives for `p2p-failed` log event

### DIFF
--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -416,7 +416,11 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
         if finish == "erred":
             ts = self.scheduler.tasks[key]
             for active_shuffle in self.active_shuffles.values():
+                # Log once per active shuffle
                 if active_shuffle._failed:
+                    continue
+                # Log IFF a P2P task is the root cause
+                if ts.exception_blame != ts:
                     continue
                 barrier = self.scheduler.tasks[barrier_key(active_shuffle.id)]
                 if (

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -246,8 +246,9 @@ async def test_cull_p2p_rechunking_single_chunk(c, s, *ws):
     n_inputs = len(
         [1 for key in dsk.dask.get_all_dependencies() if key[0].startswith("array-")]
     )
+
     assert n_inputs > 0
-    
+
     n_culled_inputs = len(
         [
             1

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -465,8 +465,13 @@ async def test_erred_task_before_p2p_does_not_log_event(c, s, a, b):
         dtypes={"x": float, "y": float},
         freq="10 s",
     )
-    lock = Lock()
-    variable = Variable("allowed_tasks", client=c)
+    semaphore = Semaphore(max_leases=s.total_nthreads * 2 + 1)
+    
+    def block_and_fail_eventually(...):
+        try:
+            sem.acquire(timeout=0)
+        except TimeoutError:
+            raise RuntimeError()
 
     async with lock:
         await variable.set(s.total_nthreads * 2 + 1)


### PR DESCRIPTION
The log event added in https://github.com/dask/distributed/pull/8663 has false positives if an input task to the P2P shuffle/rechunk causes the P2P tasks to err. We should only log this event if P2P tasks are the root cause of the failure instead. This PR fixes that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
