### PR TITLE
Temporarily pin ``setuptools < 71``

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -44,6 +44,8 @@ dependencies:
   - tornado
   - zict  # overridden by git tip below
   - zstandard
+  # Temporary fix for https://github.com/pypa/setuptools/issues/4496
+  - setuptools < 71
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask-contrib/dask-expr

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -44,6 +44,8 @@ dependencies:
   - tornado
   - zict  # overridden by git tip below
   - zstandard
+  # Temporary fix for https://github.com/pypa/setuptools/issues/4496
+  - setuptools < 71
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask-contrib/dask-expr

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -44,6 +44,8 @@ dependencies:
   - tornado
   - zict  # overridden by git tip below
   - zstandard
+  # Temporary fix for https://github.com/pypa/setuptools/issues/4496
+  - setuptools < 71
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask-contrib/dask-expr

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -51,6 +51,8 @@ dependencies:
   - tornado
   - zict
   - zstandard
+  # Temporary fix for https://github.com/pypa/setuptools/issues/4496
+  - setuptools < 71
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask-contrib/dask-expr

--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -19,6 +19,8 @@ dependencies:
   - tornado=6.0.4
   - urllib3=1.24.3
   - zict=3.0.0
+  # Temporary fix for https://github.com/pypa/setuptools/issues/4496
+  - setuptools < 71
   # Distributed depends on the latest version of Dask
   - pip
   - pip:


### PR DESCRIPTION
We're setting unrelated test failures in CI that I think are related to https://github.com/pypa/setuptools/issues/4496. Let's try temporarily pinning as a workaround. 