### PR TITLE
Make assumption in P2P's barrier mechanism explicit

### DIFF
--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -507,6 +507,10 @@ class SchedulerShuffleState(Generic[_T_partition_id]):
     def run_id(self) -> int:
         return self.run_spec.run_id
 
+    @property
+    def archived(self) -> bool:
+        return self._archived_by is not None
+
     def __str__(self) -> str:
         return f"{self.__class__.__name__}<{self.id}[{self.run_id}]>"
 

--- a/distributed/shuffle/_scheduler_plugin.py
+++ b/distributed/shuffle/_scheduler_plugin.py
@@ -124,6 +124,10 @@ class ShuffleSchedulerPlugin(SchedulerPlugin):
                     shuffle.id,
                 )
                 if any(w not in self.scheduler.workers for w in workers):
+                    if not shuffle.archived:
+                        raise P2PIllegalStateError(
+                            "Expected shuffle to be archived if participating worker is not known by scheduler"
+                        )
                     raise RuntimeError(
                         f"Worker {workers} left during shuffle {shuffle}"
                     )


### PR DESCRIPTION
I've been wondering whether the retry mechanism in the P2P barrier interferes with P2P restarts. I'm pretty sure it doesn't but I'd like an explicit exception to be in place should that ever change.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
