### PR TITLE
Skip test_tell_workers_when_peers_have_left on py3.10

### DIFF
--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -4831,6 +4831,10 @@ async def test_submit_dependency_of_erred_task(c, s, a, b):
         await y
 
 
+@pytest.mark.skipif(
+    sys.version_info <= (3, 10),
+    reason="asyncio.wait_for is unreliable on 3.10 and below",
+)
 @gen_cluster(
     client=True,
     config={


### PR DESCRIPTION
I suspect that this is due to the bugs in asyncio.wait_for

We've only seen this test fail for python3.10 so let's skip it there

![image](https://github.com/user-attachments/assets/5f940795-9f5a-4133-9369-a332458ef098)
