### PR TITLE
Add Prometheus metric for time spent on GC

### DIFF
--- a/distributed/http/scheduler/prometheus/core.py
+++ b/distributed/http/scheduler/prometheus/core.py
@@ -13,6 +13,7 @@ from distributed.http.scheduler.prometheus.semaphore import SemaphoreMetricColle
 from distributed.http.scheduler.prometheus.stealing import WorkStealingMetricCollector
 from distributed.http.utils import RequestHandler
 from distributed.scheduler import ALL_TASK_STATES, Scheduler
+from distributed.utils_perf import gc_collect_duration
 
 
 class SchedulerMetricCollector(PrometheusCollector):
@@ -92,6 +93,13 @@ class SchedulerMetricCollector(PrometheusCollector):
                 value=self.server.monitor.cumulative_gil_contention,
                 unit="seconds",
             )
+
+        yield CounterMetricFamily(
+            self.build_name("gc_collection"),
+            "Total time spent on garbage collection",
+            value=gc_collect_duration(),
+            unit="seconds",
+        )
 
         yield CounterMetricFamily(
             self.build_name("last_time"),

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -130,6 +130,7 @@ async def test_prometheus(c, s, a, b):
         "dask_scheduler_prefix_state_totals",
         "dask_scheduler_tick_count",
         "dask_scheduler_tick_duration_maximum_seconds",
+        "dask_scheduler_gc_collection_seconds",
     }
 
     try:

--- a/distributed/http/worker/prometheus/core.py
+++ b/distributed/http/worker/prometheus/core.py
@@ -10,6 +10,7 @@ from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, Metri
 
 from distributed.http.prometheus import PrometheusCollector
 from distributed.http.utils import RequestHandler
+from distributed.utils_perf import gc_collect_duration
 from distributed.worker import Worker
 
 logger = logging.getLogger("distributed.prometheus.worker")
@@ -67,6 +68,13 @@ class WorkerMetricCollector(PrometheusCollector):
                 value=self.server.monitor.cumulative_gil_contention,
                 unit="seconds",
             )
+
+        yield CounterMetricFamily(
+            self.build_name("gc_collection"),
+            "Total time spent on garbage collection",
+            value=gc_collect_duration(),
+            unit="seconds",
+        )
 
         yield GaugeMetricFamily(
             self.build_name("threads"),

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -52,7 +52,7 @@ async def test_prometheus(c, s, a):
         "dask_worker_transfer_outgoing_count",
         "dask_worker_transfer_outgoing_count_total",
         "dask_worker_transfer_outgoing_bytes_total",
-        "dask_worker_gc_collection_seconds",
+        "dask_worker_gc_collection_seconds_total",
     }
 
     try:

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -52,6 +52,7 @@ async def test_prometheus(c, s, a):
         "dask_worker_transfer_outgoing_count",
         "dask_worker_transfer_outgoing_count_total",
         "dask_worker_transfer_outgoing_bytes_total",
+        "dask_worker_gc_collection_seconds",
     }
 
     try:

--- a/distributed/tests/test_utils_perf.py
+++ b/distributed/tests/test_utils_perf.py
@@ -89,7 +89,7 @@ def enable_gc_diagnosis_and_log(diag, level="INFO"):
             gc.enable()
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 def test_gc_diagnosis_cpu_time():
     diag = GCDiagnosis(warn_over_frac=0.75)
     diag.N_SAMPLES = 3  # shorten tests

--- a/distributed/tests/test_utils_perf.py
+++ b/distributed/tests/test_utils_perf.py
@@ -48,14 +48,20 @@ def test_fractional_timer():
 
     timer = RandomTimer()
     ft = FractionalTimer(n_samples=N, timer=timer)
+    assert ft.duration_total == 0
     for _ in range(N):
         ft.start_timing()
         ft.stop_timing()
+    expected_total = sum(ft._durations)
+    assert ft.duration_total == pytest.approx(expected_total / ft.MULT)
     assert len(timer.timings) == N * 2
     assert ft.running_fraction is None
+    assert ft.duration_total > 0
 
     ft.start_timing()
     ft.stop_timing()
+    expected_total += ft._durations[-1]
+    assert ft.duration_total == pytest.approx(expected_total / ft.MULT)
     assert len(timer.timings) == (N + 1) * 2
     assert ft.running_fraction is not None
     check_fraction(timer, ft)
@@ -83,7 +89,7 @@ def enable_gc_diagnosis_and_log(diag, level="INFO"):
             gc.enable()
 
 
-@pytest.mark.slow
+# @pytest.mark.slow
 def test_gc_diagnosis_cpu_time():
     diag = GCDiagnosis(warn_over_frac=0.75)
     diag.N_SAMPLES = 3  # shorten tests

