### PR TITLE
Less verbose log messages for remove and register worker

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4571,7 +4571,7 @@ class Scheduler(SchedulerState, ServerNode):
             )
             self.stimulus_queue_slots_maybe_opened(stimulus_id=stimulus_id)
 
-        logger.info("Register worker %s", ws)
+        logger.info("Register worker addr: %s name: %s", ws.address, ws.name)
 
         msg = {
             "status": "OK",
@@ -5428,7 +5428,7 @@ class Scheduler(SchedulerState, ServerNode):
 
         ws = self.workers[address]
 
-        logger.info(f"Remove worker {ws} ({stimulus_id=})")
+        logger.info(f"Remove worker addr:{ws.address} name: {ws.name} ({stimulus_id=})")
         if close:
             with suppress(AttributeError, CommClosedError):
                 self.stream_comms[address].send(


### PR DESCRIPTION
Those logs would log the representation of the Worker state object, i.e. smth like `<WorkerState addr name status memory processing>` which is a little verbose. Most useful information is the addr and name of the worker (arguably the name is also quite verbose depending on the deployment tool)