### PR TITLE
Point to user code with ``idempotent`` plugin warning

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5084,6 +5084,7 @@ class Client(SyncMethodMixin):
                 "future version. Please mark your plugin as idempotent by setting its "
                 "`.idempotent` attribute to `True`.",
                 FutureWarning,
+                stacklevel=2,
             )
         else:
             idempotent = getattr(plugin, "idempotent", False)


### PR DESCRIPTION
I was just trying to find where a plugin that was using the old-style ``idempotent`` was and found this helpful 