### PR TITLE
Install ``tornado`` from ``conda-forge`` in Python 3.13 CI

### DIFF
--- a/continuous_integration/environment-3.13.yaml
+++ b/continuous_integration/environment-3.13.yaml
@@ -40,7 +40,7 @@ dependencies:
   - sortedcollections
   - tblib
   - toolz
-  # - tornado # Using pip below until 6.4.2 is on conda-forge
+  - tornado
   - zict  # overridden by git tip below
   - zstandard
   # Temporary fix for https://github.com/pypa/setuptools/issues/4496
@@ -53,4 +53,3 @@ dependencies:
       # - git+https://github.com/dask/s3fs
       # - git+https://github.com/fsspec/filesystem_spec
       - keras
-      - tornado>=6.4.2


### PR DESCRIPTION
This release is on conda-forge now 