### PR TITLE
Restructure cudf spill metrics and test

### DIFF
--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -3224,21 +3224,17 @@ else:
     DEFAULT_METRICS["rmm"] = rmm_metric
     del _rmm
 
-# avoid importing cuDF unless explicitly enabled
+
+async def cudf_metric(worker):
+    # avoid importing optional cudf at the top-level
+    from distributed.diagnostics import cudf
+
+    result = await offload(cudf.real_time)
+    return result
+
+
 if dask.config.get("distributed.diagnostics.cudf"):
-    try:
-        import cudf as _cudf  # noqa: F401
-    except Exception:
-        pass
-    else:
-        from distributed.diagnostics import cudf
-
-        async def cudf_metric(worker):
-            result = await offload(cudf.real_time)
-            return result
-
-        DEFAULT_METRICS["cudf"] = cudf_metric
-        del _cudf
+    DEFAULT_METRICS["cudf"] = cudf_metric
 
 
 def print(


### PR DESCRIPTION
This updates how we define the cuDF spilling metric and test. The primary motivation is to make it easier to test this within the main `pytest` process. Previously, the test was skipped if the environment wasn't configured with several environment variables controlling behavior in both distributed and cudf.

The cuDF config can be changed programmatically within the test process without issue, so I added a new fixture that sets & unsets the values we need for this test.

The distributed configuration is a bit harder, since we rely on some side-effects of `import dask.worker` to define a new metric and add it to the list of `DEFAULT_METRICS`. This makes it challenging for us to change this in our tests (not to mention users).

I changed `dask.worker` to always define this metric-collecting function, but only add it to `DEFAULT_METRICS` when `distributed.diagnostics.cudf` is set. This should result in the same behavior (whether you have dask-cudf installed or not, and whether that option is set or not) for most cases, but makes it a bit easier to test. The only change in behavior is if you have `distributed.diagnostics.cudf` set but *don't* have dask-cudf installed on your workers. Now we'll error when trying to start the metric rather than silently failing to collect that metric.

And I split the test in two:

1. The original test for the metrics, but updated to explicitly add the cuDF spill metric to the worker metrics, since the environment might not be configured to do that automatically
2. A second test that ensures that the metric is present by default when the environment is configured (by monkeypatching the environment and clearing the import cache before re-importing dask.worker).
