### PR TITLE
Skip unwritable test if root

### DIFF
--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -429,6 +429,7 @@ async def test_local_directory(s):
 
 
 @pytest.mark.skipif(WINDOWS, reason="Need POSIX filesystem permissions and UIDs")
+@pytest.mark.skipif(os.getuid() == 0, reason="Must not be root")
 @gen_cluster(nthreads=[])
 async def test_unwriteable_dask_worker_space(s, tmp_path):
     os.mkdir(f"{tmp_path}/dask-scratch-space", mode=0o500)


### PR DESCRIPTION
Very minor, but this test happens to fail when run as `root`, since the "unwritable" directory will be writable by root.