### PR TITLE
Raise explicit pickle errors when `distributed.pickle.{loads|dumps}` fails

### DIFF
--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -75,9 +75,9 @@ def dumps(x, *, buffer_callback=None, protocol=HIGHEST_PROTOCOL):
         try:
             buffers.clear()
             result = cloudpickle.dumps(x, **dump_kwargs)
-        except Exception:
+        except Exception as e:
             logger.exception("Failed to serialize %s.", x)
-            raise
+            raise pickle.PicklingError("Failed to serialize") from e
     if buffer_callback is not None:
         for b in buffers:
             buffer_callback(b)
@@ -90,6 +90,6 @@ def loads(x, *, buffers=()):
             return pickle.loads(x, buffers=buffers)
         else:
             return pickle.loads(x)
-    except Exception:
+    except Exception as e:
         logger.info("Failed to deserialize %s", x[:10000], exc_info=True)
-        raise
+        raise pickle.UnpicklingError("Failed to deserialize") from e


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
