### PR TITLE
Remove internal dependencies mapping in update_graph

### DIFF
--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -46,9 +46,7 @@ class GraphLayout(SchedulerPlugin):
                 priority=priority,
             )
 
-    def update_graph(
-        self, scheduler, *, dependencies=None, priority=None, tasks=None, **kwargs
-    ):
+    def update_graph(self, scheduler, *, priority=None, tasks=None, **kwargs):
         stack = sorted(
             tasks, key=lambda k: TupleComparable(priority.get(k, 0)), reverse=True
         )
@@ -56,7 +54,7 @@ class GraphLayout(SchedulerPlugin):
             key = stack.pop()
             if key in self.x or key not in scheduler.tasks:
                 continue
-            deps = dependencies.get(key, ())
+            deps = scheduler.tasks[key].dependencies
             if deps:
                 if not all(dep in self.y for dep in deps):
                     stack.append(key)

--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -54,7 +54,7 @@ class GraphLayout(SchedulerPlugin):
             key = stack.pop()
             if key in self.x or key not in scheduler.tasks:
                 continue
-            deps = scheduler.tasks[key].dependencies
+            deps = [ts.key for ts in scheduler.tasks[key].dependencies]
             if deps:
                 if not all(dep in self.y for dep in deps):
                     stack.append(key)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -100,7 +100,6 @@ class SchedulerPlugin:
         tasks: list[Key],
         annotations: dict[str, dict[Key, Any]],
         priority: dict[Key, tuple[int | float, ...]],
-        dependencies: dict[Key, set[Key]],
         stimulus_id: str,
         **kwargs: Any,
     ) -> None:
@@ -128,8 +127,6 @@ class SchedulerPlugin:
                     }
             priority:
                 Task calculated priorities as assigned to the tasks.
-            dependencies:
-                A mapping that maps a key to its dependencies.
             stimulus_id:
                 ID of the stimulus causing the graph update
             **kwargs:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -99,6 +99,7 @@ class SchedulerPlugin:
         keys: set[Key],
         tasks: list[Key],
         annotations: dict[str, dict[Key, Any]],
+        priority: dict[Key, tuple[int | float, ...]],
         stimulus_id: str,
         **kwargs: Any,
     ) -> None:
@@ -124,6 +125,8 @@ class SchedulerPlugin:
                         },
                         ...
                     }
+            priority:
+                Task calculated priorities as assigned to the tasks.
             stimulus_id:
                 ID of the stimulus causing the graph update
             **kwargs:

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -99,7 +99,6 @@ class SchedulerPlugin:
         keys: set[Key],
         tasks: list[Key],
         annotations: dict[str, dict[Key, Any]],
-        priority: dict[Key, tuple[int | float, ...]],
         stimulus_id: str,
         **kwargs: Any,
     ) -> None:
@@ -125,8 +124,6 @@ class SchedulerPlugin:
                         },
                         ...
                     }
-            priority:
-                Task calculated priorities as assigned to the tasks.
             stimulus_id:
                 ID of the stimulus causing the graph update
             **kwargs:

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -492,7 +492,6 @@ async def test_update_graph_hook_simple(c, s, a, b):
             tasks,
             annotations,
             priority,
-            dependencies,
             stimulus_id,
             **kwargs,
         ) -> None:
@@ -505,7 +504,6 @@ async def test_update_graph_hook_simple(c, s, a, b):
             assert annotations == {}
             assert len(priority) == 1
             assert isinstance(priority["foo"], tuple)
-            assert dependencies == {"foo": set()}
             assert stimulus_id is not None
             self.success = True
 
@@ -534,7 +532,6 @@ async def test_update_graph_hook_complex(c, s, a, b):
             tasks,
             annotations,
             priority,
-            dependencies,
             stimulus_id,
             **kwargs,
         ) -> None:
@@ -552,10 +549,6 @@ async def test_update_graph_hook_complex(c, s, a, b):
             }
             assert len(priority) == len(tasks), priority
             assert priority["f2"][0] == -13
-            for k in keys:
-                assert k in dependencies
-            assert dependencies["f1"] == set()
-            assert dependencies["sum"] == {"f1", "f3"}
             assert stimulus_id is not None
 
             self.success = True

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4823,15 +4823,17 @@ class Scheduler(SchedulerState, ServerNode):
             else:
                 annotations_for_plugin.pop("span", None)
 
+        tasks_for_plugin = [ts.key for ts in touched_tasks]
+        priorities_for_plugin = {ts.key: ts.priority for ts in touched_tasks}
         for plugin in list(self.plugins.values()):
             try:
                 plugin.update_graph(
                     self,
                     client=client,
-                    tasks=[ts.key for ts in touched_tasks],
+                    tasks=tasks_for_plugin,
                     keys=keys,
-                    annotations=dict(annotations_for_plugin),
-                    priority={ts.key: ts.priority for ts in touched_tasks},
+                    annotations=annotations_for_plugin,
+                    priority=priorities_for_plugin,
                     stimulus_id=stimulus_id,
                 )
             except Exception as e:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4831,6 +4831,7 @@ class Scheduler(SchedulerState, ServerNode):
                     tasks=[ts.key for ts in touched_tasks],
                     keys=keys,
                     annotations=dict(annotations_for_plugin),
