### PR TITLE
Make stealing more robust

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -569,7 +569,9 @@ class WorkerState:
         return self._hash
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, WorkerState) and other.server_id == self.server_id
+        return self is other or (
+            isinstance(other, WorkerState) and other.server_id == self.server_id
+        )
 
     @property
     def has_what(self) -> Set[TaskState]:

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -178,6 +178,12 @@ class WorkStealing(SchedulerPlugin):
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        # By first checking whether we've started in processing
+        # and then checking whether we've finished in processing,
+        # this logic also handles transitions that end up in the same state.
+        # Since finish is the actual end state of the task - not the desired one,
+        # this could occur if a transaction decides against moving the task to the
+        # desired state.
         if start == "processing":
             ts = self.scheduler.tasks[key]
             self.remove_key_from_stealable(ts)

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -181,7 +181,7 @@ class WorkStealing(SchedulerPlugin):
         # By first checking whether we've started in processing
         # and then checking whether we've finished in processing,
         # this logic also handles transitions that end up in the same state.
-        # Since finish is the actual end state of the task - not the desired one,
+        # Since finish is the actual end state of the task, not the desired one,
         # this could occur if a transaction decides against moving the task to the
         # desired state.
         if start == "processing":


### PR DESCRIPTION
This PR improves a few details in the stealing code that could _potentially_ cause the scheduler to deadlock. I don't have any reproducer that could confirm this, but I've identified these weak points while investigating #8787. Fixing these should be strictly beneficial. 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
