### PR TITLE
Fail tasks exceeding `no-workers-timeout`

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -91,6 +91,17 @@ properties:
 
               Works in conjunction with idle-timeout.
 
+          unrunnable-task-ttl:
+            type:
+            - string
+            - "null"
+            description: |
+              Time to live for unrunnable tasks.
+
+              If task is unrunnable for longer than this, it fails. A task is considered unrunnable, if
+              it has no pending dependencies, and the task has restrictions that are not satisfied by 
+              any available worker or no workers are running at all.
+
           work-stealing:
             type: boolean
             description: |

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -81,7 +81,7 @@ properties:
             - string
             - "null"
             description: |
-              Time to live for tasks in an unrunnable state.
+              Timeout for tasks in an unrunnable state.
 
               If task remains unrunnable for longer than this, it fails. A task is considered unrunnable IFF
               it has no pending dependencies, and the task has restrictions that are not satisfied by 

--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -81,26 +81,14 @@ properties:
             - string
             - "null"
             description: |
-              Shut down the scheduler after this duration if there are pending tasks,
-              but no workers that can process them. This can either mean that there are
-              no workers running at all, or that there are idle workers but they've been
-              excluded through worker or resource restrictions.
+              Time to live for tasks in an unrunnable state.
+
+              If task remains unrunnable for longer than this, it fails. A task is considered unrunnable IFF
+              it has no pending dependencies, and the task has restrictions that are not satisfied by 
+              any available worker or no workers are running at all.
 
               In adaptive clusters, this timeout must be set to be safely higher than
               the time it takes for workers to spin up.
-
-              Works in conjunction with idle-timeout.
-
-          unrunnable-task-ttl:
-            type:
-            - string
-            - "null"
-            description: |
-              Time to live for unrunnable tasks.
-
-              If task is unrunnable for longer than this, it fails. A task is considered unrunnable, if
-              it has no pending dependencies, and the task has restrictions that are not satisfied by 
-              any available worker or no workers are running at all.
 
           work-stealing:
             type: boolean

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -18,8 +18,7 @@ distributed:
     # after they have been removed from the scheduler
     events-cleanup-delay: 1h
     idle-timeout: null        # Shut down after this duration, like "1h" or "30 minutes"
-    no-workers-timeout: null  # Shut down if there are tasks but no workers to process them
-    unrunnable-task-ttl: null # Time to live for unrunnable tasks. If a task is unrunnable for longer than this, it fails. 
+    no-workers-timeout: null  # Time to live for tasks in an unrunnable state. If a task remains unrunnable for longer than this, it fails.
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-saturation: 1.1  # Send this fraction of nthreads root tasks to workers

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -17,8 +17,9 @@ distributed:
     # Number of seconds to wait until workers or clients are removed from the events log
     # after they have been removed from the scheduler
     events-cleanup-delay: 1h
-    idle-timeout: null       # Shut down after this duration, like "1h" or "30 minutes"
-    no-workers-timeout: null # Shut down if there are tasks but no workers to process them
+    idle-timeout: null        # Shut down after this duration, like "1h" or "30 minutes"
+    no-workers-timeout: null  # Shut down if there are tasks but no workers to process them
+    unrunnable-task-ttl: null # Time to live for unrunnable tasks. If a task is unrunnable for longer than this, it fails. 
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-saturation: 1.1  # Send this fraction of nthreads root tasks to workers

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -18,7 +18,7 @@ distributed:
     # after they have been removed from the scheduler
     events-cleanup-delay: 1h
     idle-timeout: null        # Shut down after this duration, like "1h" or "30 minutes"
-    no-workers-timeout: null  # Time to live for tasks in an unrunnable state. If a task remains unrunnable for longer than this, it fails.
+    no-workers-timeout: null  # If a task remains unrunnable for longer than this, it fails.
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-saturation: 1.1  # Send this fraction of nthreads root tasks to workers

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -17,8 +17,8 @@ distributed:
     # Number of seconds to wait until workers or clients are removed from the events log
     # after they have been removed from the scheduler
     events-cleanup-delay: 1h
