### PR TITLE
Ensure client_desires_keys does not corrupt Scheduler state

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -77,7 +77,7 @@ class Actor(WrappedKey):
         if not self._client:
             try:
                 self._client = get_client()
-                self._future = Future(self._key, self._client, inform=False)
+                self._future = Future(self._key, self._client)
                 # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
             except ValueError:
                 self._client = None

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -77,7 +77,7 @@ class Actor(WrappedKey):
         if not self._client:
             try:
                 self._client = get_client()
-                self._future = Future(self._key, inform=False)
+                self._future = Future(self._key, self._client, inform=False)
                 # ^ When running on a worker, only hold a weak reference to the key, otherwise the key could become unreleasable.
             except ValueError:
                 self._client = None

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -163,6 +163,9 @@ class FutureCancelledError(CancelledError):
             result = "\n".join([result, self.msg])
         return result
 
+    def __reduce__(self):
+        return self.__class__, (self.key, self.reason, self.msg)
+
 
 class FuturesCancelledError(CancelledError):
     error_groups: list[CancelledFuturesGroup]

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -670,7 +670,7 @@ class WorkerState:
         )
         ws._occupancy_cache = self.occupancy
 
-        ws.executing = {ts: duration for ts, duration in self.executing.items()}
+        ws.executing = {ts.key: duration for ts, duration in self.executing.items()}  # type: ignore
         return ws
 
     def __repr__(self) -> str:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -670,9 +670,7 @@ class WorkerState:
         )
         ws._occupancy_cache = self.occupancy
 
-        ws.executing = {
-            ts.key: duration for ts, duration in self.executing.items()  # type: ignore
-        }
+        ws.executing = {ts.key: duration for ts, duration in self.executing.items()}
         return ws
 
     def __repr__(self) -> str:
@@ -5595,8 +5593,8 @@ class Scheduler(SchedulerState, ServerNode):
         for k in keys:
             ts = self.tasks.get(k)
             if ts is None:
-                # For publish, queues etc.
-                ts = self.new_task(k, None, "released")
+                warnings.warn(f"Client desires key {k!r} but key is unknown.")
+                continue
             if ts.who_wants is None:
                 ts.who_wants = set()
             ts.who_wants.add(cs)
@@ -9345,7 +9343,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
 def _materialize_graph(
     graph: HighLevelGraph, global_annotations: dict[str, Any], validate: bool
 ) -> tuple[dict[Key, T_runspec], dict[Key, set[Key]], dict[str, dict[Key, Any]]]:
-    dsk = ensure_dict(graph)
+    dsk: dict = ensure_dict(graph)
     if validate:
         for k in dsk:
             validate_key(k)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4632,7 +4632,7 @@ class Scheduler(SchedulerState, ServerNode):
                 ):  # bad key
                     lost_keys.add(k)
                     logger.info("User asked for computation on lost data, %s", k)
-                    del dsk[k]
+                    dsk.pop(k, None)
                     del dependencies[k]
                     if k in keys:
                         keys.remove(k)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -670,7 +670,7 @@ class WorkerState:
         )
         ws._occupancy_cache = self.occupancy
 
-        ws.executing = {ts.key: duration for ts, duration in self.executing.items()}
+        ws.executing = {ts: duration for ts, duration in self.executing.items()}
         return ws
 
     def __repr__(self) -> str:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8441,7 +8441,7 @@ def test_release_persisted_collection_sync(c):
 
 @pytest.mark.slow()
 @pytest.mark.parametrize("do_wait", [True, False])
