### PR TITLE
Bump `test_ucx::test_stress` timeout

### DIFF
--- a/distributed/comm/tests/test_ucx.py
+++ b/distributed/comm/tests/test_ucx.py
@@ -293,7 +293,7 @@ async def test_ucx_localcluster(ucx_loop, processes, cleanup):
 
 
 @pytest.mark.slow
-@gen_test(timeout=60)
+@gen_test(timeout=120)
 async def test_stress(
     ucx_loop,
 ):


### PR DESCRIPTION
This bumps the timeout on `distributed/comm/tests/test_ucx.py::test_stress` from 60s to 120s. On the machine I have access to it takes about 70s to run.

I haven't looked into whether something has happened to slow this test down (cc @pentschev if you have thoughts on whether this is worth me looking into more).