### PR TITLE
Add retry to shuffle broadcast

### DIFF
--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -113,8 +113,8 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
                 if isinstance(r, OSError):
                     workers.append(w)
                 else:
-                    raise P2PConsistencyError(
-                        "Unexpected error encountered during barrier"
+                    raise RuntimeError(
+                        f"Unexpected error encountered during P2P barrier: {r!r}"
                     )
             workers = [w for w, r in res.items() if r is not None]
             if workers:

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -123,17 +123,19 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
                     shuffle.id,
                 )
                 if any(w not in self.scheduler.workers for w in workers):
-                    raise P2PConsistencyError(
+                    raise RuntimeError(
                         f"Worker {workers} left during shuffle {shuffle}"
                     )
                 await asyncio.sleep(0.1)
                 if len(workers) == before:
                     no_progress += 1
                     if no_progress >= 3:
-                        raise P2PConsistencyError(
+                        raise RuntimeError(
                             f"""Broadcast not making progress for {shuffle}.
                             Aborting. This is possibly due to overloaded
-                            workers. Increasing tcp.connect timeout may help."""
+                            workers. Increasing config
+                            `distributed.comm.timeouts.connect` timeout may
+                            help."""
                         )
 
     def restrict_task(

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -21,6 +21,7 @@ from tornado.ioloop import IOLoop
 import dask
 from dask.utils import key_split
 
+from distributed.comm.core import Comm
 from distributed.shuffle._core import ShuffleId, ShuffleRun, barrier_key
 from distributed.shuffle._disk import DiskShardsBuffer
 from distributed.worker import Status
@@ -3026,3 +3027,60 @@ async def test_workers_do_not_spam_get_requests(c, s, a, b):
     await assert_worker_cleanup(a)
     await assert_worker_cleanup(b)
     await assert_scheduler_cleanup(s)
+
+
+class BarrierInputsDoneOSErrorPlugin(ShuffleWorkerPlugin):
+    def __init__(
+        self,
+        failures: dict[str, tuple[int, type]] | None = None,
+    ):
+        self.failures = failures or {}
+        super().__init__()
+
+    async def shuffle_inputs_done(self, comm: Comm, *args: Any, **kwargs: Any) -> None:  # type: ignore
+        if self.worker.address in self.failures:
+            nfailures, exc_type = self.failures[self.worker.address]
+            if nfailures > 0:
+                nfailures -= 1
+                self.failures[self.worker.address] = nfailures, exc_type
+                if issubclass(exc_type, OSError):
+                    # Aborting the Comm object triggers a different path in
+                    # error handling that resembles a genuine connection failure
+                    # like a timeout while an exception that is being raised by
+                    # the handler will be serialized and sent to the scheduler
+                    comm.abort()
+                raise exc_type  # type: ignore
+        return await super().shuffle_inputs_done(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "failures, expected_exc",
+    [
+        ({}, None),
+        ({0: (1, OSError)}, None),
+        ({0: (1, RuntimeError)}, P2PConsistencyError),
+        ({0: (1, OSError), 1: (1, OSError)}, None),
+        ({0: (1, OSError), 1: (1, RuntimeError)}, P2PConsistencyError),
+        ({0: (5, OSError)}, P2PConsistencyError),
+        ({0: (5, OSError), 1: (1, OSError)}, P2PConsistencyError),
+    ],
+)
+@gen_cluster(client=True)
+async def test_flaky_broadcast(c, s, a, b, failures, expected_exc):
+    names_to_address = {w.name: w.address for w in [a, b]}
+    failures = {names_to_address[name]: failures for name, failures in failures.items()}
+    plugin = BarrierInputsDoneOSErrorPlugin(failures)
+    await c.register_plugin(plugin, name="shuffle")
+
+    if expected_exc:
+        ctx = pytest.raises(expected_exc)
+    else:
+        ctx = contextlib.nullcontext()
+    pdf = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    ddf = dd.from_pandas(pdf, npartitions=2)
+    with dask.config.set({"dataframe.shuffle.method": "p2p"}):
+        shuffled = ddf.shuffle("x")
+
+    res = c.compute(shuffled)
+    with ctx:
+        await c.gather(res)

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -3065,6 +3065,7 @@ class BarrierInputsDoneOSErrorPlugin(ShuffleWorkerPlugin):
         ({0: (5, OSError), 1: (1, OSError)}, P2PConsistencyError),
     ],
 )
+@pytest.mark.slow
 @gen_cluster(client=True)
 async def test_flaky_broadcast(c, s, a, b, failures, expected_exc):
     names_to_address = {w.name: w.address for w in [a, b]}

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -3058,11 +3058,11 @@ class BarrierInputsDoneOSErrorPlugin(ShuffleWorkerPlugin):
     [
         ({}, None),
         ({0: (1, OSError)}, None),
-        ({0: (1, RuntimeError)}, P2PConsistencyError),
+        ({0: (1, RuntimeError)}, RuntimeError),
         ({0: (1, OSError), 1: (1, OSError)}, None),
-        ({0: (1, OSError), 1: (1, RuntimeError)}, P2PConsistencyError),
-        ({0: (5, OSError)}, P2PConsistencyError),
-        ({0: (5, OSError), 1: (1, OSError)}, P2PConsistencyError),
+        ({0: (1, OSError), 1: (1, RuntimeError)}, RuntimeError),
+        ({0: (5, OSError)}, RuntimeError),
+        ({0: (5, OSError), 1: (1, OSError)}, RuntimeError),
     ],
 )
 @pytest.mark.slow


### PR DESCRIPTION
One of our P2P stress tests is failing pretty regularly `distributed.tests.test_stress.test_close_connections`

![image](https://github.com/user-attachments/assets/b93c0edb-76ee-4543-96b1-196504aab25a)

This failure is somewhat expected because the broadcast is connecting to all workers and the connection attempts may time out if the workers are too busy.

This is not an ideal fix (instead, removing broadcast would be terrific).

I opted to not implement a retry in broadcast itself since this would've more serious implications and the broadcast API provides everything for users to implement this themselves

I'm still missing a test but confirmed this with some manual patches. @hendrikmakait if you have an idea on how to put together an easy test this would be helpful