### PR TITLE
Handle Client(..., security=False)

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1146,7 +1146,7 @@ class Client(SyncMethodMixin):
         if security is None and isinstance(address, str):
             security = _maybe_call_security_loader(address)
 
-        if security is None:
+        if security is None or security is False:
             security = Security()
         elif isinstance(security, dict):
             security = Security(**security)

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -210,6 +210,15 @@ async def test_security_dict_input_no_security():
 
 
 @gen_test()
+async def test_security_bool_input_disabled_security():
+    async with Scheduler(dashboard_address=":0", security=False) as s:
+        async with Worker(s.address, security=False):
+            async with Client(s.address, security=False, asynchronous=True) as c:
+                result = await c.submit(inc, 1)
+                assert result == 2
+
+
+@gen_test()
 async def test_security_dict_input():
     conf = tls_config()
     ca_file = conf["distributed"]["comm"]["tls"]["ca-file"]

--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -215,6 +215,7 @@ async def test_security_bool_input_disabled_security():
         async with Worker(s.address, security=False):
             async with Client(s.address, security=False, asynchronous=True) as c:
                 result = await c.submit(inc, 1)
+                assert c.security.require_encryption is False
                 assert result == 2
 
 


### PR DESCRIPTION
Currently the `security` kwarg of `Client` takes a few options:

- A `Security` object with certs loaded
- A `dict` of certs that get converted into a `Security` object
- `True` to auto generate certs
- `None` to skip using TLS (the default)

Given that it accepts a `bool` type this can cause confusion when passing `False`, which currently raises an exception #8973.

This PR makes `security=False` behave the same as `security=None`.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Closes #8973
