### PR TITLE
Raise helpful error when using the wrong plugin base classes

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5106,8 +5106,8 @@ class Client(SyncMethodMixin):
             for c in plugin.__class__.__bases__
         ):
             raise TypeError(
-                "Importing plugin base classes from `from dask.distributed.diagnostics.plugin` "
-                "is not supported. Please import directly from `distributed.diagnostics.plugin` instead."
+                "Importing plugin base classes from `dask.distributed.diagnostics.plugin` is not supported. "
+                "Please import directly from `distributed.diagnostics.plugin` instead."
             )
         raise TypeError(
             "Registering duck-typed plugins is not allowed. Please inherit from "

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5101,6 +5101,14 @@ class Client(SyncMethodMixin):
     ):
         if isinstance(plugin, type):
             raise TypeError("Please provide an instance of a plugin, not a type.")
+        if any(
+            "dask.distributed.diagnostics.plugin" in str(c)
+            for c in plugin.__class__.__bases__
+        ):
+            raise TypeError(
+                "Importing plugin base classes from `from dask.distributed.diagnostics.plugin` "
+                "is not supported. Please import directly from `distributed.diagnostics.plugin` instead."
+            )
         raise TypeError(
             "Registering duck-typed plugins is not allowed. Please inherit from "
             "NannyPlugin, WorkerPlugin, or SchedulerPlugin to create a plugin."


### PR DESCRIPTION
The `Client.register_plugin()` method uses `@functools.singledispatchmethod` to dispatch to the correct plugin registration method. However `singledispatchmethod` doesn't like the `dask.distributed` import shim and can't determine that `dask.distributed.diagnostics.plugins.WorkerPlugin` is the same as `distributed.diagnostics.plugins.WorkerPlugin`.

This means that plugins based on classes like `dask.distributed.diagnostics.plugins.WorkerPlugin` raise the `TypeError("Registering duck-typed plugins is not allowed. Please inherit from NannyPlugin, WorkerPlugin, or SchedulerPlugin to create a plugin.")` exception.

I explored importing the base classes from the `dask.distributed` path and registering those for dispatch too, but it's not possible to import them from `dask.distributed.diagnostics.plugins` while `distributed` is being imported. And it's not possible to register them at runtime, only at import time.

Therefore the best option here appears to be to improve the error message. So this PR checks for plugins based on classes from `dask.distributed.diagnostics.plugins` and makes the error message more helpful.

```python
In [1]: from dask.distributed.diagnostics.plugin import WorkerPlugin
   ...: import dask.distributed as dd
   ...: 
   ...: class PolitePlugin(WorkerPlugin):
   ...:     def setup(self, worker):
   ...:         print("hi", worker)
   ...:         self.worker = worker
   ...: 
   ...:     def teardown(self, worker):
   ...:         print("bye", worker)
   ...: 
   ...: cluster = dd.LocalCluster()
   ...: client = dd.Client(cluster)
   ...: client.register_plugin(PolitePlugin())
---------------------------------------------------------------------------
TypeError: Importing plugin base classes from `from dask.distributed.diagnostics.plugin` is not supported. Import directly from `distributed.diagnostics.plugin` instead.
```

Closes #8778

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
