### PR TITLE
Remove unused "type: ignore" comment

### DIFF
--- a/distributed/shuffle/_rechunk.py
+++ b/distributed/shuffle/_rechunk.py
@@ -753,7 +753,7 @@ def partial_concatenate(
             )
             rec_cat_arg[old_partial_index] = t.ref()
         else:
-            rec_cat_arg[old_partial_index] = TaskRef((input_name,) + old_global_index)  # type: ignore[call-overload]
+            rec_cat_arg[old_partial_index] = TaskRef((input_name,) + old_global_index)
 
     concat_task = Task(
         (rechunk_name(token),) + global_new_index,


### PR DESCRIPTION
The underlying problem here seems to have been fixed at some point, since mypy complained:

```
distributed/shuffle/_rechunk.py:756: error: Unused "type: ignore" comment  [unused-ignore]
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`