### PR TITLE
Perform explicit culling step only if LLG is submitted

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -54,6 +54,7 @@ from tornado.ioloop import IOLoop
 
 import dask
 import dask.utils
+from dask._expr import LLGExpr
 from dask._task_spec import DependenciesMapping, GraphNode, convert_legacy_graph
 from dask.core import istask, validate_key
 from dask.typing import Key, no_default
@@ -4878,9 +4879,12 @@ class Scheduler(SchedulerState, ServerNode):
 
             materialization_done = time()
             logger.debug("Materialization done. Got %i tasks.", len(dsk))
+            # Most/all other expression types are implementing their own
+            # culling. For LLGExpr we just don't know
+            explicit_culling = isinstance(expr, LLGExpr)
             del expr
-
-            dsk = _cull(dsk, keys)
+            if explicit_culling:
+                dsk = _cull(dsk, keys)
 
             if not internal_priority:
                 internal_priority = await offload(dask.order.order, dsk=dsk)


### PR DESCRIPTION
This explicit culling step is for many reasons redundant. 

1. DataFrame expressions behave well and generate only what's needed. Legacy Array collections perform this as a low level optimization, etc.
2. The Scheduler._generate_taskstate method is already walking the graph in a way that automatically culls. Therefore, this optimization step is only there to cull the graph before it enters dask.order

I believe the only path where this even has a chance to trigger is if the Client.get receives a raw dictionary and in these cases we have zero information about what happened to the graph. It still makes sense to cull to avoid worst case runtimes but for all other cases this isn't necessary, I believe.