### PR TITLE
Raise an error in ``scatter`` when ``broadcast`` and AMM are incompatible

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2779,6 +2779,17 @@ class Client(SyncMethodMixin):
                 "Consider using a normal for loop and Client.submit"
             )
 
+        if broadcast and dask.config.get(
+            "distributed.scheduler.active-memory-manager.start"
+        ):
+            raise RuntimeError(
+                "Scattering data with broadcast=True is incompatible "
+                "with the Active Memory Manager’s ReduceReplicas "
+                "policy. Please disable the AMM plugin by setting "
+                "the following config to False: "
+                "'distributed.scheduler.active-memory-manager.start'"
+            )
+
         try:
             local_worker = get_worker()
         except ValueError:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2353,6 +2353,12 @@ async def test__broadcast(c, s, a, b):
     assert a.data == b.data == {x.key: 1, y.key: 2}
 
 
+@gen_cluster(client=True)
+async def test__broadcast_raises(c, s, a, b):
+    with pytest.raises(RuntimeError):
+        await c.scatter([1, 2], broadcast=True)
+
+
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)] * 4, config=NO_AMM)
 async def test__broadcast_integer(c, s, *workers):
     x, y = await c.scatter([1, 2], broadcast=2)


### PR DESCRIPTION
I spent a long time debugging a hang in XGBoost before I noticed [this doc-string note](https://github.com/dask/distributed/blob/7013e2e71bcf0a02905488447b98400ddad72d32/distributed/client.py#L2709) about disabling AMM.

It turns out that `xgboost.dask.predict(...)` uses `client.scatter(..., broadcast=True)` to replicate the `Booster` object on all workers. In some cases, the replication process seems to conflict with the active-memory-manager's `ReduceReplicas` policy - resulting in a hang.

This PR proposes that a clear error be raised by `Client.scatter` when `broadcast=True` and AMM is enabled in the config. It also seems fine to produce a warning instead. However, I definitely think it makes sense to be "loud" when the user is likely to run into a problem like this.