### PR TITLE
Increase visibility of GPU CI updates

### DIFF
--- a/.github/workflows/update-gpuci.yaml
+++ b/.github/workflows/update-gpuci.yaml
@@ -58,7 +58,7 @@ jobs:
         if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER }}  # make sure new ucx-py nightlies are available
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+          draft: false
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
           title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_RAPIDS_VER }}`"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,4 @@ distributed/widgets/*  @jacobtomlinson
 
 # GPU Support
 distributed/diagnostics/nvml.py  @jacobtomlinson @quasiben
+continuous_integration/gpuci/*  @jacobtomlinson @quasiben


### PR DESCRIPTION
In the interest of increasing visibility on PRs updating the version of RAPIDS used in GPU CI (e.g. #8786), this PR:

- sets the auto-generated GPU CI update PRs to open as ready for review
- updates the CODEOWNERS file to ping GPU codeowners on changes to `continuous_integration/gpuci/*`

cc @rjzamora
