### PR TITLE
Fix url escaping on exceptions dashboard for non-string keys

### DIFF
--- a/distributed/http/templates/exceptions.html
+++ b/distributed/http/templates/exceptions.html
@@ -26,7 +26,7 @@
         <div style="display: inline-block;">
             <p>
                 <span>Task:</span>
-                <code> <a href="../task/{{ url_escape(ts.key) }}.html">{{ts.key}}</a> </code>
+                <code> <a href="../task/{{ url_escape(str(ts.key)) }}.html">{{ts.key}}</a> </code>
             </p>
             <div>
                 <span>Worker(s):</span>


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
