### PR TITLE
Scheduler type annotations

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -886,7 +886,7 @@ class _MapExpr(Expr):
     def _meta(self):
         return []
 
-    def _layer(self):
+    def _layer(self) -> dict[Key, GraphNode]:
         dsk: _T_LowLevelGraph = {}
 
         if not self.kwargs:

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -251,8 +251,8 @@ class PreloadManager(Sequence[Preload]):
 
 def process_preloads(
     dask_server: Server | Client,
-    preload: str | list[str],
-    preload_argv: list[str] | list[list[str]],
+    preload: str | Sequence[str],
+    preload_argv: Sequence[str] | Sequence[Sequence[str]],
     *,
     file_dir: str | None = None,
 ) -> PreloadManager:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4867,19 +4867,7 @@ class Scheduler(SchedulerState, ServerNode):
             dsk = _cull(dsk, keys)
 
             if not internal_priority:
-                # Removing all non-local keys before calling order()
-                dsk_keys = set(
-                    dsk
-                )  # intersection() of sets is much faster than dict_keys
-                stripped_deps = {
-                    k: v.intersection(dsk_keys)
-                    for k, v in dependencies.items()
-                    if k in dsk_keys
-                }
-
-                internal_priority = await offload(
-                    dask.order.order, dsk=dsk, dependencies=stripped_deps
-                )
+                internal_priority = await offload(dask.order.order, dsk=dsk)
             ordering_done = time()
 
             logger.debug("Ordering done.")

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -1465,7 +1465,7 @@ async def test_story(c, s, a, b):
 @gen_cluster(client=True, nthreads=[])
 async def test_scatter_no_workers(c, s, direct):
     with pytest.raises(TimeoutError):
-        await s.scatter(data={"x": 1}, client="alice", timeout=0.1)
+        await s.scatter(data={"x": 1}, client="alice", timeout=0.1, workers=None)
 
     start = time()
     with pytest.raises(TimeoutError):
@@ -4516,12 +4516,6 @@ async def test_worker_state_unique_regardless_of_address(s, w):
     assert ws1 is not ws2
     assert ws1 != ws2
     assert hash(ws1) != ws2
-
-
-@gen_cluster(nthreads=[("", 1)])
-async def test_scheduler_close_fast_deprecated(s, w):
-    with pytest.warns(FutureWarning):
-        await s.close(fast=True)
 
 
 def test_runspec_regression_sync(loop):

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -33,7 +33,7 @@ def get_digests(
     d = w.digests_total if isinstance(w, Worker) else w.cumulative_worker_metrics
     digests = {
         k: v
-        for k, v in d.items()
+        for k, v in d.items()  # type: ignore
         if k
         not in {"latency", "tick-duration", "transfer-bandwidth", "transfer-duration"}
         and (any(a in k for a in allow) or not allow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ allow_incomplete_defs = true
 # Recent or recently overhauled modules featuring stricter validation
 module = [
     "distributed.active_memory_manager",
+    "distributed.scheduler",
     "distributed.spans",
     "distributed.system_monitor",
     "distributed.worker_memory",


### PR DESCRIPTION
Since the introduction of the Task class we are keeping redundant dependeny sets on the Scheduler. I wanted to look into this since this is one of the major sources of memory use on the scheduler today. This would trigger a moderate refactoring that would replace the TaskState.dependency sets again with keys instead of the TaskState classes themselves. That would also be a change that would help a lot with GC duration.

Before I venture into this area I wanted to have mypy running