### PR TITLE
Avoid handling stale long-running messages on scheduler

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6075,9 +6075,6 @@ class Scheduler(SchedulerState, ServerNode):
             return
 
         ts = self.tasks[key]
-        steal = self.extensions.get("stealing")
-        if steal is not None:
-            steal.remove_key_from_stealable(ts)
 
         ws = ts.processing_on
         if ws is None:
@@ -6091,6 +6088,10 @@ class Scheduler(SchedulerState, ServerNode):
                 ts,
             )
             return
+
+        steal = self.extensions.get("stealing")
+        if steal is not None:
+            steal.remove_key_from_stealable(ts)
 
         if compute_duration is not None:
             old_duration = ts.prefix.duration_average

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6086,7 +6086,7 @@ class Scheduler(SchedulerState, ServerNode):
             logger.debug("Received long-running signal from duplicate task. Ignoring.")
             return
 
-        if ws.address != worker:
+        if ws.address != worker or ts.run_id != run_id:
             logger.debug(
                 "Received stale long-running signal from worker %s for task %s. Ignoring.",
                 worker,

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6057,7 +6057,12 @@ class Scheduler(SchedulerState, ServerNode):
             self.transitions({key: "released"}, stimulus_id)
 
     def handle_long_running(
-        self, key: Key, worker: str, compute_duration: float | None, stimulus_id: str
+        self,
+        key: Key,
+        worker: str,
+        run_id: int,
+        compute_duration: float | None,
+        stimulus_id: str,
     ) -> None:
         """A task has seceded from the thread pool
 

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -575,11 +575,13 @@ def test_resumed_with_different_resources(ws_with_running_task, done_ev_cls):
     assert ws.available_resources == {"R": 0}
 
     instructions = ws.handle_stimulus(
-        ComputeTaskEvent.dummy("x", stimulus_id="s2", resource_restrictions={"R": 0.4})
+        ComputeTaskEvent.dummy(
+            "x", run_id=0, stimulus_id="s2", resource_restrictions={"R": 0.4}
+        )
     )
     if prev_state == "long-running":
         assert instructions == [
-            LongRunningMsg(key="x", compute_duration=None, stimulus_id="s2")
+            LongRunningMsg(key="x", run_id=0, compute_duration=None, stimulus_id="s2")
         ]
     else:
         assert not instructions

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -509,8 +509,9 @@ class RescheduleMsg(SendMessageToScheduler):
 class LongRunningMsg(SendMessageToScheduler):
     op = "long-running"
 
-    __slots__ = ("key", "compute_duration")
+    __slots__ = ("key", "run_id", "compute_duration")
     key: Key
+    run_id: int
     compute_duration: float | None
 
 
@@ -2171,7 +2172,10 @@ class WorkerState:
             ts.state = "long-running"
             ts.previous = None
             smsg = LongRunningMsg(
-                key=ts.key, compute_duration=None, stimulus_id=stimulus_id
+                key=ts.key,
+                run_id=ts.run_id,
+                compute_duration=None,
+                stimulus_id=stimulus_id,
             )
             return {}, [smsg]
         else:
@@ -2276,7 +2280,10 @@ class WorkerState:
         self.long_running.add(ts)
 
         smsg = LongRunningMsg(
-            key=ts.key, compute_duration=compute_duration, stimulus_id=stimulus_id
+            key=ts.key,
+            run_id=ts.run_id,
+            compute_duration=compute_duration,
+            stimulus_id=stimulus_id,
         )
         return merge_recs_instructions(
             ({}, [smsg]),


### PR DESCRIPTION
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
