### PR TITLE
Increase default work-stealing interval by 10x

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -137,7 +137,9 @@ async def test_counters(c, s, a, b):
         await asyncio.sleep(0.01)
 
 
-@gen_cluster(client=True)
+@gen_cluster(
+    client=True, config={"distributed.scheduler.work-stealing-interval": "100ms"}
+)
 async def test_stealing_events(c, s, a, b):
     se = StealingEvents(s)
 

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -21,7 +21,7 @@ distributed:
     idle-timeout: null       # Shut down after this duration, like "1h" or "30 minutes"
     no-workers-timeout: null # If a task remains unrunnable for longer than this, it fails.
     work-stealing: True     # workers should steal tasks from each other
-    work-stealing-interval: 100ms  # Callback time for work stealing
+    work-stealing-interval: 1s  # Callback time for work stealing
     worker-saturation: 1.1  # Send this fraction of nthreads root tasks to workers
     rootish-taskgroup: 5  # number of dependencies of a rootish tg
     rootish-taskgroup-dependencies: 5  # number of dependencies of the dependencies of the rootish tg

--- a/distributed/http/scheduler/tests/test_stealing_http.py
+++ b/distributed/http/scheduler/tests/test_stealing_http.py
@@ -25,7 +25,9 @@ async def test_prometheus(c, s, a, b):
     assert active_metrics == expected_metrics
 
 
-@gen_cluster(client=True)
+@gen_cluster(
+    client=True, config={"distributed.scheduler.work-stealing-interval": "100ms"}
+)
 async def test_prometheus_collect_count_total_by_cost_multipliers(c, s, a, b):
     pytest.importorskip("prometheus_client")
 
@@ -58,7 +60,9 @@ async def test_prometheus_collect_count_total_by_cost_multipliers(c, s, a, b):
     assert count == expected_count
 
 
-@gen_cluster(client=True)
+@gen_cluster(
+    client=True, config={"distributed.scheduler.work-stealing-interval": "100ms"}
+)
 async def test_prometheus_collect_cost_total_by_cost_multipliers(c, s, a, b):
     pytest.importorskip("prometheus_client")
 

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -104,7 +104,11 @@ async def test_steal_cheap_data_slow_computation(c, s, a, b):
 
 
 @pytest.mark.slow
-@gen_cluster(client=True, nthreads=[("", 1)] * 2, config=NO_AMM)
+@gen_cluster(
+    client=True,
+    nthreads=[("", 1)] * 2,
+    config={"distributed.scheduler.work-stealing-interval": "100ms", **NO_AMM},
+)
 async def test_steal_expensive_data_slow_computation(c, s, a, b):
     np = pytest.importorskip("numpy")
 
@@ -974,7 +978,7 @@ async def test_lose_task(c, s, a, b):
     assert "Error" not in out
 
 
-@pytest.mark.parametrize("interval, expected", [(None, 100), ("500ms", 500), (2, 2)])
+@pytest.mark.parametrize("interval, expected", [(None, 1000), ("500ms", 500), (2, 2)])
 @gen_cluster(nthreads=[], config={"distributed.scheduler.work-stealing": False})
 async def test_parse_stealing_interval(s, interval, expected):
     from distributed.scheduler import WorkStealing

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -416,12 +416,7 @@ async def test_new_worker_steals(c, s, a):
     client=True,
     config={"distributed.scheduler.work-stealing-interval": "100ms"},
 )
-async def test_work_steal_allow_other_workers(
-    c,
-    s,
-    a,
-    b,
-):
+async def test_work_steal_allow_other_workers(c, s, a, b):
     # Note: this test also verifies the baseline for all other tests below
     futures = c.map(
         slowinc, range(100), workers=a.address, allow_other_workers=True, delay=0.05
@@ -552,11 +547,7 @@ async def test_steal_resource_restrictions(c, s, a):
     nthreads=[("", 1, {"resources": {"A": 2, "C": 1}})],
     config={"distributed.scheduler.work-stealing-interval": "100ms"},
 )
-async def test_steal_resource_restrictions_asym_diff(
-    c,
-    s,
-    a,
-):
+async def test_steal_resource_restrictions_asym_diff(c, s, a):
     # See https://github.com/dask/distributed/issues/5565
     future = c.submit(slowinc, 1, delay=0.1, workers=a.address)
     await future
@@ -856,12 +847,7 @@ async def test_restart(c, s, a, b):
     client=True,
     config={"distributed.scheduler.work-stealing-interval": "100ms"},
 )
-async def test_steal_twice(
-    c,
-    s,
-    a,
-    b,
-):
+async def test_steal_twice(c, s, a, b):
     x = c.submit(inc, 1, workers=a.address)
     await wait(x)
 
@@ -960,12 +946,7 @@ async def test_dont_steal_already_released(c, s, a, b):
     nthreads=[("127.0.0.1", 1)] * 2,
     config={"distributed.scheduler.work-stealing-interval": "100ms"},
 )
-async def test_dont_steal_long_running_tasks(
-    c,
-    s,
-    a,
-    b,
-):
+async def test_dont_steal_long_running_tasks(c, s, a, b):
     def long(delay):
         with worker_client() as c:
             sleep(delay)


### PR DESCRIPTION
On a normal cloud setup, the staling interval is barely large enough to accomodate the roundtrips required for moving the tasks, not to mention fetching dependencies or performing actual work. I'm increasing the interval to one second (10x) which gives a little more time for actual progress to be made.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
