### PR TITLE
Bokeh 3.7 compatibility

### DIFF
--- a/distributed/dashboard/components/shared.py
+++ b/distributed/dashboard/components/shared.py
@@ -225,7 +225,12 @@ class ProfileTimePlot(DashboardComponent):
         )
         self.ts_plot.line("time", "count", source=self.ts_source)
         self.ts_plot.circle(
-            "time", "count", source=self.ts_source, color=None, selection_color="orange"
+            "time",
+            "count",
+            source=self.ts_source,
+            color=None,
+            selection_color="orange",
+            radius=1,
         )
         self.ts_plot.yaxis.visible = False
         self.ts_plot.grid.visible = False
@@ -373,7 +378,12 @@ class ProfileServer(DashboardComponent):
         )
         self.ts_plot.line("time", "count", source=self.ts_source)
         self.ts_plot.circle(
-            "time", "count", source=self.ts_source, color=None, selection_color="orange"
+            "time",
+            "count",
+            source=self.ts_source,
+            color=None,
+            selection_color="orange",
+            radius=1,
         )
         self.ts_plot.yaxis.visible = False
         self.ts_plot.grid.visible = False


### PR DESCRIPTION
radius is required now. In my testing, I couldn't provoke a meaningful difference varying that number so I just hard coded it to one. The circle that's being shown here are the measurements on the activity timeline, i.e. we also could do without

![image](https://github.com/user-attachments/assets/52b70062-ae66-4b32-a576-9a09ef7a6e55)
