### PR TITLE
Avoid spurious error log in Adaptive

### DIFF
--- a/distributed/deploy/adaptive.py
+++ b/distributed/deploy/adaptive.py
@@ -133,6 +133,8 @@ class Adaptive(AdaptiveCore):
                 str, dask.config.get("distributed.adaptive.target-duration")
             )
 
+        super().__init__(minimum=minimum, maximum=maximum, wait_count=wait_count)
+
         self.interval = parse_timedelta(interval, "seconds")
         self.periodic_callback = None
 
@@ -162,8 +164,6 @@ class Adaptive(AdaptiveCore):
             self.state = "inactive"
 
         self.target_duration = parse_timedelta(target_duration)
-
-        super().__init__(minimum=minimum, maximum=maximum, wait_count=wait_count)
 
     def _start(self) -> None:
         if self.state != "starting":


### PR DESCRIPTION
Due to a timing issue in a synchronous environment, it was possible for Adaptive to log an error (while staying functional) during its startup:

```python
import time
from distributed import LocalCluster

if __name__ == "__main__":
    cluster = LocalCluster()
    for _ in range(100):
        cluster.adapt(minimum=1, maximum=2)
        time.sleep(1)
```

logs

```
2024-10-09 07:25:24,947 - tornado.application - ERROR - Exception in callback functools.partial(<bound method Adaptive._start of <distributed.deploy.adaptive.Adaptive object at 0x14e4d56d0>>)
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/mambaforge/base/envs/dask-distributed/lib/python3.11/site-packages/tornado/ioloop.py", line 750, in _run_callback
    ret = callback()
          ^^^^^^^^^^
  File "/Users/hendrikmakait/projects/dask/distributed/distributed/deploy/adaptive.py", line 177, in _start
    self.minimum,
    ^^^^^^^^^^^^
AttributeError: 'Adaptive' object has no attribute 'minimum'
```

This PR fixes that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
