### PR TITLE
Remove traceback from sizeof failure warning

### DIFF
--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -16,8 +16,10 @@ def safe_sizeof(obj: object, default_size: float = 1e6) -> int:
     try:
         return sizeof(obj)
     except Exception:
-        logger.warning(
+        error_message = (
             f"Sizeof calculation for object of type '{typename(obj)}' failed. "
             f"Defaulting to {format_bytes(int(default_size))}",
         )
+        logger.warning(error_message)
+        logger.debug(error_message, exc_info=True)
         return int(default_size)

--- a/distributed/sizeof.py
+++ b/distributed/sizeof.py
@@ -19,6 +19,5 @@ def safe_sizeof(obj: object, default_size: float = 1e6) -> int:
         logger.warning(
             f"Sizeof calculation for object of type '{typename(obj)}' failed. "
             f"Defaulting to {format_bytes(int(default_size))}",
-            exc_info=True,
         )
         return int(default_size)


### PR DESCRIPTION
Closes #8566

Logging the traceback from a `sizeof` failure seems like it doesn't add much value to users. It might be helpful when debugging why it's happening.

This PR removes the traceback from the warning but adds a debug log which includes the traceback. This allows folks to see it when they want to by setting the appropriate log level.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
