### PR TITLE
Fix restarting workers with `PackageInstall` plugin

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -518,7 +518,6 @@ class _InstallNannyPlugin(NannyPlugin):
             await Semaphore(
                 max_leases=1,
                 name=socket.gethostname(),
-                register=True,
                 scheduler_rpc=nanny.scheduler,
                 loop=nanny.loop,
             )


### PR DESCRIPTION
Closes #8791 

https://github.com/dask/distributed/pull/8781 caused a regression in `2024.7.1` where the worker restart via nanny plugins stopped working. This PR fixes that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
