### PR TITLE
Remove dispatching in TaskCollection

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1492,13 +1492,11 @@ class TaskState:
         # function dispatch is adding notable overhead and this setter is called
         # *very* often
         gr_st = self.group.states
-        self.group._size += 1
         gr_st[self._state] -= 1
         gr_st[value] += 1
         pf = self.prefix
         pf.states[self._state] -= 1
         pf.states[value] += 1
-        pf._size += 1
         pf.state_counts[value] += 1
         self._state = value
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -981,10 +981,6 @@ class TaskCollection:
         """The result types of this collection"""
         return self._types.keys()
 
-    @staticmethod
-    def _calculate_duration_us(start: float, stop: float) -> int:
-        return max(round((stop - start) * 1e6), 0)
-
     def __len__(self) -> int:
         return sum(self.states.values())
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -948,6 +948,8 @@ class TaskCollection:
 
     _duration_us: int
 
+    _size: int
+
     _types: defaultdict[str, int]
 
     __slots__ = tuple(__annotations__)

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -1036,7 +1036,7 @@ class TaskPrefix(TaskCollection):
         self._duration_us += duration_us
         self._all_durations_us[action] += duration_us
 
-        duration_s = max(round((stop - start) * 1e6), 0) / 1e6
+        duration_s = duration_us / 1e6
         if action == "compute":
             old = self.duration_average
             if old < 0:


### PR DESCRIPTION
We refactored the TaskState a while back such that TaskPrefix, TaskGroup classes are subclasses and use similar interfaces to update their internal state. See https://github.com/dask/distributed/pull/8681 and linked ticket for context.

For large graphs (see below pyspy profile of the highlevel climatology workload of the coiled geo benchmarks) this class structure is adding notable overhead.

[scheduler.zip](https://github.com/user-attachments/files/17488588/scheduler.zip)

This screen shows _one_ of many of the papercuts we're dealing with here

(This is a left heavy view of a client_releases_keys of about 1M tasks)

![image](https://github.com/user-attachments/assets/d5163c44-a4a3-408d-90e3-775bd120f05b)

The state update/transition and other related state udpates are popping up all over the place. Tiny papercuts that add up over time. I haven't done a measurement how this will play out end to end. Likely not a huge deal but small things add up for those hot paths.

<details>
<summary>Micro benchmarks</summary>

```python
all_states = [
    "released",
    "waiting",
    "no-worker",
    "queued",
    "processing",
    "memory",
    "erred",
    "forgotten",
]

class TaskCollection:
    def __init__(self):
        self.states = dict.fromkeys(all_states, 0)
    
    def transition(self, old, new):
        self.states[old] -= 1
        self.states[new] += 1

class TaskGroup(TaskCollection):
    def __init__(self):
        super().__init__()

    def transition(self, old, new):
        super().transition(old, new)
        
class TaskGroupNoSuper(TaskCollection):
    def __init__(self):
        TaskCollection.__init__(self)

    def transition(self, old, new):
        TaskCollection.transition(self, old, new)


class TaskState:
    def __init__(self):
        self.group = TaskGroup()
        self._state = "released"

    @property
    def state(self):
        return self._state

    @state.setter
    def state(self, value) -> None:
        self.group.transition(self._state, value)
        self._state = value

class TaskStateNoSuper:
    def __init__(self):
        self.group = TaskGroupNoSuper()
        self._state = "released"

    @property
    def state(self):
        return self._state

    @state.setter
    def state(self, value) -> None:
        self.group.transition(self._state, value)
        self._state = value

class TaskStateNoIndirection:
    def __init__(self):
        self.group = TaskGroupNoSuper()
        self._state = "released"

    @property
    def state(self):
        return self._state

    @state.setter
    def state(self, value) -> None:
        self.group.states[self._state] -= 1
        self.group.states[value] += 1
        self._state = value

```

![image](https://github.com/user-attachments/assets/64596a97-3870-4cfe-b232-30323875ceb2)

</details>

The micro benchmarks (see above) show that ditching the indirection entirely speeds this up by a factor of 2. Not game changing but this abstraction is not worth *any* performance penalty.