### PR TITLE
Refactor some tests

### DIFF
--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -416,16 +416,23 @@ async def test_closed_worker_during_transfer(c, s, a, b):
     config={"distributed.scheduler.allowed-failures": 0},
 )
 async def test_restarting_during_transfer_raises_killed_worker(c, s, a, b):
+    await c.register_plugin(BlockedShuffleReceiveShuffleWorkerPlugin(), name="shuffle")
     df = dask.datasets.timeseries(
         start="2000-01-01",
-        end="2000-03-01",
+        end="2000-02-01",
         dtypes={"x": float, "y": float},
         freq="10 s",
     )
+    shuffle_extA = a.plugins["shuffle"]
+    shuffle_extB = b.plugins["shuffle"]
     with dask.config.set({"dataframe.shuffle.method": "p2p"}):
         out = df.shuffle("x")
     out = c.compute(out.x.size)
-    await wait_for_tasks_in_state("shuffle-transfer", "memory", 1, b)
+    await asyncio.gather(
+        shuffle_extA.in_shuffle_receive.wait(), shuffle_extB.in_shuffle_receive.wait()
+    )
+    shuffle_extA.block_shuffle_receive.set()
+    shuffle_extB.block_shuffle_receive.set()
     await assert_worker_cleanup(b, close=True)
 
     with pytest.raises(KilledWorker):

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -7,6 +7,7 @@ import pytest
 import distributed
 from distributed import Event, Lock, Worker
 from distributed.client import wait
+from distributed.compatibility import WINDOWS
 from distributed.utils_test import (
     BlockedExecute,
     BlockedGatherDep,
@@ -824,6 +825,7 @@ async def test_cancelled_task_error_rejected(c, s, a, b):
     )
 
 
+@pytest.mark.skipif(WINDOWS, reason="Fails on Windows")
 @pytest.mark.parametrize("intermediate_state", ["resumed", "cancelled"])
 @pytest.mark.parametrize("close_worker", [False, True])
 @gen_cluster(client=True, config={"distributed.comm.timeouts.connect": "500ms"})

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -524,6 +524,7 @@ class Worker(BaseWorker, ServerNode):
         ###################################
         # Parameters to Server
         scheduler_sni: str | None = None,
+        WorkerStateClass: type = WorkerState,
         **kwargs,
     ):
         if reconnect is not None:
@@ -770,7 +771,7 @@ class Worker(BaseWorker, ServerNode):
             transfer_incoming_bytes_limit = int(
                 self.memory_manager.memory_limit * transfer_incoming_bytes_fraction
             )
-        state = WorkerState(
+        state = WorkerStateClass(
             nthreads=nthreads,
             data=self.memory_manager.data,
             threads=self.threads,


### PR DESCRIPTION
This refactors two tests that are very flaky.

`test_deadlock_cancelled_after_inflight_before_gather_from_worker`

(I was initially able to reproduce this when running the test a couple thousand times. The windows CI is really slow it seems)

![image](https://github.com/user-attachments/assets/311f90df-4c82-43e9-b9f0-a99cd1b4fc11)


and

`test_restarting_during_transfer_raises_killed_worker`

![image](https://github.com/user-attachments/assets/c5e5fa44-136a-4ba3-8ebd-710edd0ec9c4)


Both appear to be stable now on my machine