### PR TITLE
Remove unused `delete_interval` and  `synchronize_worker_interval` from `Scheduler`

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -3601,8 +3601,6 @@ class Scheduler(SchedulerState, ServerNode):
     def __init__(
         self,
         loop=None,
-        delete_interval="500ms",
-        synchronize_worker_interval="60s",
         services=None,
         service_kwargs=None,
         allowed_failures=None,
@@ -3651,10 +3649,6 @@ class Scheduler(SchedulerState, ServerNode):
         if validate is None:
             validate = dask.config.get("distributed.scheduler.validate")
         self.proc = psutil.Process()
-        self.delete_interval = parse_timedelta(delete_interval, default="ms")
-        self.synchronize_worker_interval = parse_timedelta(
-            synchronize_worker_interval, default="ms"
-        )
         self.service_specs = services or {}
         self.service_kwargs = service_kwargs or {}
         self.services = {}

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2660,25 +2660,6 @@ async def test_futures_of_cancelled_raises(c, s, a, b):
         await c.gather(c.map(add, [1], y=x))
 
 
-@pytest.mark.skip
-@gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
-async def test_dont_delete_recomputed_results(c, s, w):
-    x = c.submit(inc, 1)  # compute first time
-    await wait([x])
-    x.__del__()  # trigger garbage collection
-    await asyncio.sleep(0)
-    xx = c.submit(inc, 1)  # compute second time
-
-    start = time()
-    while xx.key not in w.data:  # data shows up
-        await asyncio.sleep(0.01)
-        assert time() < start + 1
-
-    while time() < start + (s.delete_interval + 100) / 1000:  # and stays
-        assert xx.key in w.data
-        await asyncio.sleep(0.01)
-
-
 @pytest.mark.skip(reason="Use fast random selection now")
 @gen_cluster(client=True)
 async def test_balance_tasks_by_stacks(c, s, a, b):


### PR DESCRIPTION
From what I understand, these are not used anywhere and haven't been used in at least a year, so let's remove them. I'm open to adding a deprecation cycle if people think that's worthwhile.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
