### PR TITLE
Speed up ``Client.map`` by computing ``token`` only once for ``func`` and ``kwargs``

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -876,8 +876,9 @@ class _MapLayer(Layer):
 
             else:
                 if self.pure:
+                    tok = tokenize(self.func, self.kwargs)
                     keys = [
-                        self.key + "-" + tokenize(self.func, self.kwargs, args)  # type: ignore
+                        self.key + "-" + tokenize(tok, args)  # type: ignore
                         for args in zip(*self.iterables)
                     ]
                 else:


### PR DESCRIPTION
tokenization is unfortunately expensive at times. Especially if we're iterating over a large collection this can be expensive.

Note: The tokenize(tok, args) is also expensive but mostly because of the ctxmanager foo we're doing in tokenize so calling it often is expensive. We should think about a fast path for this