### PR TITLE
Remove IP lookup from `inproc` protocol

### DIFF
--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -15,7 +15,6 @@ from tornado.ioloop import IOLoop
 from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend, backends
 from distributed.protocol.serialize import _nested_deserialize
-from distributed.utils import get_ip
 
 logger = logging.getLogger(__name__)
 
@@ -38,10 +37,7 @@ class Manager:
     @property
     def ip(self):
         if not self._ip:
-            try:
-                self._ip = get_ip()
-            except OSError:
-                self._ip = "127.0.0.1"
+            self._ip = "127.0.0.1"
         return self._ip
 
     def add_listener(self, addr, listener):


### PR DESCRIPTION
Closes #8559 

When setting `LocalCluster(processes=False)` Dask uses the `inproc` protocol to communicate between workers. 

During the setup of the `inproc` protocol it tries to look up the IP address of the machine, which is unnecessary because all communication is inter-process. If you turn off your wifi and try to create it you will get a warning (see #8559).

```ipython
In [1]: from distributed import LocalCluster
   ...: cluster = LocalCluster(processes=False)
/Users/jtomlinson/miniconda3/envs/dask/lib/python3.11/site-packages/distributed/utils.py:181: RuntimeWarning: Couldn't detect a suitable IP address for reaching '8.8.8.8', defaulting to hostname: [Errno 51] Network is unreachable
  warnings.warn(
```

This PR skips looking up the IP when using the `inproc` protocol and just assumes our IP is `127.0.0.1`.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
