### PR TITLE
Do not log full worker info in retire_workers

### DIFF
--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -977,7 +977,7 @@ async def test_RetireWorker_all_recipients_are_paused(c, s, a, b):
 
     x = await c.scatter("x", workers=[a.address])
     out = await c.retire_workers([a.address])
-    assert out == {}
+    assert not out
     assert not s.extensions["amm"].policies
     assert set(s.workers) == {a.address, b.address}
 
@@ -1230,7 +1230,7 @@ async def test_RetireWorker_with_actor(c, s, a, b, has_proxy):
 
     with captured_logger("distributed.active_memory_manager", logging.WARNING) as log:
         out = await c.retire_workers([a.address])
-    assert out == {}
+    assert not out
     assert "it holds actor(s)" in log.getvalue()
     assert "x" in a.state.actors
 
@@ -1250,7 +1250,7 @@ async def test_RetireWorker_with_actor_proxy(c, s, a, b):
     assert "y" in b.data
 
     out = await c.retire_workers([b.address])
-    assert out.keys() == {b.address}
+    assert out == (b.address,)
     assert "x" in a.state.actors
     assert "y" in a.data
 
@@ -1301,6 +1301,7 @@ async def tensordot_stress(c, s):
     assert sum(t.start == "memory" for t in s.transition_log) == expected_tasks
 
 
+@pytest.mark.slow
 @gen_cluster(
     client=True,
     nthreads=[("", 1)] * 4,
@@ -1356,6 +1357,7 @@ async def test_ReduceReplicas_stress(c, s, *workers):
     await tensordot_stress(c, s)
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("use_ReduceReplicas", [False, True])
 @gen_cluster(
     client=True,

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1499,7 +1499,6 @@ async def test_retire_workers(c, s, a, b):
 
     workers = await s.retire_workers()
     assert list(workers) == [a.address]
-    assert workers[a.address]["nthreads"] == a.state.nthreads
     assert list(s.workers) == [b.address]
 
     assert s.workers_to_close() == []

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -3553,7 +3553,7 @@ async def test_execute_preamble_abort_retirement(c, s):
 
         # b has shut down. There's nowhere to replicate x to anymore, so retire_workers
         # will give up and reinstate a to running status.
-        assert await retire_fut == {}
+        assert not await retire_fut
         while a.status != Status.running:
             await asyncio.sleep(0.01)
 


### PR DESCRIPTION
Whenever we retire a worker we're apparently logging the `WorkerState.identity` information to the internal event system.

I've seen individual events of this message grow to 150KiB and beyond for large clusters.

Apart from the unnecessary memory this eats up, this can cause issues when the message is ingested elsewhere. It can also become quite a substantial problem if this message is tried being printed since that can easily overflow buffers and lock up the scheduler process.

While all of those ingestion/logging issues are not the fault of this code, logging this information is entirely unnecessary and too verbose.

As an example of the information that's being logged 

```
{
    "tls://123.0.456.789:1234": {
        "type": "Worker",
        "id": "12345",
        "host": "123.0.456.789",
        "resources": {},
        "local_directory": "/scratch/dask-scratch-space/worker-foo",
        "name": "12345",
        "nthreads": 4,
        "memory_limit": 15923011584,
        "last_seen": 1731554289.3153517,
        "services": {"dashboard": 8788},
        "metrics": {
            "task_counts": {"memory": 45},
            "bandwidth": {"total": 100000000, "workers": {}, "types": {}},
            "digests_total_since_heartbeat": {
                "latency": 0.0008902549743652344,
                "tick-duration": 2.978916883468628,
                ("get-data", "memory-read", "count"): 24,
                ("get-data", "memory-read", "bytes"): 4943466,
                ("get-data", "serialize", "seconds"): 0.08324008999994703,
                ("get-data", "compress", "seconds"): 0.0023884560009150846,
                ("get-data", "network", "seconds"): 0.38302203345165253,
            },
            "managed_bytes": 9270953,
            "spilled_bytes": {"memory": 0, "disk": 0},
            "transfer": {
                "incoming_bytes": 0,
                "incoming_count": 0,
                "incoming_count_total": 0,
                "outgoing_bytes": 0,
                "outgoing_count": 0,
                "outgoing_count_total": 10,
            },
            "event_loop_interval": 0.02000030517578125,
            "cpu": 2.0,
            "memory": 847728640,
            "time": 1731554289.0746875,
            "host_net_io": {
                "read_bps": 2962.6441596327654,
                "write_bps": 2337.352438820186,
            },
            "host_disk_io": {"read_bps": 0.0, "write_bps": 0.0},
            "gil_contention": 0.0004726344777736813,
            "num_fds": 33,
        },
        "status": "closed",
        "nanny": "tls://123.0.456.789:1234",
    }
}

```

A few of those keys _may_ be remotely interesting when debugging why / why not certain workers are retiring but I don't think this approach is feasible.