### PR TITLE
Fix CI by using `client.persist(collection)` instead of `collection.persist()`

### DIFF
--- a/distributed/comm/tests/test_ws.py
+++ b/distributed/comm/tests/test_ws.py
@@ -125,7 +125,7 @@ async def test_collections(c, s, a, b):
     da = pytest.importorskip("dask.array")
     x = da.random.random((1000, 1000), chunks=(100, 100))
     x = x + x.T
-    await x.persist()
+    await c.persist(x)
 
 
 @gen_cluster(client=True, scheduler_kwargs={"protocol": "ws://"})

--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -833,9 +833,9 @@ async def test_TaskGraph(c, s, a, b):
     json.dumps(gp.node_source.data)
 
     da = pytest.importorskip("dask.array")
-    x = da.random.random((20, 20), chunks=(10, 10)).persist()
+    x = c.persist(da.random.random((20, 20), chunks=(10, 10)))
     y = (x + x.T) - x.mean(axis=0)
-    y = y.persist()
+    y = c.persist(y)
     await wait(y)
 
     gp.update()
@@ -912,12 +912,12 @@ async def test_TaskGraph_complex(c, s, a, b):
     da = pytest.importorskip("dask.array")
     gp = TaskGraph(s)
     x = da.random.random((2000, 2000), chunks=(1000, 1000))
-    y = ((x + x.T) - x.mean(axis=0)).persist()
+    y = c.persist((x + x.T) - x.mean(axis=0))
     await wait(y)
     gp.update()
     assert len(gp.layout.index) == len(gp.node_source.data["x"])
     assert len(gp.layout.index) == len(s.tasks)
-    z = (x - y).sum().persist()
+    z = c.persist((x - y).sum())
     await wait(z)
     gp.update()
     assert len(gp.layout.index) == len(gp.node_source.data["x"])
@@ -1177,10 +1177,10 @@ async def test_memory_by_key(c, s, a, b):
     mbk = MemoryByKey(s)
 
     da = pytest.importorskip("dask.array")
-    x = (da.random.random((20, 20), chunks=(10, 10)) + 1).persist(optimize_graph=False)
+    x = c.persist(da.random.random((20, 20), chunks=(10, 10)) + 1, optimize_graph=False)
     await x
 
-    y = await dask.delayed(inc)(1).persist()
+    y = await c.persist(dask.delayed(inc)(1))
 
     mbk.update()
     assert mbk.source.data["name"] == ["add", "inc"]
@@ -1260,10 +1260,10 @@ async def test_aggregate_action(c, s, a, b):
     mbk = AggregateAction(s)
 
     da = pytest.importorskip("dask.array")
-    x = (da.ones((20, 20), chunks=(10, 10)) + 1).persist(optimize_graph=False)
+    x = c.persist(da.ones((20, 20), chunks=(10, 10)) + 1, optimize_graph=False)
 
     await x
-    y = await dask.delayed(inc)(1).persist()
+    y = await c.persist(dask.delayed(inc)(1))
     z = (x + x.T) - x.mean(axis=0)
     await c.compute(z.sum())
 
@@ -1289,9 +1289,9 @@ async def test_compute_per_key(c, s, a, b):
     mbk = ComputePerKey(s)
 
     da = pytest.importorskip("dask.array")
-    x = (da.ones((20, 20), chunks=(10, 10)) + 1).persist(optimize_graph=False)
+    x = c.persist(da.ones((20, 20), chunks=(10, 10)) + 1, optimize_graph=False)
     await x
-    y = await dask.delayed(inc)(1).persist()
+    y = await c.persist(dask.delayed(inc)(1))
     z = (x + x.T) - x.mean(axis=0)
     zsum = z.sum()
     await c.compute(zsum)
@@ -1367,7 +1367,7 @@ async def test_shuffling(c, s, a, b):
         freq="10 s",
     )
     with dask.config.set({"dataframe.shuffle.method": "p2p"}):
