### PR TITLE
SpecCluster: add option to *not* shut down the scheduler when the cluster is closed

### DIFF
--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -519,3 +519,28 @@ async def test_bad_close():
         await cluster.close()
 
     assert not record
+
+
+@gen_test()
+async def test_shutdown_scheduler_disabled():
+    async with SpecCluster(
+        workers=worker_spec,
+        scheduler=scheduler,
+        asynchronous=True,
+        shutdown_scheduler=False,
+    ) as cluster:
+        s = cluster.scheduler
+        assert isinstance(s, Scheduler)
+
+    assert s.status == Status.running
+
+
+@gen_test()
+async def test_shutdown_scheduler():
+    async with SpecCluster(
+        workers=worker_spec, scheduler=scheduler, asynchronous=True
+    ) as cluster:
+        s = cluster.scheduler
+        assert isinstance(s, Scheduler)
+
+    assert s.status == Status.closed


### PR DESCRIPTION
Add `shutdown_scheduler` option to `SpecCluster`. Defaults to `True` so this is backward compatible.

- Closes #7025
- Closes dask/dask-cloudprovider#375

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
