### PR TITLE
Bump minimum ``cloudpickle`` to 3

### DIFF
--- a/continuous_integration/environment-mindeps.yaml
+++ b/continuous_integration/environment-mindeps.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - click=8.0
-  - cloudpickle=2.0.0
+  - cloudpickle=3.0.0
   - cytoolz=0.11.2
   - jinja2=2.10.3
   - locket=1.0.0

--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -32,7 +32,7 @@ requirements:
   run:
     - python >=3.10
     - click >=8.0
-    - cloudpickle >=2.0.0
+    - cloudpickle >=3.0.0
     - cytoolz >=0.11.2
     - {{ pin_compatible('dask-core', max_pin='x.x.x.x') }}
     - jinja2 >=2.10.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ readme = "README.rst"
 requires-python = ">=3.10"
 dependencies = [
     "click >= 8.0",
-    "cloudpickle >= 2.0.0",
+    "cloudpickle >= 3.0.0",
     "dask == 2024.8.0",
     "jinja2 >= 2.10.3",
     "locket >= 1.0.0",


### PR DESCRIPTION
https://github.com/dask/dask/pull/11320 bumped our `cloudpickle` version constraint to be `cloudpickle >= 3.0.0`. Given `distributed` pins tightly to `dask`, we transitively will always pull in  `cloudpickle >= 3.0.0` anyways. This PR just formally bumps the pinning in `distributed` to match that in `dask`. Not a functional change, just housekeeping. 