### PR TITLE
Disable profiler on python 3.11

### DIFF
--- a/distributed/core.py
+++ b/distributed/core.py
@@ -312,7 +312,10 @@ class Server:
         self.io_loop = self.loop = IOLoop.current()
 
         if not hasattr(self.io_loop, "profile"):
-            if dask.config.get("distributed.worker.profile.enabled"):
+            if (
+                dask.config.get("distributed.worker.profile.enabled")
+                and sys.version_info.minor != 11
+            ):
                 ref = weakref.ref(self.io_loop)
 
                 def stop() -> bool:

--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import weakref
 
 import tlz as toolz
@@ -275,6 +276,12 @@ class ProfileTimePlot(DashboardComponent):
         self.profile_plot.add_layout(self.subtitle, "above")
         if not dask.config.get("distributed.worker.profile.enabled"):
             self.subtitle.text = "Profiling is disabled."
+
+            self.select.disabled = True
+            self.reset_button.disabled = True
+            self.update_button.disabled = True
+        elif sys.version_info.minor == 11:
+            self.subtitle.text = "Profiling is disabled due to a known deadlock in CPython 3.11 that can be triggered by the profiler. See https://github.com/dask/distributed/issues/8616 for more information."
             self.select.disabled = True
             self.reset_button.disabled = True
             self.update_button.disabled = True
@@ -401,6 +408,10 @@ class ProfileServer(DashboardComponent):
         self.profile_plot.add_layout(self.subtitle, "above")
         if not dask.config.get("distributed.worker.profile.enabled"):
             self.subtitle.text = "Profiling is disabled."
+            self.reset_button.disabled = True
+            self.update_button.disabled = True
+        elif sys.version_info.minor == 11:
+            self.subtitle.text = "Profiling is disabled due to a known deadlock in CPython 3.11 that can be triggered by the profiler. See https://github.com/dask/distributed/issues/8616 for more information."
             self.reset_button.disabled = True
             self.update_button.disabled = True
 

--- a/distributed/dashboard/tests/test_components.py
+++ b/distributed/dashboard/tests/test_components.py
@@ -4,6 +4,8 @@ import pytest
 
 pytest.importorskip("bokeh")
 
+import sys
+
 from bokeh.models import ColumnDataSource, Model
 
 from distributed.dashboard.components.shared import (
@@ -21,6 +23,7 @@ def test_basic(Component):
     assert isinstance(c.root, Model)
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     clean_kwargs={"threads": False},
@@ -34,6 +37,7 @@ async def test_profile_plot(c, s, a, b):
         p.update(a.profile_recent)
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     clean_kwargs={"threads": False},

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -1010,6 +1010,7 @@ async def test_TaskGroupGraph_arrows(c, s, a, b):
     assert not any(tgg.arrows_source.data.values())
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={

--- a/distributed/tests/test_actor.py
+++ b/distributed/tests/test_actor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import operator
+import sys
 from time import sleep
 
 import pytest
@@ -526,6 +527,7 @@ def test_compute_sync(client):
         assert time() < start + 30
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     nthreads=[("127.0.0.1", 1)],

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -5521,6 +5521,7 @@ async def test_call_stack_collections_all(c, s, a, b):
     assert result
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @pytest.mark.flaky(condition=WINDOWS, reruns=10, reruns_delay=5)
 @gen_cluster(
     client=True,
@@ -6374,6 +6375,7 @@ async def test_futures_of_sorted(c, s, a, b):
     assert [fut.key for fut in futures] == [k for k in b.__dask_keys__()]
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1973,6 +1973,7 @@ async def test_profile_metadata(c, s, a, b):
     assert not meta["counts"][-1][1]
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={
@@ -2000,6 +2001,7 @@ async def test_profile_metadata_timeout(c, s, a, b):
     assert not meta["counts"][-1][1]
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={
@@ -2019,6 +2021,7 @@ async def test_profile_metadata_keys(c, s, a, b):
     )
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={
@@ -2036,6 +2039,7 @@ async def test_statistical_profiling(c, s, a, b):
     assert profile["count"]
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1161,6 +1161,7 @@ async def test_scheduler_delay(c, s, a, b):
     assert a.scheduler_delay != old
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @pytest.mark.flaky(reruns=10, reruns_delay=5)
 @gen_cluster(
     client=True,
@@ -1176,6 +1177,7 @@ async def test_statistical_profiling(c, s, a, b):
     assert profile["count"]
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @pytest.mark.slow
 @nodebug
 @gen_cluster(
@@ -1202,6 +1204,7 @@ async def test_statistical_profiling_2(c, s, a, b):
             break
 
 
+@pytest.mark.skipif(sys.version_info.minor == 11, reason="Profiler disabled")
 @gen_cluster(
     client=True,
     config={


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8616

I'm not sure how often this actually happens but I think we should disable the profiler for py3.11 to be sure