### PR TITLE
Skip collecting coverage for CLI calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,8 +224,7 @@ source = ["distributed"]
 omit = [
     "distributed/tests/test*",
     "distributed/*/tests/test*",
-    "distributed/cli/utils.py",
-    "distributed/cli/dask_spec.py",
+    "distributed/cli/*",
     "distributed/deploy/ssh.py",
     "distributed/_version.py",
     "distributed/pytest_resourceleaks.py",


### PR DESCRIPTION
We're frequently seeing weird deadlocks / stuck tests when running CLI tests. I've tuned the timeouts a couple of times and for some this was indeed helpful.

I've been looking into this again and saw in https://github.com/dask/distributed/actions/runs/11736945020/job/32696964203 an interesting traceback


```python-traceback
E           subprocess.TimeoutExpired: Command '['/home/runner/miniconda3/envs/dask-distributed/bin/dask', 'worker', 'tcp://127.0.0.1:34103', '--nworkers=2', '--no-nanny']' timed out after 10 seconds

../../../miniconda3/envs/dask-distributed/lib/python3.10/subprocess.py:1198: TimeoutExpired
----------------------------- Captured stdout call -----------------------------
b'2024-11-08 06:03:36,069 - distributed.dask_worker - ERROR - Failed to launch worker.  You cannot use the --no-nanny argument when n_workers > 1.\n'
------ stdout: returncode -9, ['/home/runner/miniconda3/envs/dask-distributed/bin/dask', 'worker', 'tcp://127.0.0.1:34103', '--nworkers=2', '--no-nanny'] ------
Exception ignored in atexit callback: <function _python_exit at 0x7fb6909fde10>
Traceback (most recent call last):
  File "/home/runner/miniconda3/envs/dask-distributed/lib/python3.10/site-packages/coverage/collector.py", line 252, in lock_data
    self.data_lock.acquire()
KeyboardInterrupt: 
```

This suggests that coverage has a python atexit hook that is locking up for some reason. Possibly because it cannot write the coverage data out quickly enough.

I hope that a quick fix is to just not collect coverage for the CLI tests