### PR TITLE
Ensure restarts for workers without nanny dont run into timeout

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1238,16 +1238,14 @@ async def test_restart_no_wait_for_workers(c, s, a, b):
     await b.finished()
 
 
-@pytest.mark.slow
 @gen_cluster(client=True, Worker=Nanny)
 async def test_restart_some_nannies_some_not(c, s, a, b):
     original_addrs = set(s.workers)
     async with Worker(s.address, nthreads=1) as w:
         await c.wait_for_workers(3)
 
-        # FIXME how to make this not always take 20s if the nannies do restart quickly?
         with pytest.raises(TimeoutError, match=r"The 1 worker\(s\) not using Nannies"):
-            await c.restart(timeout="20s")
+            await c.restart()
 
         assert w.status == Status.closed
 


### PR DESCRIPTION
Was running into test runtimes. This one is written in a way that guaranteed a runtime of more than 20s. It _should_ be easily fixed... let's see what CI says