### PR TITLE
Allow exceptions that fail pickle deserialisation to be easily identified downstream.

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -1690,6 +1690,10 @@ def error_message(e: BaseException, status: str = "error") -> ErrorMessage:
     }
 
 
+class UnreadablePickledException(Exception):
+    pass
+
+
 def clean_exception(
     exception: BaseException | bytes | bytearray | str | None,
     traceback: types.TracebackType | bytes | str | None = None,
@@ -1707,7 +1711,7 @@ def clean_exception(
         try:
             exception = protocol.pickle.loads(exception)
         except Exception:
-            exception = Exception(exception)
+            exception = UnreadablePickledException(exception)
     elif isinstance(exception, str):
         exception = Exception(exception)
 

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -25,6 +25,7 @@ from distributed.core import (
     RPCClosed,
     Server,
     Status,
+    UnreadablePickledException,
     _expects_comm,
     clean_exception,
     coerce_to_address,
@@ -1357,3 +1358,13 @@ async def test_large_payload(caplog):
 
         assert response["result"] == data
         await comm.close()
+
+
+@gen_test()
+async def test_unreadable_pickled_exceptions_kept():
+    pickled_ex = b"\x80\x04\x954\x00\x00\x00\x00\x00\x00\x00\x8c\x08__main__\x94\x8c\x14SomeUnknownException\x94\x93\x94\x8c\x08some arg\x94\x85\x94R\x94."
+    ex_type, ex, tb = clean_exception(pickled_ex)
+    assert ex_type == UnreadablePickledException
+    assert isinstance(ex, UnreadablePickledException)
+    assert ex.args[0] == pickled_ex
+    assert tb is None


### PR DESCRIPTION
Something we see quite a lot in our production dask (Coiled-powered) setup is exceptions failing to be deserialised when sent from the cluster to the client. This is usually due to either version mismatch or code being present within the cluster software environment that is not there on the client. Obviously this is not an ideal situation and one we're working to resolve.

However, the below change should make it easier to handle this situation in the meantime, as it makes such errors obvious (and able to be easily caught and handled, e.g. by adding a sensible user-facing message) rather than having to catch `Exception` and fish about for if the first argument is a bytestring that looks like a pickled object.

I think this change should be compatible with any existing code that is attempting to do the above. If a breaking change were possible, would be nicer to add a "Unreadable pickled exception received" message to UnreadablePickledException and attach the actual pickled output as a separate field.

Closes #xxxx

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

(I hope all the tests will pass on CI, seeing failures locally but I think that's due to not having working IPv6.)
