### PR TITLE
Ensure ConnectionPool closes even if network stack swallows cancellation

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -623,6 +623,7 @@ class Nanny(ServerNode):
         self.status = Status.closed
         await super().close()
         self.__exit_stack.__exit__(None, None, None)
+        logger.info("Nanny at %r closed.", self.address_safe)
         return "OK"
 
     async def _log_event(self, topic, msg):


### PR DESCRIPTION
we've seen some workers not closing properly in cases where the scheduler died very unusual deaths. We saw that workers, particularly Nannies, wouldn't close for whatever reason without any sound.

For this section in the code it is at least in theory possible to lock up in case the connector (in this case tornado which I generally trust to do these things properly) swallows cancellation attempts completely.

I don't have confidence that this is actually related but in case I'm missing something, let's remove that edge case.