### PR TITLE
Fix typo in transitions event logging

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2100,7 +2100,7 @@ class SchedulerState:
                     "key": key,
                     "start": start,
                     "finish": finish,
-                    "transistion_log": list(self.transition_log),
+                    "transition_log": list(self.transition_log),
                 },
             )
             if LOG_PDB:


### PR DESCRIPTION
Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
