### PR TITLE
Adjust timeouts in jupyter cli test

### DIFF
--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -56,6 +56,8 @@ def test_jupyter_cli(loop):
             "--host",
             f"127.0.0.1:{port}",
         ],
+        terminate_timeout=120,
+        kill_timeout=60,
     ):
         with Client(f"127.0.0.1:{port}", loop=loop):
             response = requests.get("http://127.0.0.1:8787/jupyter/api/status")

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -45,7 +45,7 @@ async def test_jupyter_server():
 
 
 @pytest.mark.slow
-def test_jupyter_cli(loop):
+def test_jupyter_cli(loop, requires_default_ports):
     port = open_port()
     with popen(
         [


### PR DESCRIPTION
This test is failing pretty constantly. https://github.com/dask/distributed/pull/8848 made things worse so I suggest increasing the timeout for this. I also put in the default ports fixture since the test requires the port `8787`


If that doesn't work I'll likely skip the test since the signal it adds is only marginal and it is failing all over CI (but running locally)