### PR TITLE
Fix exception handling for ``WorkerPlugin.setup`` and ``WorkerPlugin.teardown``

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5410,9 +5410,6 @@ class Client(SyncMethodMixin):
         for response in responses.values():
             if response["status"] == "error":
                 _, exc, tb = clean_exception(**response)
-                # exc = exc.with_traceback(tb)
-                # exc = response["exception"]
-                # tb = response["traceback"]
                 raise exc.with_traceback(tb)
         return responses
 

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5409,8 +5409,10 @@ class Client(SyncMethodMixin):
 
         for response in responses.values():
             if response["status"] == "error":
-                exc = response["exception"]
-                tb = response["traceback"]
+                _, exc, tb = clean_exception(**response)
+                # exc = exc.with_traceback(tb)
+                # exc = response["exception"]
+                # tb = response["traceback"]
                 raise exc.with_traceback(tb)
         return responses
 

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import warnings
 
 import pytest
 
 from distributed import Worker, WorkerPlugin
 from distributed.protocol.pickle import dumps
-from distributed.utils_test import async_poll_for, gen_cluster, inc
+from distributed.utils_test import async_poll_for, captured_logger, gen_cluster, inc
 
 
 class MyPlugin(WorkerPlugin):
@@ -423,3 +424,30 @@ async def test_register_plugin_with_idempotent_keyword_is_deprecated(c, s, a):
         await c.register_plugin(second, idempotent=True)
     assert "idempotentplugin" in a.plugins
     assert a.plugins["idempotentplugin"].instance == "first"
+
+
+class BrokenSetupPlugin(WorkerPlugin):
+    def setup(self, worker):
+        raise RuntimeError("test error")
+
+
+@gen_cluster(client=True, nthreads=[("", 1)])
+async def test_register_plugin_with_broken_setup_to_existing_workers_raises(c, s, a):
+    with pytest.raises(RuntimeError, match="test error"):
+        with captured_logger("distributed.worker", level=logging.ERROR) as caplog:
+            await c.register_plugin(BrokenSetupPlugin(), name="TestPlugin1")
+    logs = caplog.getvalue()
+    assert "TestPlugin1 failed to setup" in logs
+    assert "test error" in logs
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_plugin_with_broken_setup_on_new_worker_logs(c, s):
+    await c.register_plugin(BrokenSetupPlugin(), name="TestPlugin1")
+
+    with captured_logger("distributed.worker", level=logging.ERROR) as caplog:
+        async with Worker(s.address):
+            pass
+    logs = caplog.getvalue()
+    assert "TestPlugin1 failed to setup" in logs
+    assert "test error" in logs

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1225,16 +1225,12 @@ class Worker(BaseWorker, ServerNode):
         self.batched_stream.start(comm)
         self.status = Status.running
 
-        plugins_msgs = await asyncio.gather(
+        await asyncio.gather(
             *(
-                self.plugin_add(name=name, plugin=plugin, catch_errors=False)
+                self.plugin_add(name=name, plugin=plugin)
                 for name, plugin in response["worker-plugins"].items()
             ),
-            return_exceptions=True,
         )
-        plugins_exceptions = [msg for msg in plugins_msgs if isinstance(msg, Exception)]
-        for exc in plugins_exceptions:
-            logger.exception(exc, exc_info=exc)
 
         logger.info("        Registered to: %26s", self.scheduler.address)
         logger.info("-" * 49)
@@ -1898,7 +1894,7 @@ class Worker(BaseWorker, ServerNode):
                 if isawaitable(result):
                     result = await result
         except Exception as e:
-            # logger.exception("Worker plugin %s failed to teardown", name)
+            logger.exception("Worker plugin %s failed to teardown", name)
             return error_message(e)
 
         return {"status": "OK"}

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1560,12 +1560,7 @@ class Worker(BaseWorker, ServerNode):
         # Cancel async instructions
         await BaseWorker.close(self, timeout=timeout)
 
-        teardowns = [
-            plugin.teardown(self)
-            for plugin in self.plugins.values()
-            if hasattr(plugin, "teardown")
-        ]
-        await asyncio.gather(*(td for td in teardowns if isawaitable(td)))
+        await asyncio.gather(*(self.plugin_remove(name) for name in self.plugins))
 
         for extension in self.extensions.values():
             if hasattr(extension, "close"):


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
