### PR TITLE
Run dask with a matching interpreter

### DIFF
--- a/distributed/cli/tests/test_dask_spec.py
+++ b/distributed/cli/tests/test_dask_spec.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import signal
 import subprocess
+import sys
 
 import pytest
 import yaml
@@ -19,6 +20,8 @@ async def test_text():
     port = open_port()
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "spec",
             "--spec",
@@ -27,6 +30,8 @@ async def test_text():
     ):
         with popen(
             [
+                sys.executable,
+                "-m",
                 "dask",
                 "spec",
                 "tcp://localhost:%d" % port,
@@ -55,6 +60,8 @@ async def test_file(c, s, tmp_path):
         )
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "spec",
             s.address,
@@ -72,6 +79,8 @@ async def test_file(c, s, tmp_path):
 def test_errors():
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "spec",
             "--spec",
@@ -85,7 +94,7 @@ def test_errors():
         assert "exactly one" in line
         assert "--spec" in line and "--spec-file" in line
 
-    with popen(["dask", "spec"], capture_output=True) as proc:
+    with popen([sys.executable, "-m", "dask", "spec"], capture_output=True) as proc:
         line = proc.stdout.readline().decode()
         assert "exactly one" in line
         assert "--spec" in line and "--spec-file" in line
@@ -97,6 +106,8 @@ def test_errors():
 @gen_cluster(client=True, nthreads=[])
 async def test_signal_handling_worker(c, s, worker_type, sig):
     worker = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
         "dask",
         "spec",
         "--spec",
@@ -136,6 +147,8 @@ async def test_signal_handling_worker(c, s, worker_type, sig):
 async def test_signal_handling_scheduler(sig):
     port = open_port()
     scheduler = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
         "dask",
         "spec",
         "--spec",

--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -173,6 +173,8 @@ async def test_nanny_worker_ports(c, s):
     nanny_port = open_port()
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -220,6 +222,8 @@ async def test_nanny_worker_port_range(c, s):
 
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -243,6 +247,8 @@ async def test_nanny_worker_port_range(c, s):
 async def test_nanny_worker_port_range_too_many_workers_raises(s):
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -266,6 +272,8 @@ async def test_nanny_worker_port_range_too_many_workers_raises(s):
 async def test_memory_limit(c, s):
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -283,7 +291,17 @@ async def test_memory_limit(c, s):
 
 @gen_cluster(client=True, nthreads=[])
 async def test_no_nanny(c, s):
-    with popen(["dask", "worker", s.address, "--no-nanny", "--no-dashboard"]):
+    with popen(
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "worker",
+            s.address,
+            "--no-nanny",
+            "--no-dashboard",
+        ]
+    ):
         await c.wait_for_workers(1)
 
 
@@ -292,6 +310,8 @@ async def test_no_nanny(c, s):
 async def test_resources(c, s):
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -312,6 +332,8 @@ async def test_resources(c, s):
 async def test_local_directory(c, s, nanny, tmp_path):
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -332,8 +354,29 @@ async def test_local_directory(c, s, nanny, tmp_path):
 def test_scheduler_file(loop, nanny):
     with (
         tmpfile() as fn,
-        popen(["dask", "scheduler", "--no-dashboard", "--scheduler-file", fn]),
-        popen(["dask", "worker", "--scheduler-file", fn, nanny, "--no-dashboard"]),
+        popen(
+            [
+                sys.executable,
+                "-m",
+                "dask",
+                "scheduler",
+                "--no-dashboard",
+                "--scheduler-file",
+                fn,
+            ]
+        ),
+        popen(
+            [
+                sys.executable,
+                "-m",
+                "dask",
+                "worker",
+                "--scheduler-file",
+                fn,
+                nanny,
+                "--no-dashboard",
+            ]
+        ),
         Client(scheduler_file=fn, loop=loop) as c,
     ):
         start = time()
@@ -347,8 +390,18 @@ def test_scheduler_address_env(loop, monkeypatch):
     port = open_port()
     monkeypatch.setenv("DASK_SCHEDULER_ADDRESS", f"tcp://127.0.0.1:{port}")
     # The env var is only picked up by the dask worker command