--- a/distributed/utils_perf.py
+++ b/distributed/utils_perf.py
@@ -4,6 +4,7 @@ import gc
 import logging
 import threading
 from collections import deque
+from typing import Callable, Final
 
 import psutil
 
@@ -76,9 +77,18 @@ class FractionalTimer:
     elapsed time.
     """
 
-    MULT = 1e9  # convert to nanoseconds
+    MULT: Final[float] = 1e9  # convert to nanoseconds
 
-    def __init__(self, n_samples, timer=thread_time):
+    _timer: Callable[[], float]
+    _n_samples: int
+    _start_stops: deque[tuple[float, float]]
+    _durations: deque[int]
+    _cur_start: float | None
+    _running_sum: int | None
+    _running_fraction: float | None
+    _duration_total: int
+
+    def __init__(self, n_samples: int, timer: Callable[[], float] = thread_time):
         self._timer = timer
         self._n_samples = n_samples
         self._start_stops = deque()
@@ -86,8 +96,9 @@ class FractionalTimer:
         self._cur_start = None
         self._running_sum = None
         self._running_fraction = None
+        self._duration_total = 0
 
-    def _add_measurement(self, start, stop):
+    def _add_measurement(self, start: float, stop: float) -> None:
         start_stops = self._start_stops
         durations = self._durations
         if stop < start or (start_stops and start < start_stops[-1][1]):
@@ -98,6 +109,7 @@ class FractionalTimer:
         duration = int((stop - start) * self.MULT)
         start_stops.append((start, stop))
         durations.append(duration)
+        self._duration_total += duration
 
         n = len(durations)
         assert n == len(start_stops)
@@ -114,11 +126,11 @@ class FractionalTimer:
                         self._running_sum / (stop - old_stop) / self.MULT
                     )
 
-    def start_timing(self):
+    def start_timing(self) -> None:
         assert self._cur_start is None
         self._cur_start = self._timer()
 
-    def stop_timing(self):
+    def stop_timing(self) -> None:
         stop = self._timer()
         start = self._cur_start
         self._cur_start = None
@@ -126,7 +138,14 @@ class FractionalTimer:
         self._add_measurement(start, stop)
 
     @property
-    def running_fraction(self):
+    def duration_total(self) -> float:
+        current_duration = 0.0
+        if self._cur_start is not None:
+            current_duration = self._timer() - self._cur_start
+        return self._duration_total / self.MULT + current_duration
+
+    @property
+    def running_fraction(self) -> float | None:
         return self._running_fraction
 
 
@@ -145,6 +164,7 @@ class GCDiagnosis:
         self._warn_over_frac = warn_over_frac
         self._info_over_rss_win = info_over_rss_win
         self._enabled = False
+        self._fractional_timer = None
 
     def enable(self):
         assert not self._enabled
@@ -244,3 +264,9 @@ def disable_gc_diagnosis(force=False):
                 _gc_diagnosis_users = 0
             else:
                 assert _gc_diagnosis.enabled
+
+
+def gc_collect_duration() -> float:
+    if _gc_diagnosis._fractional_timer is None:
+        return 0
+    return _gc_diagnosis._fractional_timer.duration_total

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -49,6 +49,13 @@ dask_scheduler_gil_contention_seconds_total
        ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
 
+dask_scheduler_gc_collection_seconds_total
+    Total time spent on garbage dask_scheduler_gc_collection_seconds_total
+
+    .. note::
+        Due to measurement overhead, this metric only measures
+        time spent on garbage collection for generation=2
+
 dask_scheduler_workers
     Number of workers known by scheduler
 dask_scheduler_workers_added_total
@@ -158,6 +165,13 @@ dask_worker_gil_contention_seconds_total
        Requires ``gilknocker`` to be installed, and
        ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
+
+dask_scheduler_gc_collection_seconds_total
+    Total time spent on garbage dask_scheduler_gc_collection_seconds_total
+
+    .. note::
+        Due to measurement overhead, this metric only measures
+        time spent on garbage collection for generation=2
 
 dask_worker_latency_seconds
     Latency of worker connection

--- a/docs/source/prometheus.rst
+++ b/docs/source/prometheus.rst
@@ -166,7 +166,7 @@ dask_worker_gil_contention_seconds_total
        ``distributed.admin.system-monitor.gil.enabled``
        configuration to be set.
 
-dask_scheduler_gc_collection_seconds_total
+dask_worker_gc_collection_seconds_total
     Total time spent on garbage dask_scheduler_gc_collection_seconds_total
 
     .. note::


### PR DESCRIPTION
#8543 pointed out that the GC warnings provide _some_ value but are rather spammy. This PR presents adds a Prometheus metric that presents the data in an alternative format that should provide more value when monitoring cluster and workload health.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
