### PR TITLE
Fix exception handling for ``NannyPlugin.setup`` and ``NannyPlugin.teardown``

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5409,8 +5409,7 @@ class Client(SyncMethodMixin):
 
         for response in responses.values():
             if response["status"] == "error":
-                exc = response["exception"]
-                tb = response["traceback"]
+                _, exc, tb = clean_exception(**response)
                 raise exc.with_traceback(tb)
         return responses
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -477,13 +477,14 @@ class Nanny(ServerNode):
 
         self.plugins[name] = plugin
 
-        logger.info("Starting Nanny plugin %s" % name)
+        logger.info("Starting Nanny plugin %s", name)
         if hasattr(plugin, "setup"):
             try:
                 result = plugin.setup(nanny=self)
                 if isawaitable(result):
                     result = await result
             except Exception as e:
+                logger.exception("Worker plugin %s failed to setup", name)
                 return error_message(e)
         if getattr(plugin, "restart", False):
             await self.restart(reason=f"nanny-plugin-{name}-restart")


### PR DESCRIPTION
Analogous to #8810 

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
