### PR TITLE
Avoid capturing code of xdist

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -290,6 +290,8 @@ distributed:
         - xarray
         - xgboost
         - xdist
+        - __channelexec__  # more xdist
+        - execnet  # more xdist
       ignore-files:
         - runpy\.py  # `python -m pytest` (or other module) shell command
         - pytest  # `pytest` shell command


### PR DESCRIPTION
We don't have automated tests for this but this can be verified by running

`pytest distributed/tests/test_client.py::test_computation_object_code_dask_compute -s -n1`