### PR TITLE
Set usedforsecurity=False for md5 call in utils.color_of

### DIFF
--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -1283,7 +1283,7 @@ palette = [
 
 @toolz.memoize
 def color_of(x, palette=palette):
-    h = md5(str(x).encode())
+    h = md5(str(x).encode(), usedforsecurity=False)
     n = int(h.hexdigest()[:8], 16)
     return palette[n % len(palette)]
 


### PR DESCRIPTION
Closes #8974
Adds `usedforsecurity=False` to `md5` call in `utils.color_of`. This will allow this function to work on FIPS systems where the md5 function is blocked for `usedforsecurity=True`.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
