### PR TITLE
Fix windows ci to avoid os.getuid

### DIFF
--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -428,8 +428,10 @@ async def test_local_directory(s):
                 assert n.process.worker_dir.count("dask-scratch-space") == 1
 
 
-@pytest.mark.skipif(WINDOWS, reason="Need POSIX filesystem permissions and UIDs")
-@pytest.mark.skipif(os.getuid() == 0, reason="Must not be root")
+@pytest.mark.skipif(
+    WINDOWS or os.getuid() == 0,
+    reason="Need POSIX filesystem permissions and UIDs and Must not be root",
+)
 @gen_cluster(nthreads=[])
 async def test_unwriteable_dask_worker_space(s, tmp_path):
     os.mkdir(f"{tmp_path}/dask-scratch-space", mode=0o500)


### PR DESCRIPTION
Closes #xxxx

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