-    with popen(["dask", "scheduler", "--no-dashboard", "--port", str(port)]):
-        with popen(["dask", "worker", "--no-dashboard"]):
+    with popen(
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "scheduler",
+            "--no-dashboard",
+            "--port",
+            str(port),
+        ]
+    ):
+        with popen([sys.executable, "-m", "dask", "worker", "--no-dashboard"]):
             with Client(os.environ["DASK_SCHEDULER_ADDRESS"], loop=loop) as c:
                 start = time()
                 while not c.scheduler_info()["workers"]:
@@ -359,7 +412,15 @@ def test_scheduler_address_env(loop, monkeypatch):
 @gen_cluster(nthreads=[])
 async def test_nworkers_requires_nanny(s):
     with popen(
-        ["dask", "worker", s.address, "--nworkers=2", "--no-nanny"],
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "worker",
+            s.address,
+            "--nworkers=2",
+            "--no-nanny",
+        ],
         capture_output=True,
     ) as worker:
         wait_for_log_line(b"Failed to launch worker", worker.stdout, max_lines=15)
@@ -368,14 +429,14 @@ async def test_nworkers_requires_nanny(s):
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[])
 async def test_nworkers_negative(c, s):
-    with popen(["dask", "worker", s.address, "--nworkers=-1"]):
+    with popen([sys.executable, "-m", "dask", "worker", s.address, "--nworkers=-1"]):
         await c.wait_for_workers(cpu_count())
 
 
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[])
 async def test_nworkers_auto(c, s):
-    with popen(["dask", "worker", s.address, "--nworkers=auto"]):
+    with popen([sys.executable, "-m", "dask", "worker", s.address, "--nworkers=auto"]):
         procs, _ = nprocesses_nthreads()
         await c.wait_for_workers(procs)
 
@@ -383,8 +444,22 @@ async def test_nworkers_auto(c, s):
 @pytest.mark.slow
 @gen_cluster(client=True, nthreads=[])
 async def test_nworkers_expands_name(c, s):
-    with popen(["dask", "worker", s.address, "--nworkers", "2", "--name", "0"]):
-        with popen(["dask", "worker", s.address, "--nworkers", "2"]):
+    with popen(
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "worker",
+            s.address,
+            "--nworkers",
+            "2",
+            "--name",
+            "0",
+        ]
+    ):
+        with popen(
+            [sys.executable, "-m", "dask", "worker", s.address, "--nworkers", "2"]
+        ):
             await c.wait_for_workers(4)
             info = c.scheduler_info()
 
@@ -404,6 +479,8 @@ async def test_contact_listen_address(c, s, nanny, listen_address):
     listen_address += str(port)
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -438,6 +515,8 @@ async def test_listen_address_ipv6(c, s, nanny, listen_address):
     listen_address += str(port)
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -471,7 +550,19 @@ async def test_listen_address_ipv6(c, s, nanny, listen_address):
 @pytest.mark.parametrize("host", ["127.0.0.2", "0.0.0.0"])
 @gen_cluster(client=True, nthreads=[])
 async def test_respect_host_listen_address(c, s, nanny, host):
-    with popen(["dask", "worker", s.address, nanny, "--no-dashboard", "--host", host]):
+    with popen(
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "worker",
+            s.address,
+            nanny,
+            "--no-dashboard",
+            "--host",
+            host,
+        ]
+    ):
         await c.wait_for_workers(1)
 
         # roundtrip works
@@ -536,7 +627,7 @@ def test_worker_timeout(no_nanny):
 @pytest.mark.slow
 @gen_cluster(nthreads=[])
 async def test_integer_names(s):
-    with popen(["dask", "worker", s.address, "--name", "123"]):
+    with popen([sys.executable, "-m", "dask", "worker", s.address, "--name", "123"]):
         while not s.workers:
             await asyncio.sleep(0.01)
         [ws] = s.workers.values()
@@ -568,6 +659,8 @@ class MyWorker(Worker):
 
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "worker",
             s.address,