-        df2 = df.shuffle("x").persist()
+        df2 = c.persist(df.shuffle("x"))
     start = time()
     while not ss.source.data["comm_written"]:
         await asyncio.gather(*[a.heartbeat(), b.heartbeat()])

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -1404,7 +1404,7 @@ async def test_tail(c, s, a, b):
     del full
     while s.tasks:
         await asyncio.sleep(0)
-    partial = await x.tail(compute=False).persist()  # Only ask for one key
+    partial = await c.persist(x.tail(compute=False))  # Only ask for one key
 
     assert len(s.tasks) < ntasks_full
     del partial

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3407,68 +3407,6 @@ def test_default_get(loop_in_thread):
         assert dask.base.get_scheduler() == pre_get
 
 
-@gen_cluster(config={"scheduler": "sync"}, nthreads=[])
-async def test_get_scheduler_default_client_config_interleaving(s):
-    # This test is using context managers intentionally. We should not refactor
-    # this to use it in more places to make the client closing cleaner.
-    with pytest.warns(UserWarning):
-        assert dask.base.get_scheduler() == dask.local.get_sync
-        with dask.config.set(scheduler="threads"):
-            assert dask.base.get_scheduler() == dask.threaded.get
-            client = await Client(s.address, set_as_default=False, asynchronous=True)
-            try:
-                assert dask.base.get_scheduler() == dask.threaded.get
-            finally:
-                await client.close()
-
-            client = await Client(s.address, set_as_default=True, asynchronous=True)
-            try:
-                assert dask.base.get_scheduler() == client.get
-            finally:
-                await client.close()
-            assert dask.base.get_scheduler() == dask.threaded.get
-
-            # FIXME: As soon as async with uses as_current this will be true as well
-            # async with Client(s.address, set_as_default=False, asynchronous=True) as c:
-            #     assert dask.base.get_scheduler() == c.get
-            # assert dask.base.get_scheduler() == dask.threaded.get
-
-            client = await Client(s.address, set_as_default=False, asynchronous=True)
-            try:
-                assert dask.base.get_scheduler() == dask.threaded.get
-                with client.as_current():
-                    sc = dask.base.get_scheduler()
-                    assert sc == client.get
-                assert dask.base.get_scheduler() == dask.threaded.get
-            finally:
-                await client.close()
-
-            # If it comes to a race between default and current, current wins
-            client = await Client(s.address, set_as_default=True, asynchronous=True)
-            client2 = await Client(s.address, set_as_default=False, asynchronous=True)
-            try:
-                with client2.as_current():
-                    assert dask.base.get_scheduler() == client2.get
-                assert dask.base.get_scheduler() == client.get
-            finally:
-                await client.close()
-                await client2.close()
-
-            assert dask.base.get_scheduler() == dask.threaded.get
-
-        assert dask.base.get_scheduler() == dask.local.get_sync
-
-        client = await Client(s.address, set_as_default=True, asynchronous=True)
-        try:
-            assert dask.base.get_scheduler() == client.get
-            with dask.config.set(scheduler="threads"):
-                assert dask.base.get_scheduler() == dask.threaded.get
-                with client.as_current():
-                    assert dask.base.get_scheduler() == client.get
-        finally:
-            await client.close()
-
-
 @gen_cluster()
 async def test_ensure_default_client(s, a, b):
     # Note: this test will fail if you use `async with Client`

--- a/distributed/tests/test_computations.py
+++ b/distributed/tests/test_computations.py
@@ -14,10 +14,10 @@ async def test_computations(c, s, a, b):
     da = pytest.importorskip("dask.array")
 
     x = da.ones(100, chunks=(10,))
-    y = (x + 1).persist()
+    y = c.persist(x + 1)
     await y
 
