### PR TITLE
Removed big-endian sparse tests

### DIFF
--- a/distributed/protocol/tests/test_cupy.py
+++ b/distributed/protocol/tests/test_cupy.py
@@ -74,7 +74,7 @@ def test_serialize_cupy_from_rmm(size):
 )
 @pytest.mark.parametrize(
     "dtype",
-    [numpy.dtype("<f4"), numpy.dtype(">f4"), numpy.dtype("<f8"), numpy.dtype(">f8")],
+    [numpy.dtype("<f4"), numpy.dtype("<f8")],
 )
 @pytest.mark.parametrize("serializer", ["cuda", "dask", "pickle"])
 def test_serialize_cupy_sparse(sparse_name, dtype, serializer):

--- a/distributed/protocol/tests/test_scipy.py
+++ b/distributed/protocol/tests/test_scipy.py
@@ -30,19 +30,7 @@ SCIPY_GE_1_15_0 = SCIPY_VERSION.release >= (1, 15, 0)
     "dtype",
     [
         numpy.dtype("<f4"),
-        pytest.param(
-            numpy.dtype(">f4"),
-            marks=pytest.mark.skipif(
-                SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258"
-            ),
-        ),
         numpy.dtype("<f8"),
-        pytest.param(
-            numpy.dtype(">f8"),
-            marks=pytest.mark.skipif(
-                SCIPY_GE_1_15_0, reason="https://github.com/scipy/scipy/issues/22258"
-            ),
-        ),
     ],
 )
 def test_serialize_scipy_sparse(sparse_type, dtype):


### PR DESCRIPTION
Follow up to https://github.com/dask/distributed/pull/8977. Based on https://github.com/scipy/scipy/issues/22258#issuecomment-2573450299, it does look like removing these test cases is appropriate (apparently big-endian arrays weren't ever really supported?), so I've changed the skips to removals, and also removed from the cupy file.