### PR TITLE
Bump ``bokeh`` minimum version to 3.1.0

### DIFF
--- a/continuous_integration/recipes/dask/meta.yaml
+++ b/continuous_integration/recipes/dask/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - lz4 >=4.3.2
     - numpy >=1.21
     - pandas >=2
-    - bokeh >=2.4.2,!=3.0.*
+    - bokeh >=3.1.0
     - jinja2 >=2.10.3
     - pyarrow >=7.0
 

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -38,6 +38,7 @@ from bokeh.models import (
     Range1d,
     ResetTool,
     Select,
+    TabPanel,
     Tabs,
     TapTool,
     Title,
@@ -73,10 +74,8 @@ from distributed.dashboard.components.shared import (
     ProfileTimePlot,
     SystemMonitor,
 )
-from distributed.dashboard.core import TabPanel
 from distributed.dashboard.utils import (
     _DATATABLE_STYLESHEETS_KWARGS,
-    BOKEH_VERSION,
     PROFILING,
     transpose,
     update,
@@ -2271,18 +2270,8 @@ class TaskGraph(DashboardComponent):
         self.edge_source = ColumnDataSource({"x": [], "y": [], "visible": []})
 
         filter = GroupFilter(column_name="visible", group="True")
-        if BOKEH_VERSION.major < 3:
-            filter_kwargs = {"filters": [filter]}
-        else:
-            filter_kwargs = {"filter": filter}
-        node_view = CDSView(**filter_kwargs)
-        edge_view = CDSView(**filter_kwargs)
-
-        # Bokeh >= 3.0 automatically infers the source to use
-        if BOKEH_VERSION.major < 3:
-            node_view.source = self.node_source
-            edge_view.source = self.edge_source
-
+        node_view = CDSView(filter=filter)
+        edge_view = CDSView(filter=filter)
         node_colors = factor_cmap(
             "state",
             factors=["waiting", "queued", "processing", "memory", "released", "erred"],
@@ -4515,10 +4504,6 @@ _STYLES = {
     "box-shadow": "inset 1px 0 8px 0 lightgray",
     "overflow": "auto",
 }
-if BOKEH_VERSION.major < 3:
-    _BOKEH_STYLES_KWARGS = {"style": _STYLES}
-else:
-    _BOKEH_STYLES_KWARGS = {"styles": _STYLES}
 
 
 class SchedulerLogs:
@@ -4538,7 +4523,7 @@ class SchedulerLogs:
                 )
             )._repr_html_()
 
-        self.root = Div(text=logs_html, **_BOKEH_STYLES_KWARGS)
+        self.root = Div(text=logs_html, styles=_STYLES)
 
 
 @log_errors

--- a/distributed/dashboard/core.py
+++ b/distributed/dashboard/core.py
@@ -26,12 +26,6 @@ if not BOKEH_REQUIREMENT.specifier.contains(BOKEH_VERSION, prereleases=True):
     )
 
 
-if BOKEH_VERSION.major < 3:
-    from bokeh.models import Panel as TabPanel  # noqa: F401
-else:
-    from bokeh.models import TabPanel  # noqa: F401
-
-
 if BOKEH_VERSION < parse_version("3.3.0"):
     from bokeh.server.server import BokehTornado as DaskBokehTornado
 else:

--- a/distributed/dashboard/utils.py
+++ b/distributed/dashboard/utils.py
@@ -18,18 +18,15 @@ BOKEH_VERSION = Version(bokeh.__version__)
 
 PROFILING = False
 
-if BOKEH_VERSION.major < 3:
-    _DATATABLE_STYLESHEETS_KWARGS = {}
-else:
-    _DATATABLE_STYLESHEETS_KWARGS = {
-        "stylesheets": [
-            """
-    .bk-data-table {
-    z-index: 0;
-    }
-    """
-        ]
-    }
+_DATATABLE_STYLESHEETS_KWARGS = {
+    "stylesheets": [
+        """
+.bk-data-table {
+z-index: 0;
+}
+"""
+    ]
+}
 
 
 def transpose(lod):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8421,17 +8421,13 @@ class Scheduler(SchedulerState, ServerNode):
         sysmon.update()
 
         # Scheduler logs
-        from distributed.dashboard.components.scheduler import (
-            _BOKEH_STYLES_KWARGS,
-            SchedulerLogs,
-        )
+        from distributed.dashboard.components.scheduler import _STYLES, SchedulerLogs
 
         logs = SchedulerLogs(self, start=start)
 
-        from bokeh.models import Div, Tabs
+        from bokeh.models import Div, TabPanel, Tabs
 
         import distributed
-        from distributed.dashboard.core import TabPanel
 
         # HTML
         html = """
@@ -8472,7 +8468,7 @@ class Scheduler(SchedulerState, ServerNode):
             dask_version=dask.__version__,
             distributed_version=distributed.__version__,
         )
-        html = Div(text=html, **_BOKEH_STYLES_KWARGS)
+        html = Div(text=html, styles=_STYLES)
 
         html = TabPanel(child=html, title="Summary")
         compute = TabPanel(child=compute, title="Worker Profile (compute)")

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from packaging.requirements import Requirement
 
-BOKEH_REQUIREMENT = Requirement("bokeh>=2.4.2,!=3.0.*")
+BOKEH_REQUIREMENT = Requirement("bokeh>=3.1.0")
 
 required_packages = [
     ("dask", lambda p: p.__version__),


### PR DESCRIPTION
@hendrikmakait ran into a case where using an older version of `bokeh` with a newer version of `numpy` (specifically `numpy` 2) resulting in a hard-to-diagnose issue on the scheduler. This PR proposes we bump our minimum supported version of `bokeh` to `bokeh>=3.1.0`, which has been out for a while anyways (since March 10, 2023). 