### PR TITLE
Ensure Locks always register with scheduler

### DIFF
--- a/distributed/lock.py
+++ b/distributed/lock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 
 from distributed.semaphore import Semaphore
 
@@ -51,7 +52,6 @@ class Lock(Semaphore):
         self,
         name=None,
         client=_no_value,
-        register=True,
         scheduler_rpc=None,
         loop=None,
     ):
@@ -64,10 +64,10 @@ class Lock(Semaphore):
                 stacklevel=2,
             )
 
+        self.name = name or "lock-" + uuid.uuid4().hex
         super().__init__(
             max_leases=1,
             name=name,
-            register=register,
             scheduler_rpc=scheduler_rpc,
             loop=loop,
         )
@@ -112,4 +112,4 @@ class Lock(Semaphore):
         return self.name
 
     def __setstate__(self, state):
-        self.__init__(name=state, register=False)
+        self.__init__(name=state)

--- a/distributed/tests/test_semaphore.py
+++ b/distributed/tests/test_semaphore.py
@@ -202,13 +202,8 @@ async def test_close_async(c, s, a):
         match="Closing semaphore test but there remain unreleased leases .*",
     ):
         await sem.close()
-    # After close, the semaphore is reset
-    await sem.acquire()
-    with pytest.warns(
-        RuntimeWarning,
-        match="Closing semaphore test but there remain unreleased leases .*",
-    ):
-        await sem.close()
+    with pytest.raises(RuntimeError, match="not known"):
+        await sem.acquire()
 
     sem2 = await Semaphore(name="t2", max_leases=1)
     assert await sem2.acquire()


### PR DESCRIPTION
The register keyword is not necessary and added unnecessary complexity from what I can tell. I added this myself in https://github.com/dask/distributed/pull/4060 to avoid having the PC being initialized outside of a running event loop but I think this register argument was not the right mechanism for this.

With this, an initialized lock that's been send over the nework would not be able to use acquire/release but woudl have to be awaited / explicitly registered. By removing this, all that complexity goes away (now every instance checks in with the scheduler but that's idempotent)