### PR TITLE
Ensure that adaptive only stops once

### DIFF
--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -109,8 +109,6 @@ class Adaptive(AdaptiveCore):
 
         self.target_duration = parse_timedelta(target_duration)
 
-        logger.info("Adaptive scaling started: minimum=%s maximum=%s", minimum, maximum)
-
         super().__init__(
             minimum=minimum, maximum=maximum, wait_count=wait_count, interval=interval
         )

--- a/distributed/deploy/adaptive_core.py
+++ b/distributed/deploy/adaptive_core.py
@@ -129,8 +129,8 @@ class AdaptiveCore:
                     await core.adapt()
 
             self.periodic_callback = PeriodicCallback(_adapt, self.interval * 1000)
-            self.loop.add_callback(self._start)
             self._state = "starting"
+            self.loop.add_callback(self._start)
         else:
             self._state = "inactive"
         try:

--- a/distributed/deploy/tests/test_adaptive_core.py
+++ b/distributed/deploy/tests/test_adaptive_core.py
@@ -104,10 +104,12 @@ async def test_adapt_oserror_safe_target():
             raise OSError()
 
     with captured_logger("distributed.deploy.adaptive_core") as log:
-        adapt = BadAdaptive(minimum=1, maximum=4)
-        await adapt.adapt()
+        adapt = BadAdaptive(minimum=1, maximum=4, interval="10ms")
+        while adapt._state != "stopped":
+            await asyncio.sleep(0.01)
     text = log.getvalue()
     assert "Adaptive stopping due to error" in text
+    assert "Adaptive scaling stopped" in text
     assert not adapt._adapting
     assert not adapt.periodic_callback
 

--- a/distributed/deploy/tests/test_adaptive_core.py
+++ b/distributed/deploy/tests/test_adaptive_core.py
@@ -108,7 +108,6 @@ async def test_adapt_oserror_safe_target():
         await adapt.adapt()
     text = log.getvalue()
     assert "Adaptive stopping due to error" in text
-    assert "Adaptive stop" in text
     assert not adapt._adapting
     assert not adapt.periodic_callback
 
@@ -145,6 +144,18 @@ async def test_adapt_oserror_scale():
     assert adapt.periodic_callback
     assert adapt.periodic_callback.is_running()
     adapt.stop()
+
+
+@gen_test()
+async def test_adaptive_logs_stopping_once():
+    with captured_logger("distributed.deploy.adaptive_core") as log:
+        adapt = MyAdaptive(interval="100ms")
+        while not adapt.periodic_callback.is_running():
+            await asyncio.sleep(0.01)
+        adapt.stop()
+        adapt.stop()
+    lines = log.getvalue().splitlines()
+    assert sum("Adaptive scaling stopped" in line for line in lines) == 1
 
 
 @gen_test()


### PR DESCRIPTION
On `main`, Adaptive could get stopped multiple times, issuing an `Adaptive stop` log message each time. This could get confusing if adaptive is replaced because the `stop` logs of the old Adaptive might appear _after_ the `start` log of the new one.

Example

```
2024-07-31 09:13:47,960 - distributed.deploy.adaptive_core - INFO - Adaptive stop
2024-07-31 09:13:47,960 - distributed.deploy.adaptive - INFO - Adaptive scaling started: minimum=5 maximum=990
2024-07-31 09:13:48,460 - distributed.deploy.adaptive_core - INFO - Adaptive stop
```

 This PR avoids that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
