### PR TITLE
Restore len() on TaskPrefix

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1000,6 +1000,9 @@ class TaskCollection:
     def _calculate_duration_us(start: float, stop: float) -> int:
         return max(round((stop - start) * 1e6), 0)
 
+    def __len__(self) -> int:
+        return sum(self.states.values())
+
 
 class TaskPrefix(TaskCollection):
     """Collection tracking all tasks within a prefix
@@ -1189,9 +1192,6 @@ class TaskGroup(TaskCollection):
             )
             + ">"
         )
-
-    def __len__(self) -> int:
-        return sum(self.states.values())
 
     def _to_dict_no_nest(self, *, exclude: Container[str] = ()) -> dict[str, Any]:
         """Dictionary representation for debugging purposes.

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2822,6 +2822,8 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert tg.states["memory"] == 0
     assert tg.states["released"] == 5
     assert sum(tg.states.values()) == 5
+    assert len(tg) == 5
+    assert len(tp) == 5
     assert tg.nbytes_total == sum(
         ts.get_nbytes() for ts in s.tasks.values() if ts.group is tg
     )
@@ -2844,6 +2846,8 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     tg = s.task_groups[y.name]
     assert tg.states["memory"] == 5
     assert sum(tg.states.values()) == 5
+    assert len(tg) == 5
+    assert len(tp) == 5
 
     tp = s.task_prefixes["add"]
     assert tg.prefix is tp
@@ -2881,6 +2885,9 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert tg.states["forgotten"] == 4
     assert tg.states["released"] == 1
     assert sum(tg.states.values()) == 5
+    assert len(tg) == 5
+    assert len(tp) == 5
+
     assert tg.states == tp.states
     with pytest.warns(FutureWarning, match="active_states"):
         assert tp.states == tp.active_states
@@ -2895,6 +2902,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
 
     assert tg.states["forgotten"] == 5
     assert sum(tg.states.values()) == 5
+    assert len(tg) == 5
 
     assert tg.states["forgotten"] == 5
     assert tg.name not in s.task_groups
@@ -2913,6 +2921,7 @@ async def test_task_group_and_prefix_statistics(c, s, a, b, no_time_resync):
     assert all(count == 0 for count in tp.states.values())
     with pytest.warns(FutureWarning, match="active_states"):
         assert tp.states == tp.active_states
+    assert len(tp) == 0
     assert tp.duration == 0
     assert tp.nbytes_total == 0
     assert tp.types == set()


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8780

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