-def test_persisted_collection_submitted(c, do_wait):
+def test_worker_clients_do_not_claim_ownership_of_serialize_futures(c, do_wait):
     # Note: sending collections like this should be considered an anti-pattern
     # but it is possible. As long as the user ensures the futures stay alive
     # this is fine but the cluster will not take over this responsibility. The

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -102,7 +102,6 @@ from distributed.utils_test import (
     dec,
     div,
     double,
-    ensure_no_new_clients,
     gen_cluster,
     gen_test,
     get_cert,
@@ -2636,27 +2635,36 @@ def test_futures_of_class():
     assert futures_of([da.Array]) == []
 
 
+@pytest.mark.filterwarnings("ignore:.*key is unknown")
 @gen_cluster(client=True)
 async def test_futures_of_cancelled_raises(c, s, a, b):
     x = c.submit(inc, 1)
-    await c.cancel([x])
+    while x.key not in s.tasks:
+        await asyncio.sleep(0.01)
+    await c.cancel([x], reason="testreason")
 
-    with pytest.raises(CancelledError):
+    # Note: The scheduler currently doesn't remember the reason but rather
+    # forgets the task immediately. The reason is currently. only raised if the
+    # client checks on it. Therefore, we expect an unknown reason and definitely
+    # not a scheduler disconnected which would otherwise indicate a bug, e.g. an
+    # AssertionError during transitioning.
+    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
         await x
     while x.key in s.tasks:
         await asyncio.sleep(0.01)
-    with pytest.raises(CancelledError):
+
+    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
         get_obj = c.get({"x": (inc, x), "y": (inc, 2)}, ["x", "y"], sync=False)
         gather_obj = c.gather(get_obj)
         await gather_obj
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
         await c.submit(inc, x)
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
         await c.submit(add, 1, y=x)
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
         await c.gather(c.map(add, [1], y=x))
 
 
@@ -3025,14 +3033,6 @@ async def test_rebalance_unprepared(c, s, a, b):
     # block until all futures are completed before invoking Scheduler.rebalance().
     await c.rebalance(futures)
     s.validate_state()
-
-
-@gen_cluster(client=True, config=NO_AMM)
-async def test_rebalance_raises_on_explicit_missing_data(c, s, a, b):
-    """rebalance() raises KeyError if explicitly listed futures disappear"""
-    f = Future("x", client=c, state="memory")
-    with pytest.raises(KeyError, match="Could not rebalance keys:"):
-        await c.rebalance(futures=[f])
 
 
 @gen_cluster(client=True)
@@ -4139,51 +4139,6 @@ async def test_scatter_compute_store_lose_processing(c, s, a, b):
 
     assert y.status == "cancelled"
     assert z.status == "cancelled"
-
-
-@gen_cluster()
-async def test_serialize_future(s, a, b):
-    async with (
-        Client(s.address, asynchronous=True) as c1,
-        Client(s.address, asynchronous=True) as c2,
-    ):
-        future = c1.submit(lambda: 1)
-        result = await future
-
-        for ci in (c1, c2):
-            with ensure_no_new_clients():
-                with ci.as_current():
-                    future2 = pickle.loads(pickle.dumps(future))
-                    assert future2.client is ci
-                    assert future2.key in ci.futures
-                    result2 = await future2
-                    assert result == result2
-                with temp_default_client(ci):
-                    future2 = pickle.loads(pickle.dumps(future))
-
-
-@gen_cluster()
-async def test_serialize_future_without_client(s, a, b):
-    # Do not use a ctx manager to avoid having this being set as a current and/or default client
-    c1 = await Client(s.address, asynchronous=True, set_as_default=False)
-    try:
-        with ensure_no_new_clients():
-
-            def do_stuff():
-                return 1
-
-            future = c1.submit(do_stuff)
-            pickled = pickle.dumps(future)
-            unpickled_fut = pickle.loads(pickled)
-
-        with pytest.raises(RuntimeError):
-            await unpickled_fut
-
-        with c1.as_current():
-            unpickled_fut_ctx = pickle.loads(pickled)
-            assert await unpickled_fut_ctx == 1
-    finally:
-        await c1.close()
 
 
 @gen_cluster()
@@ -5825,27 +5780,6 @@ async def test_client_with_name(s, a, b):
 
     text = sio.getvalue()
     assert "foo" in text
-
-
-@gen_cluster(client=True)
-async def test_future_defaults_to_default_client(c, s, a, b):
-    x = c.submit(inc, 1)
-    await wait(x)
-
-    future = Future(x.key)
-    assert future.client is c
-
-
-@gen_cluster(client=True)
-async def test_future_auto_inform(c, s, a, b):
-    x = c.submit(inc, 1)
-    await wait(x)
-
-    async with Client(s.address, asynchronous=True) as client:
-        future = Future(x.key, client)
-
-        while future.status != "finished":
-            await asyncio.sleep(0.01)
 
 
 def test_client_async_before_loop_starts(cleanup):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2635,7 +2635,6 @@ def test_futures_of_class():
     assert futures_of([da.Array]) == []
 
 
-@pytest.mark.filterwarnings("ignore:.*key is unknown")
 @gen_cluster(client=True)
 async def test_futures_of_cancelled_raises(c, s, a, b):
     x = c.submit(inc, 1)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8448,7 +8448,7 @@ def test_worker_clients_do_not_claim_ownership_of_serialize_futures(c, do_wait):
     # client will not unpack the collection when using submit and will therefore
     # not handle the dependencies in any way.
     # See also https://github.com/dask/distributed/issues/7498
-    da = pytest.importorskip("dask.array")
+    da = pytest.importorskip("dask.array", exc_type=ImportError)
     x = da.arange(10, chunks=(5,)).persist()
     if do_wait:
         wait(x)

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -332,3 +332,14 @@ async def test_unpickle_without_client(s):
         q3 = pickle.loads(pickled)
         await q3.put(1)
         assert await q3.get() == 1
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_set_cancelled_future(c, s):
+    x = c.submit(inc, 1)
+    await x.cancel()
+    q = Queue("x")
+    # FIXME: This is a TimeoutError but pytest doesn't appear to recognize it as
+    # such
+    with pytest.raises(Exception, match="unknown to scheudler"):
+        await q.put(x, timeout="100ms")

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -32,7 +32,6 @@ from distributed import (
     CancelledError,
     Client,
     Event,
-    Future,
     Lock,
     Nanny,
     SchedulerPlugin,
@@ -4849,25 +4848,6 @@ async def test_tell_workers_when_peers_have_left(c, s, a, b):
         g = await c.submit(inc, f, key="g", workers=[w3.address])
         # fails over to the second worker in less than the connect timeout
         assert time() < start + connect_timeout
-
-
-@gen_cluster(client=True)
-async def test_client_desires_keys_creates_ts(c, s, a, b):
-    """A TaskState object is created by client_desires_keys, and
-    is only later submitted with submit/compute by a different client
-
-    See also
-    --------
-    test_scheduler.py::test_scatter_creates_ts
-    test_spans.py::test_client_desires_keys_creates_ts
-    """
-    x = Future(key="x")
-    await wait_for_state("x", "released", s)
-    assert s.tasks["x"].run_spec is None
-    async with Client(s.address, asynchronous=True) as c2:
-        c2.submit(inc, 1, key="x")
-        assert await x == 2
-    assert s.tasks["x"].run_spec is not None
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -8,7 +8,7 @@ import dask
 from dask import delayed
 
 import distributed
-from distributed import Client, Event, Future, Worker, span, wait
+from distributed import Client, Event, Worker, span, wait
 from distributed.diagnostics.plugin import SchedulerPlugin
 from distributed.utils_test import (
     NoSchedulerDelayWorker,
@@ -387,54 +387,12 @@ def test_no_tags():
 
 
 @gen_cluster(client=True)
-async def test_client_desires_keys_creates_ts(c, s, a, b):
-    """A TaskState object is created by client_desires_keys, and
-    is only later submitted with submit/compute by a different client
-
-    See also
-    --------
-    test_scheduler.py::test_client_desires_keys_creates_ts
-    test_spans.py::test_client_desires_keys_creates_tg
-    test_spans.py::test_scatter_creates_ts
-    test_spans.py::test_scatter_creates_tg
-    """
-    x = Future(key="x")
-    await wait_for_state("x", "released", s)
-    assert s.tasks["x"].group.span_id is None
-    async with Client(s.address, asynchronous=True) as c2:
-        c2.submit(inc, 1, key="x")
-        assert await x == 2
-    assert s.tasks["x"].group.span_id is not None
-
-
-@gen_cluster(client=True)
-async def test_client_desires_keys_creates_tg(c, s, a, b):
-    """A TaskGroup object is created by client_desires_keys, and
-    only later gains runnable tasks
-
-    See also
-    --------
-    test_spans.py::test_client_desires_keys_creates_ts
-    test_spans.py::test_scatter_creates_ts
-    test_spans.py::test_scatter_creates_tg
-    """
-    x0 = Future(key="x-0")
-    await wait_for_state("x-0", "released", s)
-    assert s.tasks["x-0"].group.span_id is None
-    x1 = c.submit(inc, 1, key="x-1")
-    assert await x1 == 2
-    assert s.tasks["x-0"].group.span_id is not None
-
-
-@gen_cluster(client=True)
 async def test_scatter_creates_ts(c, s, a, b):
     """A TaskState object is created by scatter, and only later becomes runnable
 
     See also
     --------
     test_scheduler.py::test_scatter_creates_ts
-    test_spans.py::test_client_desires_keys_creates_ts
-    test_spans.py::test_client_desires_keys_creates_tg
     test_spans.py::test_scatter_creates_tg
     """
     x1 = (await c.scatter({"x": 1}, workers=[a.address]))["x"]
@@ -454,8 +412,6 @@ async def test_scatter_creates_tg(c, s, a, b):
 
     See also
     --------
-    test_spans.py::test_client_desires_keys_creates_ts
-    test_spans.py::test_client_desires_keys_creates_tg
     test_spans.py::test_scatter_creates_ts
     """
     x0 = (await c.scatter({"x-0": 1}))["x-0"]

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -325,3 +325,12 @@ async def test_unpickle_without_client(s):
         obj3 = pickle.loads(pickled)
         await obj3.set(42)
         assert await obj3.get() == 42
+
+
+@gen_cluster(client=True, nthreads=[])
+async def test_set_cancelled_future(c, s):
+    x = c.submit(inc, 1)
+    await x.cancel()
+    v = Variable("x")
+    with pytest.raises(TimeoutError):
+        await v.set(x, timeout="5ms")

--- a/distributed/variable.py
+++ b/distributed/variable.py
@@ -218,7 +218,7 @@ class Variable:
             timeout=timeout, name=self.name, client=self.client.id
         )
         if d["type"] == "Future":
-            value = Future(d["value"], self.client, inform=False, state=d["state"])
+            value = Future(d["value"], self.client, state=d["state"])
             if d["state"] == "erred":
                 value._state.set_error(d["exception"], d["traceback"])
             self.client._send_to_scheduler(


### PR DESCRIPTION
I ran into this over in https://github.com/dask/dask/pull/11248 where I was somehow triggering this condition in a very different way.

The test `test_futures_of_cancelled_raises` is actually broken on main. It is indeed raising a CancelledError but not for the reason we'd like it to. What happens under the hood is that this behavior is triggering an AssertionError during transitioning which will close the network connection to the scheduler and raises a `FutureCancelledError` but not a "This task has been cancelled" `CancelledError` 🙄 

The reason for this is that `client_desires_keys` instantiates a new TaskState object if the key is unknown. This is a pretty breaking behavior in general but so far has been required to make Variable, Queue, etc. work the way they do. Variables and the like are communicating via an unordered RPC to the scheduler causing the key often to not be registered yet and this premature initialization just worked because typically the state corruption would only last for a brief moment.

However, the case that cannot be corrected easily (and something I'd like to fix but is more work than I currently care to invest) is that `Future` objects are _inform_ing the scheduler about their existence whenever they are instantiated. This is important to allow the submission of persisted collections (e.g. used by publish/get_dataset) or when storing/recovering stored futures in a variable.
This mechanism is _typically_ disabled on ordinary clusters because there is no client in the context of the scheduler. However, when running in async mode, the async test client is shared with the scheduler and therefore the future in the scheduler context is also calling `client_desires_keys` even though it was already released...

Alas, this is only a small patch but it should make things more reliable. Eventually this should be cleaned up...


closes https://github.com/dask/distributed/issues/7498