-    z = (x - 2).persist()
+    z = c.persist(x - 2)
     await z
 
     assert len(s.computations) == 2

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -803,7 +803,7 @@ async def test_malloc_trim_threshold(c, s, a):
     da = pytest.importorskip("dask.array")
 
     arr = da.random.random(2**29 // 8, chunks="512 kiB")  # 0.5 GiB
-    arr = arr.persist()
+    arr = c.persist(arr)
     await wait(arr)
     # Wait for heartbeat
     await async_poll_for(lambda: s.memory.process > 2**29, timeout=5)

--- a/distributed/tests/test_priorities.py
+++ b/distributed/tests/test_priorities.py
@@ -151,10 +151,10 @@ async def test_compute(c, s, a, pause):
 @gen_blockable_cluster
 async def test_persist(c, s, a, pause):
     async with block_worker(c, s, a, pause):
-        low = dinc(1, dask_key_name="low").persist(priority=-1)
+        low = c.persist(dinc(1, dask_key_name="low"), priority=-1)
         ev = Event()
         clog = c.submit(lambda ev: ev.wait(), ev, key="clog")
-        high = dinc(2, dask_key_name="high").persist(priority=1)
+        high = c.persist(dinc(2, dask_key_name="high"), priority=1)
 
     await wait(high)
     assert all(ws.processing for ws in s.workers.values())
@@ -209,8 +209,8 @@ async def test_repeated_persists_same_priority(c, s, a, pause):
     zs = [delayed(slowinc)(xs[i], delay=0.05, dask_key_name=f"z{i}") for i in range(10)]
 
     async with block_worker(c, s, a, pause, 30, 10):
-        ys = dask.persist(*ys)
-        zs = dask.persist(*zs)
+        ys = c.persist(ys)
+        zs = c.persist(zs)
 
     while (
         sum(t.state == "memory" for t in s.tasks.values()) < 5

--- a/distributed/tests/test_resources.py
+++ b/distributed/tests/test_resources.py
@@ -219,7 +219,7 @@ async def test_resources_str(c, s, a, b):
 
     x = dd.from_pandas(pd.DataFrame({"A": [1, 2], "B": [3, 4]}), npartitions=1)
     y = x.apply(lambda row: row.sum(), axis=1, meta=(None, "int64"))
-    yy = y.persist(resources={"MyRes": 1})
+    yy = c.persist(y, resources={"MyRes": 1})
     await wait(yy)
 
     ts_first = s.tasks[y.__dask_keys__()[0]]

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -231,7 +231,7 @@ def test_decide_worker_coschedule_order_neighbors(ndeps, nthreads):
             )
             random_keys = set(flatten(x.__dask_keys__()))
 
-        xx, xsum = dask.persist(x, x.sum(axis=1, split_every=20))
+        xx, xsum = c.persist([x, x.sum(axis=1, split_every=20)])
         await xsum
 
         # Check that each chunk-row of the array is (mostly) stored on the same worker
@@ -2236,7 +2236,7 @@ async def test_dont_recompute_if_persisted_4(c, s, a, b):
     while s.tasks["x"].state == "memory":
         await asyncio.sleep(0.01)
 
-    yyy, zzz = dask.persist(y, z)
+    yyy, zzz = c.persist([y, z])
     await wait([yyy, zzz])
 
     new = s.story("x")

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -342,14 +342,14 @@ async def test_mismatched_span(c, s, a, use_default):
     s.add_plugin(MyPlugin(), name="my-plugin")
 
     if use_default:
-        x0 = delayed(inc)(1, dask_key_name=("x", 0)).persist()
+        x0 = c.persist(delayed(inc)(1, dask_key_name=("x", 0)))
     else:
         with span("p1"):
-            x0 = delayed(inc)(1, dask_key_name=("x", 0)).persist()
+            x0 = c.persist(delayed(inc)(1, dask_key_name=("x", 0)))
     await x0
 
     with span("p2"):
-        x1 = delayed(inc)(2, dask_key_name=("x", 1)).persist()
+        x1 = c.persist(delayed(inc)(2, dask_key_name=("x", 1)))
     await x1
     span_name = ("default",) if use_default else ("p1",)
 

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -1195,7 +1195,7 @@ async def test_statistical_profiling_2(c, s, a, b):
 
     while True:
         x = da.random.random(1000000, chunks=(10000,))
-        y = (x + x * 2) - x.sum().persist()
+        y = c.persist((x + x * 2) - x.sum())
         await wait(y)
 
         profile = await a.get_profile()


### PR DESCRIPTION
CI has been pretty broken ever since we merged https://github.com/dask/dask/pull/11790.

This PR fixes that.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