@@ -597,7 +690,7 @@ def dask_setup(worker):
 """
     env = os.environ.copy()
     env["DASK_DISTRIBUTED__WORKER__PRELOAD"] = preload_text
-    with popen(["dask", "worker", s.address], env=env):
+    with popen([sys.executable, "-m", "dask", "worker", s.address], env=env):
         await c.wait_for_workers(1)
         [foo] = (await c.run(lambda dask_worker: dask_worker.foo)).values()
         assert foo == "setup"
@@ -611,8 +704,8 @@ async def test_set_lifetime_stagger_via_env_var(c, s):
     env["DASK_DISTRIBUTED__WORKER__LIFETIME__DURATION"] = "10 seconds"
     env["DASK_DISTRIBUTED__WORKER__LIFETIME__STAGGER"] = "2 seconds"
     with (
-        popen(["dask", "worker", s.address], env=env),
-        popen(["dask", "worker", s.address], env=env),
+        popen([sys.executable, "-m", "dask", "worker", s.address], env=env),
+        popen([sys.executable, "-m", "dask", "worker", s.address], env=env),
     ):
         await c.wait_for_workers(2)
         [lifetime1, lifetime2] = (
@@ -629,7 +722,7 @@ async def test_set_lifetime_restart_via_env_var(c, s):
     # Ensure that lifetime restart can be set via an environment variable
     env = os.environ.copy()
     env["DASK_DISTRIBUTED__WORKER__LIFETIME__RESTART"] = "True"
-    with popen(["dask", "worker", s.address], env=env):
+    with popen([sys.executable, "-m", "dask", "worker", s.address], env=env):
         await c.wait_for_workers(1)
         [lifetime_restart] = (
             await c.run(lambda dask_worker: dask_worker.lifetime_restart)
@@ -697,6 +790,8 @@ def test_error_during_startup(monkeypatch, nanny, loop):
     monkeypatch.setenv("DASK_SCHEDULER_ADDRESS", scheduler_addr)
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "scheduler",
             f"--port={scheduler_port}",
@@ -706,6 +801,8 @@ def test_error_during_startup(monkeypatch, nanny, loop):
         with Client(scheduler_addr, loop=loop) as c:
             with popen(
                 [
+                    sys.executable,
+                    "-m",
                     "dask",
                     "worker",
                     scheduler_addr,

--- a/distributed/cli/tests/test_tls_cli.py
+++ b/distributed/cli/tests/test_tls_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from time import sleep
 
 from distributed import Client
@@ -32,8 +33,18 @@ def wait_for_cores(c, nthreads=1):
 
 def test_basic(loop, requires_default_ports):
     with (
-        popen(["dask", "scheduler", "--no-dashboard"] + tls_args),
-        popen(["dask", "worker", "--no-dashboard", "tls://127.0.0.1:8786"] + tls_args),
+        popen([sys.executable, "-m", "dask", "scheduler", "--no-dashboard"] + tls_args),
+        popen(
+            [
+                sys.executable,
+                "-m",
+                "dask",
+                "worker",
+                "--no-dashboard",
+                "tls://127.0.0.1:8786",
+            ]
+            + tls_args
+        ),
         Client("tls://127.0.0.1:8786", loop=loop, security=tls_security()) as c,
     ):
         wait_for_cores(c)
@@ -42,10 +53,13 @@ def test_basic(loop, requires_default_ports):
 def test_sni(loop):
     port = open_port()
     with popen(
-        ["dask", "scheduler", "--no-dashboard", f"--port={port}"] + tls_args
+        [sys.executable, "-m", "dask", "scheduler", "--no-dashboard", f"--port={port}"]
+        + tls_args
     ) as s:
         with popen(
             [
+                sys.executable,
+                "-m",
                 "dask",
                 "worker",
                 "--no-dashboard",
@@ -65,6 +79,8 @@ def test_nanny(loop):
     port = open_port()
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "scheduler",
             "--no-dashboard",
@@ -73,7 +89,15 @@ def test_nanny(loop):
         + tls_args
     ) as s:
         with popen(
-            ["dask", "worker", "--no-dashboard", "--nanny", f"tls://127.0.0.1:{port}"]
+            [
+                sys.executable,
+                "-m",
+                "dask",
+                "worker",
+                "--no-dashboard",
+                "--nanny",
+                f"tls://127.0.0.1:{port}",
+            ]
             + tls_args
         ) as w:
             with Client(
@@ -86,6 +110,8 @@ def test_separate_key_cert(loop):
     port = open_port()
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "scheduler",
             "--no-dashboard",
@@ -94,7 +120,15 @@ def test_separate_key_cert(loop):
         + tls_args_2
     ) as s:
         with popen(
-            ["dask", "worker", "--no-dashboard", f"tls://127.0.0.1:{port}"] + tls_args_2
+            [
+                sys.executable,
+                "-m",
+                "dask",
+                "worker",
+                "--no-dashboard",
+                f"tls://127.0.0.1:{port}",
+            ]
+            + tls_args_2
         ) as w:
             with Client(
                 f"tls://127.0.0.1:{port}", loop=loop, security=tls_security()
@@ -107,6 +141,8 @@ def test_use_config_file(loop):
     with new_config_file(tls_only_config()):
         with popen(
             [
+                sys.executable,
+                "-m",
                 "dask",
                 "scheduler",
                 "--no-dashboard",
@@ -117,7 +153,14 @@ def test_use_config_file(loop):
             ]
         ) as s:
             with popen(
-                ["dask", "worker", "--no-dashboard", f"tls://127.0.0.1:{port}"]
+                [
+                    sys.executable,
+                    "-m",
+                    "dask",
+                    "worker",
+                    "--no-dashboard",
+                    f"tls://127.0.0.1:{port}",
+                ]
             ) as w:
                 with Client(
                     f"tls://127.0.0.1:{port}", loop=loop, security=tls_security()

--- a/distributed/comm/tests/test_ucx_config.py
+++ b/distributed/comm/tests/test_ucx_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from time import sleep
 
 import pytest
@@ -118,11 +119,23 @@ def test_ucx_config_w_env_var(ucx_loop, cleanup, loop):
     sched_addr = f"ucx://127.0.0.1:{port}"
 
     with popen(
-        ["dask", "scheduler", "--no-dashboard", "--protocol", "ucx", "--port", port],
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "scheduler",
+            "--no-dashboard",
+            "--protocol",
+            "ucx",
+            "--port",
+            port,
+        ],
         env=env,
     ):
         with popen(
             [
+                sys.executable,
+                "-m",
                 "dask",
                 "worker",
                 sched_addr,

--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import os
+import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -82,6 +83,8 @@ class SubprocessScheduler(Subprocess):
 
     async def _start(self):
         cmd = [
+            sys.executable,
+            "-m",
             "dask",
             "spec",
             "--spec",
@@ -153,6 +156,8 @@ class SubprocessWorker(Subprocess):
 
     async def _start(self) -> None:
         cmd = [
+            sys.executable,
+            "-m",
             "dask",
             "spec",
             self.scheduler,

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3764,7 +3764,9 @@ async def test_reconnect():
     port = open_port()
 
     stack = ExitStack()
-    proc = popen(["dask", "scheduler", "--no-dashboard", f"--port={port}"])
+    proc = popen(
+        [sys.executable, "-m", "dask", "scheduler", "--no-dashboard", f"--port={port}"]
+    )
     stack.enter_context(proc)
     async with (
         Client(f"127.0.0.1:{port}", asynchronous=True) as c,
@@ -3784,7 +3786,16 @@ async def test_reconnect():
         with pytest.raises(CancelledError):
             await x
 
-        with popen(["dask", "scheduler", "--no-dashboard", f"--port={port}"]):
+        with popen(
+            [
+                sys.executable,
+                "-m",
+                "dask",
+                "scheduler",
+                "--no-dashboard",
+                f"--port={port}",
+            ]
+        ):
             start = time()
             while c.status != "running":
                 await asyncio.sleep(0.1)

--- a/distributed/tests/test_jupyter.py
+++ b/distributed/tests/test_jupyter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 from time import perf_counter
 
@@ -49,6 +50,8 @@ def test_jupyter_cli(loop, requires_default_ports):
     port = open_port()
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "scheduler",
             "--jupyter",
@@ -120,6 +123,8 @@ def test_shutsdown_cleanly(requires_default_ports):
         subprocess_fut = tpe.submit(
             subprocess.run,
             [
+                sys.executable,
+                "-m",
                 "dask",
                 "scheduler",
                 "--jupyter",

--- a/distributed/tests/test_queues.py
+++ b/distributed/tests/test_queues.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import pickle
+import sys
 from datetime import timedelta
 from time import sleep
 
@@ -282,13 +283,15 @@ def test_queue_in_task(loop):
     # worker in a separate Python process than the client
     with popen(
         [
+            sys.executable,
+            "-m",
             "dask",
             "scheduler",
             "--no-dashboard",
             f"--port={port}",
         ]
     ):
-        with popen(["dask", "worker", f"127.0.0.1:{port}"]):
+        with popen([sys.executable, "-m", "dask", "worker", f"127.0.0.1:{port}"]):
             with Client(f"tcp://127.0.0.1:{port}", loop=loop) as c:
                 c.wait_for_workers(1)
 

--- a/distributed/tests/test_variable.py
+++ b/distributed/tests/test_variable.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import pickle
 import random
+import sys
 from datetime import timedelta
 from time import sleep
 
@@ -44,8 +45,18 @@ def test_variable_in_task(loop):
     port = open_port()
     # Ensure that we can create a Variable inside a task on a
     # worker in a separate Python process than the client
-    with popen(["dask", "scheduler", "--no-dashboard", "--port", str(port)]):
-        with popen(["dask", "worker", f"127.0.0.1:{port}"]):
+    with popen(
+        [
+            sys.executable,
+            "-m",
+            "dask",
+            "scheduler",
+            "--no-dashboard",
+            "--port",
+            str(port),
+        ]
+    ):
+        with popen([sys.executable, "-m", "dask", "worker", f"127.0.0.1:{port}"]):
             with Client(f"tcp://127.0.0.1:{port}", loop=loop) as c:
                 c.wait_for_workers(1)
 


### PR DESCRIPTION
When Debian is in the process of migrating from one Python version to another, there's a transitional period when we run tests on each of two Python versions, although `/usr/bin/python3` can only point to one at a time.  `distributed` runs `dask` from the executable search path, and when it's installed as a system package rather than in a virtual environment, it's possible during this transitional period for `distributed` to be running under (e.g.) Python 3.13 while `/usr/bin/dask` has a `#!` line that causes it to be run under (e.g.) Python 3.12.  This results in the following obscure failure mode in some tests in `distributed/deploy/tests/test_subprocess.py`:

```
______________________________ test_basic ______________________________

    @pytest.mark.skipif(WINDOWS, reason="distributed#7434")
    @gen_test()
    async def test_basic():
        async with SubprocessCluster(
            asynchronous=True,
            dashboard_address=":0",
            scheduler_kwargs={"idle_timeout": "5s"},
            worker_kwargs={"death_timeout": "5s"},
        ) as cluster:
            async with Client(cluster, asynchronous=True) as client:
>               result = await client.submit(lambda x: x + 1, 10)

distributed/deploy/tests/test_subprocess.py:27:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Future: cancelled, key: lambda-e426db6b5bc630ab037e145b5e8f631c>, raiseit = True

    async def _result(self, raiseit=True):
        await self._state.wait()
        if self.status == "error":
            exc = clean_exception(self._state.exception, self._state.traceback)
            if raiseit:
                typ, exc, tb = exc
>               raise exc.with_traceback(tb)
E               SystemError: no locals found when setting up annotations

distributed/client.py:410: SystemError
```

Explicitly running `dask` using `sys.executable` fixes this.  It's only _strictly_ necessary to change the invocations of `dask` in `distributed.deploy.subprocess`, but it seemed better to apply the same change to the whole codebase for consistency.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`