### PR TITLE
Remove redundant methods in P2PBarrierTask

### DIFF
--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -27,7 +27,6 @@ from tornado.ioloop import IOLoop
 import dask.config
 from dask._task_spec import Task, _inline_recursively
 from dask.core import flatten
-from dask.sizeof import sizeof
 from dask.typing import Key
 from dask.utils import parse_bytes, parse_timedelta
 
@@ -601,41 +600,17 @@ class P2PBarrierTask(Task):
         super().__init__(key, func, *args, **kwargs)
 
     def copy(self) -> P2PBarrierTask:
-        self.unpack()
-        assert self.func is not None
         return P2PBarrierTask(
             self.key, self.func, *self.args, spec=self.spec, **self.kwargs
         )
-
-    def __sizeof__(self) -> int:
-        return super().__sizeof__() + sizeof(self.spec)
 
     def __repr__(self) -> str:
         return f"P2PBarrierTask({self.key!r})"
 
     def inline(self, dsk: dict[Key, Any]) -> P2PBarrierTask:
-        self.unpack()
         new_args = _inline_recursively(self.args, dsk)
         new_kwargs = _inline_recursively(self.kwargs, dsk)
         assert self.func is not None
         return P2PBarrierTask(
             self.key, self.func, *new_args, spec=self.spec, **new_kwargs
         )
-
-    def __getstate__(self) -> dict[str, Any]:
-        state = super().__getstate__()
-        state["spec"] = self.spec
-        return state
-
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        super().__setstate__(state)
-        self.spec = state["spec"]
-
-    def __eq__(self, value: object) -> bool:
-        if not isinstance(value, P2PBarrierTask):
-            return False
-        if not super().__eq__(value):
-            return False
-        if self.spec != value.spec:
-            return False
-        return True


### PR DESCRIPTION
These methods are fragile and no longer necessary with https://github.com/dask/dask/pull/11496