-    idle-timeout: null        # Shut down after this duration, like "1h" or "30 minutes"
-    no-workers-timeout: null  # If a task remains unrunnable for longer than this, it fails.
+    idle-timeout: null       # Shut down after this duration, like "1h" or "30 minutes"
+    no-workers-timeout: null # If a task remains unrunnable for longer than this, it fails.
     work-stealing: True     # workers should steal tasks from each other
     work-stealing-interval: 100ms  # Callback time for work stealing
     worker-saturation: 1.1  # Send this fraction of nthreads root tasks to workers

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4039,7 +4039,7 @@ class Scheduler(SchedulerState, ServerNode):
         pc = PeriodicCallback(self.check_idle, 250)
         self.periodic_callbacks["idle-timeout"] = pc
 
-        pc = PeriodicCallback(self._check_no_workers_timeout, 250)
+        pc = PeriodicCallback(self._check_no_workers, 250)
         self.periodic_callbacks["no-workers-timeout"] = pc
 
         if extensions is None:
@@ -8651,7 +8651,7 @@ class Scheduler(SchedulerState, ServerNode):
                 self._ongoing_background_tasks.call_soon(self.close)
         return self.idle_since
 
-    def _check_no_workers_timeout(self) -> None:
+    def _check_no_workers(self) -> None:
         if (
             self.status in (Status.closing, Status.closed)
             or self.no_workers_timeout is None

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2918,6 +2918,7 @@ class SchedulerState:
 
         if not ts.erred_on:
             ts.erred_on = set()
+        ts.erred_on.add(worker)
         if exception is not None:
             ts.exception = exception
             ts.exception_text = exception_text

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8775,7 +8775,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         for ts in unsatisfied:
             e = pickle.dumps(
-                UnsatisfiedRestrictionsError(
+                NoSuitableWorkerError(
                     task=ts.key,
                     host_restrictions=(ts.host_restrictions or set()).copy(),
                     worker_restrictions=(ts.worker_restrictions or set()).copy(),
@@ -8823,7 +8823,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         for ts in timed_out:
             e = pickle.dumps(
-                NoWorkersError(
+                NoWorkerError(
                     task=ts.key,
                     timeout=self.no_workers_timeout,
                 ),
@@ -9253,7 +9253,7 @@ class KilledWorker(Exception):
         )
 
 
-class UnsatisfiedRestrictionsError(Exception):
+class NoSuitableWorkerError(Exception):
     def __init__(
         self,
         task: Key,
@@ -9296,7 +9296,7 @@ class UnsatisfiedRestrictionsError(Exception):
         )
 
 
-class NoWorkersError(Exception):
+class NoWorkerError(Exception):
     def __init__(self, task: Key, timeout: float):
         super().__init__(task, timeout)
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8843,7 +8843,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
 
     def _refresh_no_workers_since(self, timestamp: float | None = None) -> None:
-        if not self.queued or self.running:
+        if self.running or not (self.queued or self.unrunnable):
             self._no_workers_since = None
             return
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8675,10 +8675,11 @@ class Scheduler(SchedulerState, ServerNode):
             )
         )
         self.transitions(recommendations, stimulus_id=stimulus_id)
-        self.log_event(
-            "scheduler",
-            {"action": "tasks-exceeded-no-workers-timeout", "keys": affected},
-        )
+        if affected:
+            self.log_event(
+                "scheduler",
+                {"action": "no-workers-timeout-exceeded", "keys": affected},
+            )
 
     def _check_unrunnable_task_timeouts(
         self, timestamp: float, recommendations: Recs, stimulus_id: str
@@ -8725,7 +8726,7 @@ class Scheduler(SchedulerState, ServerNode):
         self._fail_tasks_after_no_workers_timeout(
             no_workers, recommendations, stimulus_id
         )
-        return {ts.key for ts in concat(unsatisfied, no_workers)}
+        return {ts.key for ts in concat([unsatisfied, no_workers])}
 
     def _check_queued_task_timeouts(
         self, timestamp: float, recommendations: Recs, stimulus_id: str

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8702,7 +8702,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         for ts in unsatisfied:
             e = pickle.dumps(
-                NoSuitableWorkerError(
+                NoValidWorkerError(
                     task=ts.key,
                     host_restrictions=(ts.host_restrictions or set()).copy(),
                     worker_restrictions=(ts.worker_restrictions or set()).copy(),
@@ -9181,7 +9181,7 @@ class KilledWorker(Exception):
         )
 
 
-class NoSuitableWorkerError(Exception):
+class NoValidWorkerError(Exception):
     def __init__(
         self,
         task: Key,
@@ -9217,7 +9217,7 @@ class NoSuitableWorkerError(Exception):
     def __str__(self) -> str:
         return (
             f"Attempted to run task {self.task!r} but timed out after {format_time(self.timeout)} "
-            "waiting for a suitable worker.\n\nRestrictions:\n"
+            "waiting for a valid worker matching all restrictions.\n\nRestrictions:\n"
             "host_restrictions={self.host_restrictions!s}\n"
             "worker_restrictions={self.worker_restrictions!s}\n"
             "resource_restrictions={self.resource_restrictions!s}\n"

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -50,7 +50,7 @@ from distributed.protocol.serialize import ToPickle
 from distributed.scheduler import (
     KilledWorker,
     MemoryState,
-    NoSuitableWorkerError,
+    NoValidWorkerError,
     NoWorkerError,
     Scheduler,
     WorkerState,
@@ -2486,9 +2486,7 @@ async def test_no_workers_timeout_without_workers(c, s):
     s._check_no_workers()
     await asyncio.sleep(0.2)
 
-    with pytest.raises(
-        NoWorkerError if QUEUING_ON_BY_DEFAULT else NoSuitableWorkerError
-    ):
+    with pytest.raises(NoWorkerError if QUEUING_ON_BY_DEFAULT else NoValidWorkerError):
         await future
 
     events = [
@@ -2510,7 +2508,7 @@ async def test_no_workers_timeout_bad_restrictions(c, s, a, b):
     task restrictions
     """
     future = c.submit(inc, 1, key="x", workers=["127.0.0.2:1234"])
-    with pytest.raises(NoSuitableWorkerError):
+    with pytest.raises(NoValidWorkerError):
         await future
 
     events = [
@@ -2567,7 +2565,7 @@ async def test_no_workers_timeout_processing(c, s, a, b):
     s._check_no_workers()
     await asyncio.sleep(0.2)
 
-    with pytest.raises(NoSuitableWorkerError):
+    with pytest.raises(NoValidWorkerError):
         await y
 
     events = [

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -50,9 +50,9 @@ from distributed.protocol.serialize import ToPickle
 from distributed.scheduler import (
     KilledWorker,
     MemoryState,
-    NoWorkersError,
+    NoSuitableWorkerError,
+    NoWorkerError,
     Scheduler,
-    UnsatisfiedRestrictionsError,
     WorkerState,
 )
 from distributed.utils import TimeoutError, wait_for
@@ -2485,7 +2485,7 @@ async def test_no_workers_timeout_without_workers(c, s):
 
     assert s.status == Status.running
     with pytest.raises(
-        NoWorkersError if QUEUING_ON_BY_DEFAULT else UnsatisfiedRestrictionsError
+        NoWorkerError if QUEUING_ON_BY_DEFAULT else NoSuitableWorkerError
     ):
         await future
 
@@ -2500,7 +2500,7 @@ async def test_no_workers_timeout_bad_restrictions(c, s, a, b):
     task restrictions
     """
     future = c.submit(inc, 1, key="x", workers=["127.0.0.2:1234"])
-    with pytest.raises(UnsatisfiedRestrictionsError):
+    with pytest.raises(NoSuitableWorkerError):
         await future
 
 
@@ -2548,7 +2548,7 @@ async def test_no_workers_timeout_processing(c, s, a, b):
 
     await ev.set()
     await x
-    with pytest.raises(UnsatisfiedRestrictionsError):
+    with pytest.raises(NoSuitableWorkerError):
         await y
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2484,7 +2484,9 @@ async def test_no_workers_timeout_without_workers(c, s):
     await asyncio.sleep(0.2)
 
     assert s.status == Status.running
-    with pytest.raises(NoWorkersError):
+    with pytest.raises(
+        NoWorkersError if QUEUING_ON_BY_DEFAULT else UnsatisfiedRestrictionsError
+    ):
         await future
 
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2115,7 +2115,7 @@ async def test_cancel_fire_and_forget(c, s, a, b):
     await ev2.set()
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @gen_cluster(
     client=True, Worker=Nanny, clean_kwargs={"processes": False, "threads": False}
 )
@@ -2468,7 +2468,7 @@ async def test_no_workers_timeout_disabled(c, s):
         await future
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @gen_cluster(
     client=True,
     nthreads=[],
@@ -2488,7 +2488,7 @@ async def test_no_workers_timeout_without_workers(c, s):
         await future
 
 
-# @pytest.mark.slow
+@pytest.mark.slow
 @gen_cluster(
     client=True,
     config={"distributed.scheduler.no-workers-timeout": "100ms"},
@@ -2538,17 +2538,16 @@ async def test_no_workers_timeout_processing(c, s, a, b):
     await wait_for_state("y", "no-worker", s)
 
     # Scheduler won't shut down for as long as f1 is running
-    s._check_no_workers()
+    s._check_no_workers_timeout()
     await asyncio.sleep(0.2)
-    s._check_no_workers()
+    s._check_no_workers_timeout()
     await asyncio.sleep(0.2)
     assert s.status == Status.running
 
     await ev.set()
     await x
-
-    while s.status != Status.closed:
-        await asyncio.sleep(0.01)
+    with pytest.raises(UnsatisfiedRestrictionsError):
+        await y
 
 
 @gen_cluster(client=True, config={"distributed.scheduler.bandwidth": "100 GB"})

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2457,9 +2457,9 @@ async def test_no_workers_timeout_disabled(c, s):
     future = c.submit(inc, 1, key="x")
     await wait_for_state("x", ("queued", "no-worker"), s)
 
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
 
     async with Worker(s.address):
@@ -2481,9 +2481,9 @@ async def test_no_workers_timeout_without_workers(c, s):
     """Trip no-workers-timeout when there are no workers available"""
     future = c.submit(inc, 1, key="x")
     await wait_for_state("x", ("queued", "no-worker"), s)
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
 
     with pytest.raises(
@@ -2534,9 +2534,9 @@ async def test_no_workers_timeout_queued(c, s, a):
     await async_poll_for(lambda: len(s.tasks) == 3 and a.state.tasks, timeout=5)
     assert s.queued or math.isinf(s.WORKER_SATURATION)
 
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
 
     await ev.set()
@@ -2562,9 +2562,9 @@ async def test_no_workers_timeout_processing(c, s, a, b):
     await wait_for_state("y", "no-worker", s)
 
     # Scheduler won't shut down for as long as f1 is running
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
-    s._check_no_workers_timeout()
+    s._check_no_workers()
     await asyncio.sleep(0.2)
 
     with pytest.raises(NoSuitableWorkerError):

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -538,7 +538,7 @@ async def test_pause_executor_manual(c, s, a):
     z = c.submit(inc, 2, key="z")
     while "z" not in s.tasks or s.tasks["z"].state != "no-worker":
         await asyncio.sleep(0.01)
-    assert s.unrunnable == {s.tasks["z"]}
+    assert s.unrunnable.keys() == {s.tasks["z"]}
 
     # Test that a task that already started when the worker paused can complete
     # and its output can be retrieved. Also test that the now free slot won't be
@@ -605,7 +605,7 @@ async def test_pause_executor_with_memory_monitor(c, s, a):
         z = c.submit(inc, 2, key="z")
         while "z" not in s.tasks or s.tasks["z"].state != "no-worker":
             await asyncio.sleep(0.01)
-        assert s.unrunnable == {s.tasks["z"]}
+        assert s.unrunnable.keys() == {s.tasks["z"]}
 
         # Test that a task that already started when the worker paused can complete
         # and its output can be retrieved. Also test that the now free slot won't be


### PR DESCRIPTION
Follow-up to https://github.com/dask/distributed/issues/8126.

Instead of shutting down clusters when the `no-workers-timeout` is exceeded, we fail the affected tasks and return a more meaningful `NoWorkerError` or `NoSuitableWorkerError` to the client. This changes behavior in several ways:

* Users get a meaningful error when their unrunnable tasks time out, they don't just end up with a cluster that shut down _for some reason_.
* Tasks with unsatisfiable restrictions will already be failed _while other tasks are still running_, improving the feedback loop here.
* For cases where no other tasks are running, cluster shutdown will be delayed until the `idle-timeout` kicks in once all unrunnable tasks have been failed. This delays shutdown, but reduces the number of ways a cluster can be shut down, so it should be a net improvement.


Additionally, we log an event whenever tasks fail via the timeout for better observability.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
