### PR TITLE
Explicitly list setuptools as a build dependency in conda recipe

### DIFF
--- a/continuous_integration/recipes/distributed/meta.yaml
+++ b/continuous_integration/recipes/distributed/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - pip
     - dask-core {{ dask_version }}
     - versioneer =0.29
+    - setuptools >=62.6
     - tomli # [py<311]
   run:
     - python >=3.10


### PR DESCRIPTION
With Python 3.13, `setuptools` has been removed as a default dependency of `pip` on conda-forge, with the encouraged advice to explicitly list this dependency in the build/host section:

https://conda-forge.org/news/2024/08/21/sunsetting-pip-deps/