### PR TITLE
Run graph normalisation after dask order

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4884,6 +4884,7 @@ class Scheduler(SchedulerState, ServerNode):
                 internal_priority = await offload(
                     dask.order.order, dsk=dsk, dependencies=stripped_deps
                 )
+            dsk = valmap(_normalize_task, dsk)
 
             self._create_taskstate_from_graph(
                 dsk=dsk,
@@ -9383,5 +9384,4 @@ def _materialize_graph(
         deps.discard(k)
         dependencies[k] = deps
 
-    dsk = valmap(_normalize_task, dsk)
     return dsk, dependencies, annotations_by_type

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2889,8 +2889,6 @@ def _normalize_task(task: Any) -> T_runspec:
             return task[1], task[2], task[3] if len(task) == 4 else {}
         elif not any(map(_maybe_complex, task[1:])):
             return task[0], task[1:], {}
-    else:
-        return task
 
     return execute_task, (task,), {}
 

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2889,6 +2889,8 @@ def _normalize_task(task: Any) -> T_runspec:
             return task[1], task[2], task[3] if len(task) == 4 else {}
         elif not any(map(_maybe_complex, task[1:])):
             return task[0], task[1:], {}
+    else:
+        return task
 
     return execute_task, (task,), {}
 


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


cc @dcherian 

This adresses the memory pressure in https://github.com/dcherian/dask-demo/blob/main/nwm-climatology-cohorts.ipynb for the "map-reduce" case.

<img width="1447" alt="map-reduce-memory" src="https://github.com/user-attachments/assets/3d3db38f-a83c-443b-bf86-8d94cf5f4236">

No clue how we can test this though, I intend to add the workload to coiled benchmarks so that we have at least some test coverage