### PR TITLE
Properly forward cancellation reason

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2796,7 +2796,15 @@ class Client(SyncMethodMixin):
     async def _cancel(self, futures, reason=None, msg=None, force=False):
         # FIXME: This method is asynchronous since interacting with the FutureState below requires an event loop.
         keys = list({f.key for f in futures_of(futures)})
-        self._send_to_scheduler({"op": "cancel-keys", "keys": keys, "force": force})
+        self._send_to_scheduler(
+            {
+                "op": "cancel-keys",
+                "keys": keys,
+                "force": force,
+                "reason": reason,
+                "msg": msg,
+            }
+        )
         for k in keys:
             st = self.futures.pop(k, None)
             if st is not None:

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1839,11 +1839,11 @@ class Client(SyncMethodMixin):
         if state is not None:
             state.lose()
 
-    def _handle_cancelled_keys(self, keys):
+    def _handle_cancelled_keys(self, keys, reason=None, msg=None):
         for key in keys:
             state = self.futures.get(key)
             if state is not None:
-                state.cancel()
+                state.cancel(reason=reason, msg=msg)
 
     def _handle_retried_key(self, key=None):
         state = self.futures.get(key)
@@ -2823,7 +2823,12 @@ class Client(SyncMethodMixin):
             Message that will be attached to the cancelled future
         """
         return self.sync(
-            self._cancel, futures, asynchronous=asynchronous, force=force, msg=msg
+            self._cancel,
+            futures,
+            asynchronous=asynchronous,
+            force=force,
+            msg=msg,
+            reason=reason,
         )
 
     async def _retry(self, futures):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4865,7 +4865,14 @@ class Scheduler(SchedulerState, ServerNode):
             lost_keys = self._find_lost_dependencies(dsk, dependencies, keys)
 
             if lost_keys:
-                self.report({"op": "cancelled-keys", "keys": lost_keys}, client=client)
+                self.report(
+                    {
+                        "op": "cancelled-keys",
+                        "keys": lost_keys,
+                        "reason": "lost dependencies",
+                    },
+                    client=client,
+                )
                 self.client_releases_keys(
                     keys=lost_keys, client=client, stimulus_id=stimulus_id
                 )

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2641,28 +2641,23 @@ async def test_futures_of_cancelled_raises(c, s, a, b):
         await asyncio.sleep(0.01)
     await c.cancel([x], reason="testreason")
 
-    # Note: The scheduler currently doesn't remember the reason but rather
-    # forgets the task immediately. The reason is currently. only raised if the
-    # client checks on it. Therefore, we expect an unknown reason and definitely
-    # not a scheduler disconnected which would otherwise indicate a bug, e.g. an
-    # AssertionError during transitioning.
-    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
+    with pytest.raises(CancelledError, match="reason: testreason"):
         await x
     while x.key in s.tasks:
         await asyncio.sleep(0.01)
 
-    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
+    with pytest.raises(CancelledError, match="reason: lost dependencies"):
         get_obj = c.get({"x": (inc, x), "y": (inc, 2)}, ["x", "y"], sync=False)
         gather_obj = c.gather(get_obj)
         await gather_obj
 
-    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
+    with pytest.raises(CancelledError, match="reason: lost dependencies"):
         await c.submit(inc, x)
 
-    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
+    with pytest.raises(CancelledError, match="reason: lost dependencies"):
         await c.submit(add, 1, y=x)
 
-    with pytest.raises(CancelledError, match="(reason: unknown|testreason)"):
+    with pytest.raises(CancelledError, match="reason: lost dependencies"):
         await c.gather(c.map(add, [1], y=x))
 
 


### PR DESCRIPTION
This will attach a reason to the exception if we know the cause. The causes spelled out here are still rather ambiguous but it's a little better than just "unknown"