### PR TITLE
Skip big-endian floats in `test_serialize_scipy_sparse` if using `scipy>=1.15.0`

### DIFF
--- a/distributed/protocol/tests/test_scipy.py
+++ b/distributed/protocol/tests/test_scipy.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from packaging.version import Version
 
 import pytest
 
@@ -8,6 +9,9 @@ numpy = pytest.importorskip("numpy")
 scipy = pytest.importorskip("scipy")
 scipy_sparse = pytest.importorskip("scipy.sparse")
 
+
+SCIPY_VERSION = Version(scipy.__version__)
+SCIPY_GE_1_15_0 = SCIPY_VERSION.release >= (1, 15, 0)
 
 @pytest.mark.parametrize(
     "sparse_type",
@@ -23,7 +27,12 @@ scipy_sparse = pytest.importorskip("scipy.sparse")
 )
 @pytest.mark.parametrize(
     "dtype",
-    [numpy.dtype("<f4"), numpy.dtype(">f4"), numpy.dtype("<f8"), numpy.dtype(">f8")],
+    [
+        numpy.dtype("<f4"), 
+        pytest.param(numpy.dtype(">f4"), marks=pytest.mark.skipif(SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258")), 
+        numpy.dtype("<f8"),
+        pytest.param(numpy.dtype(">f8"), marks=pytest.mark.skipif(SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258")), 
+    ],
 )
 def test_serialize_scipy_sparse(sparse_type, dtype):
     a = numpy.array([[0, 1, 0], [2, 0, 3], [0, 4, 0]], dtype=dtype)

--- a/distributed/protocol/tests/test_scipy.py
+++ b/distributed/protocol/tests/test_scipy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from packaging.version import Version
 
 import pytest
+from packaging.version import Version
 
 from distributed.protocol import deserialize, serialize
 
@@ -12,6 +12,7 @@ scipy_sparse = pytest.importorskip("scipy.sparse")
 
 SCIPY_VERSION = Version(scipy.__version__)
 SCIPY_GE_1_15_0 = SCIPY_VERSION.release >= (1, 15, 0)
+
 
 @pytest.mark.parametrize(
     "sparse_type",
@@ -28,10 +29,20 @@ SCIPY_GE_1_15_0 = SCIPY_VERSION.release >= (1, 15, 0)
 @pytest.mark.parametrize(
     "dtype",
     [
-        numpy.dtype("<f4"), 
-        pytest.param(numpy.dtype(">f4"), marks=pytest.mark.skipif(SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258")), 
+        numpy.dtype("<f4"),
+        pytest.param(
+            numpy.dtype(">f4"),
+            marks=pytest.mark.skipif(
+                SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258"
+            ),
+        ),
         numpy.dtype("<f8"),
-        pytest.param(numpy.dtype(">f8"), marks=pytest.mark.skipif(SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258")), 
+        pytest.param(
+            numpy.dtype(">f8"),
+            marks=pytest.mark.skipif(
+                SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258"
+            ),
+        ),
     ],
 )
 def test_serialize_scipy_sparse(sparse_type, dtype):


### PR DESCRIPTION
Fixes CI.
Upstream issue: https://github.com/scipy/scipy/issues/22258

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
