### PR TITLE
Support pynvml>=11.5 in WSL

### DIFF
--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -104,9 +104,11 @@ def init_once():
             NVML_STATE = NVMLState.DISABLED_LIBRARY_NOT_FOUND
             return
 
-        if _in_wsl() and parse_version(
-            pynvml.nvmlSystemGetDriverVersion().decode()
-        ) < parse_version(MINIMUM_WSL_VERSION):
+        try:
+            driver_vsn = pynvml.nvmlSystemGetDriverVersion().decode()
+        except AttributeError:
+            driver_vsn = pynvml.nvmlSystemGetDriverVersion()
+        if _in_wsl() and parse_version(driver_vsn) < parse_version(MINIMUM_WSL_VERSION):
             NVML_STATE = NVMLState.DISABLED_WSL_INSUFFICIENT_DRIVER
             return
         else:

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -8,6 +8,7 @@ from typing import NamedTuple
 from packaging.version import parse as parse_version
 
 import dask
+from dask.utils import ensure_unicode
 
 try:
     import pynvml
@@ -68,11 +69,6 @@ def _in_wsl():
     return "microsoft-standard" in uname().release
 
 
-def _maybe_decode(value):
-    """Decode if bytes instance"""
-    return value.decode() if isinstance(value, bytes) else value
-
-
 def init_once():
     """Idempotent (per-process) initialization of PyNVML
 
@@ -110,7 +106,7 @@ def init_once():
             return
 
         if _in_wsl() and parse_version(
-            _maybe_decode(pynvml.nvmlSystemGetDriverVersion())
+            ensure_unicode(pynvml.nvmlSystemGetDriverVersion())
         ) < parse_version(MINIMUM_WSL_VERSION):
             NVML_STATE = NVMLState.DISABLED_WSL_INSUFFICIENT_DRIVER
             return

--- a/distributed/diagnostics/nvml.py
+++ b/distributed/diagnostics/nvml.py
@@ -68,6 +68,11 @@ def _in_wsl():
     return "microsoft-standard" in uname().release
 
 
+def _maybe_decode(value):
+    """Decode if bytes instance"""
+    return value.decode() if isinstance(value, bytes) else value
+
+
 def init_once():
     """Idempotent (per-process) initialization of PyNVML
 
@@ -104,11 +109,9 @@ def init_once():
             NVML_STATE = NVMLState.DISABLED_LIBRARY_NOT_FOUND
             return
 
-        try:
-            driver_vsn = pynvml.nvmlSystemGetDriverVersion().decode()
-        except AttributeError:
-            driver_vsn = pynvml.nvmlSystemGetDriverVersion()
-        if _in_wsl() and parse_version(driver_vsn) < parse_version(MINIMUM_WSL_VERSION):
+        if _in_wsl() and parse_version(
+            _maybe_decode(pynvml.nvmlSystemGetDriverVersion())
+        ) < parse_version(MINIMUM_WSL_VERSION):
             NVML_STATE = NVMLState.DISABLED_WSL_INSUFFICIENT_DRIVER
             return
         else:


### PR DESCRIPTION
Closes https://github.com/dask/distributed/issues/8961

Handles the case that `pynvml.nvmlSystemGetDriverVersion()` returns `str` instead of `bytes`.