### PR TITLE
Add `stimulus_id` to `SchedulerPlugin.update_graph` hook

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -101,6 +101,7 @@ class SchedulerPlugin:
         annotations: dict[str, dict[Key, Any]],
         priority: dict[Key, tuple[int | float, ...]],
         dependencies: dict[Key, set[Key]],
+        stimulus_id: str,
         **kwargs: Any,
     ) -> None:
         """Run when a new graph / tasks enter the scheduler
@@ -129,6 +130,8 @@ class SchedulerPlugin:
                 Task calculated priorities as assigned to the tasks.
             dependencies:
                 A mapping that maps a key to its dependencies.
+            stimulus_id:
+                ID of the stimulus causing the graph update
             **kwargs:
                 It is recommended to allow plugins to accept more parameters to
                 ensure future compatibility.

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -493,6 +493,7 @@ async def test_update_graph_hook_simple(c, s, a, b):
             annotations,
             priority,
             dependencies,
+            stimulus_id,
             **kwargs,
         ) -> None:
             assert scheduler is s
@@ -505,6 +506,7 @@ async def test_update_graph_hook_simple(c, s, a, b):
             assert len(priority) == 1
             assert isinstance(priority["foo"], tuple)
             assert dependencies == {"foo": set()}
+            assert stimulus_id is not None
             self.success = True
 
     plugin = UpdateGraph()
@@ -533,6 +535,7 @@ async def test_update_graph_hook_complex(c, s, a, b):
             annotations,
             priority,
             dependencies,
+            stimulus_id,
             **kwargs,
         ) -> None:
             assert scheduler is s
@@ -553,6 +556,7 @@ async def test_update_graph_hook_complex(c, s, a, b):
                 assert k in dependencies
             assert dependencies["f1"] == set()
             assert dependencies["sum"] == {"f1", "f3"}
+            assert stimulus_id is not None
 
             self.success = True
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4780,6 +4780,7 @@ class Scheduler(SchedulerState, ServerNode):
                     dependencies=dependencies,
                     annotations=dict(annotations_for_plugin),
                     priority=priority,
+                    stimulus_id=stimulus_id,
                 )
             except Exception as e:
                 logger.exception(e)
@@ -4846,6 +4847,7 @@ class Scheduler(SchedulerState, ServerNode):
         stimulus_id: str | None = None,
     ) -> None:
         start = time()
+        stimulus_id = stimulus_id or f"update-graph-{start}"
         self._active_graph_updates += 1
         try:
             logger.debug("Received new graph. Deserializing...")
@@ -4923,7 +4925,7 @@ class Scheduler(SchedulerState, ServerNode):
                 # objects. This should be removed
                 global_annotations=annotations,
                 start=start,
-                stimulus_id=stimulus_id or f"update-graph-{start}",
+                stimulus_id=stimulus_id,
             )
             task_state_created = time()
             metrics.update(


### PR DESCRIPTION
This helps correlate different hooks

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