+                    priority={ts.key: ts.priority for ts in touched_tasks},
                     stimulus_id=stimulus_id,
                 )
             except Exception as e:

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3111,8 +3111,9 @@ async def test_submit_on_cancelled_future(c, s, a, b):
 
 
 @pytest.mark.parametrize("validate", [True, False])
+@pytest.mark.parametrize("swap_keys", [True, False])
 @gen_cluster(client=True)
-async def test_compute_partially_forgotten(c, s, *workers, validate):
+async def test_compute_partially_forgotten(c, s, *workers, validate, swap_keys):
     if not validate:
         s.validate = False
     # (CPython impl detail)
@@ -3127,6 +3128,8 @@ async def test_compute_partially_forgotten(c, s, *workers, validate):
     # At the time of writing, it is unclear why the lost_dep_of_key is part of
     # keys but this triggers an observed error
     keys = key, lost_dep_of_key = list({"foo", "bar"})
+    if swap_keys:
+        keys = lost_dep_of_key, key = [key, lost_dep_of_key]
 
     # Ordinarily this is not submitted as a graph but it could be if a persist
     # was leading up to this
@@ -3135,13 +3138,14 @@ async def test_compute_partially_forgotten(c, s, *workers, validate):
     # zombie task around after triggering the "lost deps" exception. That zombie
     # causes the second one to trigger the transition error.
     res = c.get({task.key: task}, keys, sync=False)
-
     res = c.get({task.key: task}, keys, sync=False)
     assert res[1].key == lost_dep_of_key
     with pytest.raises(CancelledError, match="lost dependencies"):
         await res[1].result()
 
+    # No transition errors
     while (
+        # This waits until update-graph is truly finished
         len([msg[1]["action"] == "update-graph" for msg in s.get_events("scheduler")])
         < 2
     ):

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3139,9 +3139,10 @@ async def test_compute_partially_forgotten(c, s, *workers, validate, swap_keys):
     # causes the second one to trigger the transition error.
     res = c.get({task.key: task}, keys, sync=False)
     res = c.get({task.key: task}, keys, sync=False)
-    assert res[1].key == lost_dep_of_key
     with pytest.raises(CancelledError, match="lost dependencies"):
         await res[1].result()
+    with pytest.raises(CancelledError, match="lost dependencies"):
+        await res[0].result()
 
     # No transition errors
     while (

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2268,11 +2268,14 @@ async def test_dont_recompute_if_erred(c, s, a, b):
     y = delayed(div_only_once("y"))(x, 0, dask_key_name="y")
 
     yy = c.persist(y)
-    await c.compute(yy)
+    with pytest.raises(ZeroDivisionError):
+        await c.compute(yy)
 
     yyy = c.persist(y)
-    await c.compute(yyy)
+    with pytest.raises(ZeroDivisionError):
+        await c.compute(yyy)
 
+    # If they did run a second time, the error would be different
     with pytest.raises(RuntimeError, match="Must only be called once"):
         inc_only_once("x")(1)
     with pytest.raises(RuntimeError, match="Must only be called once"):


### PR DESCRIPTION
This is a long overdue follow up of the `Task` class changes and is aiming to reduce transmission overhead and reduce memory utilization on the scheduler during graph submission.

The need to materialize the dependencies as a separate dict is entirely redundant. For backwards compatibility, `_materialize_graph` generated a materialized version of the dependencies mapping to keep the changes minimal at the time.

The caveat was that `Scheduler._remove_done_tasks_from_dsk` was actually mutating that view which turns out to be false behavior.

`dependencies` of a task are **immutable** and every attempt to treat it differently is very likely corrupting the state or at the very least is altering the graph itself. This argument alone should already suffice to see that changes to dependencies are a bad idea.
After closer review of the code, I believe that the entire logic around `_remove_done_tasks_from_dsk` is actually redundant and can be removed. This method was parsing the `dsk` graph for tasks that were already in `memory` or were already `erred` and removed them from `dsk` accordingly. The reasoning is sound since we do not want to recompute those tasks again. However, the transition engine is already taking care of this and is producing appropriate recommendations that end up doing nothing.
Ultimately, this is a performance tradeoff. This logic in `_remove_done_tasks_from_dsk` allows us to not throw already computed keys into the transition engine which is arguably slower than the `_remove_done_tasks_from_dsk` logic itself. Essentially, this makes repeated `persist`s faster at the cost of slowing *everything* else down.
In particular, `_remove_done_tasks_from_dsk` contains a call to `reverse_dict` which walks the entire graph and all edges and constructs a dict with dependents. Contrary to dependencies, dependents are ephemeral and have to be recomputed every time. This is actually expensive and not doing it is helpful.

I haven't done any measuremnets but I strongly suspect this is a win-win (even repeated persists are likely faster).


There may be a couple of wrinkles in CI that I'll have to check on but I'm very confident about the change itself.