### PR TITLE
Fcourtial/fix retire workers 500

### DIFF
--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -30,9 +30,7 @@ class RetireWorkersHandler(RequestHandler):
                 if not isinstance(d, dict):
                     return d
                 return {
-                    k: clean_dict(v)
-                    for k, v in d.items()
-                    if not isinstance(k, tuple)
+                    k: clean_dict(v) for k, v in d.items() if not isinstance(k, tuple)
                 }
 
             workers_info = clean_dict(workers_info)

--- a/distributed/http/scheduler/api.py
+++ b/distributed/http/scheduler/api.py
@@ -24,6 +24,18 @@ class RetireWorkersHandler(RequestHandler):
             else:
                 workers = params.get("workers", {})
                 workers_info = await scheduler.retire_workers(workers=workers)
+
+            # digests_total_since_heartbeat contains tuples as keys which are not json serializable
+            def clean_dict(d):
+                if not isinstance(d, dict):
+                    return d
+                return {
+                    k: clean_dict(v)
+                    for k, v in d.items()
+                    if not isinstance(k, tuple)
+                }
+
+            workers_info = clean_dict(workers_info)
             self.write(json.dumps(workers_info))
         except Exception as e:
             self.set_status(500, str(e))

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -732,6 +732,7 @@ async def test_retire_workers_with_tuple_keys(c, s, a, b):
     aiohttp = pytest.importorskip("aiohttp")
 
     worker_address = "tcp://172.17.0.3:39571"
+
     async def mock_retire_workers(*args, **kwargs):
         # Return problematic data structure
         # tuple are not json serializable
@@ -740,10 +741,16 @@ async def test_retire_workers_with_tuple_keys(c, s, a, b):
                 "type": "Worker",
                 "metrics": {
                     "digests_total_since_heartbeat": {
-                        ("execute", "slowadd", "thread-cpu", "seconds"): 0.0003396660000000093,
+                        (
+                            "execute",
+                            "slowadd",
+                            "thread-cpu",
+                            "seconds",
+                        ): 0.0003396660000000093,
                     },
-                }
-            }}
+                },
+            }
+        }
 
     # Replace the method with our mock
     s.retire_workers = mock_retire_workers

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -728,6 +728,46 @@ async def test_retire_workers(c, s, a, b):
         + ["distributed.http.scheduler.api"]
     },
 )
+async def test_retire_workers_with_tuple_keys(c, s, a, b):
+    aiohttp = pytest.importorskip("aiohttp")
+
+    worker_address = "tcp://172.17.0.3:39571"
+    async def mock_retire_workers(*args, **kwargs):
+        # Return problematic data structure
+        # tuple are not json serializable
+        return {
+            worker_address: {
+                "type": "Worker",
+                "metrics": {
+                    "digests_total_since_heartbeat": {
+                        ("execute", "slowadd", "thread-cpu", "seconds"): 0.0003396660000000093,
+                    },
+                }
+            }}
+
+    # Replace the method with our mock
+    s.retire_workers = mock_retire_workers
+
+    async with aiohttp.ClientSession() as session:
+        params = {"workers": [a.address, b.address]}
+        async with session.post(
+            "http://localhost:%d/api/v1/retire_workers" % s.http_server.port,
+            json=params,
+        ) as resp:
+            assert resp.status == 200
+            assert resp.headers["Content-Type"] == "application/json"
+            retired_workers_info = json.loads(await resp.text())
+            assert worker_address in retired_workers_info
+
+
+@gen_cluster(
+    client=True,
+    clean_kwargs={"threads": False},
+    config={
+        "distributed.scheduler.http.routes": DEFAULT_ROUTES
+        + ["distributed.http.scheduler.api"]
+    },
+)
 async def test_get_workers(c, s, a, b):
     aiohttp = pytest.importorskip("aiohttp")
 


### PR DESCRIPTION
Fix JSON serialization error in retire_workers API endpoint

When retiring workers through the HTTP API endpoint `/api/v1/retire_workers`, the response includes worker metrics that contain tuple keys (e.g., `digests_total_since_heartbeat`). These tuple keys cannot be JSON serialized, causing a 500 error that breaks clients like the Dask Kubernetes Operator.

This PR:
- Adds a `clean_dict` function to delete tuple keys during serialization
- Preserves the dictionary structure while making it JSON-serializable

Example:
```python
# Before - causes 500 error
{
    "metrics": {
        ("execute", "thread-cpu"): 1
    }
}

# After - properly serialized
{
    "metrics": {}
}