### PR TITLE
Migrate dependencies dependents sets from TaskState to Key

### DIFF
--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -46,9 +46,7 @@ class GraphLayout(SchedulerPlugin):
                 priority=priority,
             )
 
-    def update_graph(
-        self, scheduler, *, dependencies=None, priority=None, tasks=None, **kwargs
-    ):
+    def update_graph(self, scheduler, *, priority=None, tasks=None, **kwargs):
         stack = sorted(
             tasks, key=lambda k: TupleComparable(priority.get(k, 0)), reverse=True
         )
@@ -56,7 +54,7 @@ class GraphLayout(SchedulerPlugin):
             key = stack.pop()
             if key in self.x or key not in scheduler.tasks:
                 continue
-            deps = dependencies.get(key, ())
+            deps = scheduler.tasks[key].dependencies
             if deps:
                 if not all(dep in self.y for dep in deps):
                     stack.append(key)

--- a/distributed/diagnostics/graph_layout.py
+++ b/distributed/diagnostics/graph_layout.py
@@ -54,7 +54,7 @@ class GraphLayout(SchedulerPlugin):
             key = stack.pop()
             if key in self.x or key not in scheduler.tasks:
                 continue
-            deps = scheduler.tasks[key].dependencies
+            deps = [ts.key for ts in scheduler.tasks[key].dependencies]
             if deps:
                 if not all(dep in self.y for dep in deps):
                     stack.append(key)

--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -100,7 +100,6 @@ class SchedulerPlugin:
         tasks: list[Key],
         annotations: dict[str, dict[Key, Any]],
         priority: dict[Key, tuple[int | float, ...]],
-        dependencies: dict[Key, set[Key]],
         stimulus_id: str,
         **kwargs: Any,
     ) -> None:
@@ -128,8 +127,6 @@ class SchedulerPlugin:
                     }
             priority:
                 Task calculated priorities as assigned to the tasks.
-            dependencies:
-                A mapping that maps a key to its dependencies.
             stimulus_id:
                 ID of the stimulus causing the graph update
             **kwargs:

--- a/distributed/diagnostics/tests/test_scheduler_plugin.py
+++ b/distributed/diagnostics/tests/test_scheduler_plugin.py
@@ -492,7 +492,6 @@ async def test_update_graph_hook_simple(c, s, a, b):
             tasks,
             annotations,
             priority,
-            dependencies,
             stimulus_id,
             **kwargs,
         ) -> None:
@@ -505,7 +504,6 @@ async def test_update_graph_hook_simple(c, s, a, b):
             assert annotations == {}
             assert len(priority) == 1
             assert isinstance(priority["foo"], tuple)
-            assert dependencies == {"foo": set()}
             assert stimulus_id is not None
             self.success = True
 
@@ -534,7 +532,6 @@ async def test_update_graph_hook_complex(c, s, a, b):
             tasks,
             annotations,
             priority,
-            dependencies,
             stimulus_id,
             **kwargs,
         ) -> None:
@@ -552,10 +549,6 @@ async def test_update_graph_hook_complex(c, s, a, b):
             }
             assert len(priority) == len(tasks), priority
             assert priority["f2"][0] == -13
-            for k in keys:
-                assert k in dependencies
-            assert dependencies["f1"] == set()
-            assert dependencies["sum"] == {"f1", "f3"}
             assert stimulus_id is not None
 
             self.success = True

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -53,9 +53,8 @@ from tlz import (
 from tornado.ioloop import IOLoop
 
 import dask
-import dask.utils
 from dask._expr import LLGExpr
-from dask._task_spec import DependenciesMapping, GraphNode, convert_legacy_graph
+from dask._task_spec import GraphNode, convert_legacy_graph
 from dask.core import istask, validate_key
 from dask.typing import Key, no_default
 from dask.utils import (
@@ -4615,7 +4614,6 @@ class Scheduler(SchedulerState, ServerNode):
     def _find_lost_dependencies(
         self,
         dsk: dict[Key, T_runspec],
-        dependencies: dict[Key, set[Key]],
         keys: set[Key],
     ) -> set[Key]:
         lost_keys = set()
@@ -4639,7 +4637,6 @@ class Scheduler(SchedulerState, ServerNode):
                             k,
                             d,
                         )
-                        dependencies.pop(d, None)
                         keys.discard(k)
                     continue
                 wupdate(dsk[d].dependencies)
@@ -4650,7 +4647,6 @@ class Scheduler(SchedulerState, ServerNode):
         *,
         start: float,
         dsk: dict[Key, T_runspec],
-        dependencies: dict,
         keys: set[Key],
         ordered: dict[Key, int],
         client: str,
@@ -4696,7 +4692,6 @@ class Scheduler(SchedulerState, ServerNode):
         ) = self._generate_taskstates(
             keys=keys,
             dsk=dsk,
-            dependencies=dependencies,
             computation=computation,
         )
 
@@ -4781,7 +4776,6 @@ class Scheduler(SchedulerState, ServerNode):
                     client=client,
                     tasks=[ts.key for ts in touched_tasks],
                     keys=keys,
-                    dependencies=dependencies,
                     annotations=dict(annotations_for_plugin),
                     priority=priority,
                     stimulus_id=stimulus_id,
@@ -4796,42 +4790,6 @@ class Scheduler(SchedulerState, ServerNode):
                 self.report_on_key(ts=ts, client=client)
 
         return metrics
-
-    def _remove_done_tasks_from_dsk(
-        self,
-        dsk: dict[Key, T_runspec],
-        dependencies: dict[Key, set[Key]],
-    ) -> None:
-        # Avoid computation that is already finished
-        done = set()  # tasks that are already done
-        for k, v in dependencies.items():
-            if v and k in self.tasks:
-                ts = self.tasks[k]
-                if ts.state in ("memory", "erred"):
-                    done.add(k)
-        if done:
-            dependents = dask.core.reverse_dict(dependencies)
-            stack = list(done)
-            while stack:  # remove unnecessary dependencies
-                key = stack.pop()
-                try:
-                    deps = dependencies[key]
-                except KeyError:
-                    deps = {ts.key for ts in self.tasks[key].dependencies}
-                for dep in deps:
-                    if dep in dependents:
-                        child_deps = dependents[dep]
-                    elif dep in self.tasks:
-                        child_deps = {ts.key for ts in self.tasks[key].dependencies}
-                    else:
-                        child_deps = set()
-                    if all(d in done for d in child_deps):
-                        if dep in self.tasks and dep not in done:
-                            done.add(dep)
-                            stack.append(dep)
-        for anc in done:
-            dsk.pop(anc, None)
-            dependencies.pop(anc, None)
 
     @log_errors
     async def update_graph(
@@ -4868,7 +4826,6 @@ class Scheduler(SchedulerState, ServerNode):
                 raise RuntimeError(textwrap.dedent(msg)) from e
             (
                 dsk,
-                dependencies,
                 annotations_by_type,
             ) = await offload(
                 _materialize_graph,
@@ -4898,7 +4855,7 @@ class Scheduler(SchedulerState, ServerNode):
             # has to happen in the same event loop.
             # *************************************
 
-            lost_keys = self._find_lost_dependencies(dsk, dependencies, keys)
+            lost_keys = self._find_lost_dependencies(dsk, keys)
 
             if lost_keys:
                 self.report(
@@ -4915,12 +4872,9 @@ class Scheduler(SchedulerState, ServerNode):
 
             before = len(self.tasks)
 
-            self._remove_done_tasks_from_dsk(dsk, dependencies)
-
             metrics = self._create_taskstate_from_graph(
                 dsk=dsk,
                 client=client,
-                dependencies=dependencies,
                 keys=set(keys),
                 ordered=internal_priority or {},
                 submitting_task=submitting_task,
@@ -4984,7 +4938,6 @@ class Scheduler(SchedulerState, ServerNode):
         self,
         keys: set[Key],
         dsk: dict[Key, T_runspec],
-        dependencies: dict[Key, set[Key]],
         computation: Computation,
     ) -> tuple:
         # Get or create task states
@@ -5017,7 +4970,7 @@ class Scheduler(SchedulerState, ServerNode):
             elif k in dsk:
                 # Check dependency names.
                 deps_lhs = {dts.key for dts in ts.dependencies}
-                deps_rhs = dependencies[k]
+                deps_rhs = dsk[k].dependencies
 
                 # FIXME It would be a really healthy idea to change this to a hard
                 # failure. However, this is not possible at the moment because of
@@ -5027,7 +4980,7 @@ class Scheduler(SchedulerState, ServerNode):
                     # This sweeps the issue of collision under the carpet as long as the
                     # old and new task produce the same output - such as in
                     # dask/dask#9888.
-                    dependencies[k] = deps_lhs
+                    # We're just updating this below
 
                     colliding_task_count += 1
                     if ts.group not in tgs_with_bad_run_spec:
@@ -5063,14 +5016,15 @@ class Scheduler(SchedulerState, ServerNode):
                 runnable.append(ts)
             touched_keys.add(k)
             touched_tasks.append(ts)
-            stack.extend(dependencies.get(k, ()))
+            if tspec := dsk.get(k, ()):
+                stack.extend(tspec.dependencies)
 
         # Add dependencies
-        for key, deps in dependencies.items():
+        for key, tspec in dsk.items():
             ts = self.tasks.get(key)
             if ts is None or ts.dependencies:
                 continue
-            for dep in deps:
+            for dep in tspec.dependencies:
                 dts = self.tasks[dep]
                 ts.add_dependency(dts)
 
@@ -9437,7 +9391,7 @@ class CollectTaskMetaDataPlugin(SchedulerPlugin):
 def _materialize_graph(
     expr: Expr,
     validate: bool,
-) -> tuple[dict[Key, T_runspec], dict[Key, set[Key]], dict[str, dict[Key, Any]]]:
+) -> tuple[dict[Key, T_runspec], dict[str, dict[Key, Any]]]:
     dsk: dict = expr.__dask_graph__()
     if validate:
         for k in dsk:
@@ -9448,10 +9402,7 @@ def _materialize_graph(
         annotations_by_type[annotations_type].update(value)
 
     dsk2 = convert_legacy_graph(dsk)
-    # FIXME: There should be no need to fully materialize and copy this but some
-    # sections in the scheduler are mutating it.
-    dependencies = {k: set(v) for k, v in DependenciesMapping(dsk2).items()}
-    return dsk2, dependencies, annotations_by_type
+    return dsk2, annotations_by_type
 
 
 def _cull(dsk: dict[Key, GraphNode], keys: set[Key]) -> dict[Key, GraphNode]:

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4948,6 +4948,7 @@ class Scheduler(SchedulerState, ServerNode):
         touched_tasks = []
         tgs_with_bad_run_spec = set()
         colliding_task_count = 0
+        collisions = set()
         while stack:
             k = stack.pop()
             if k in touched_keys:
@@ -4956,6 +4957,8 @@ class Scheduler(SchedulerState, ServerNode):
             if ts is None:
                 ts = self.new_task(k, dsk.get(k), "released", computation=computation)
                 new_tasks.append(ts)
+                if ts.run_spec:
+                    runnable.append(ts)
             # It is possible to create the TaskState object before its runspec is known
             # to the scheduler. For instance, this is possible when using a Variable:
             # `f = c.submit(foo); await Variable().set(f)` since the Variable uses a
@@ -4965,6 +4968,8 @@ class Scheduler(SchedulerState, ServerNode):
             # see for example test_scatter_creates_ts
             elif ts.run_spec is None:
                 ts.run_spec = dsk.get(k)
+                if ts.run_spec:
+                    runnable.append(ts)
             # run_spec in the submitted graph may be None. This happens
             # when an already persisted future is part of the graph
             elif k in dsk:
@@ -4976,12 +4981,7 @@ class Scheduler(SchedulerState, ServerNode):
                 # failure. However, this is not possible at the moment because of
                 # https://github.com/dask/dask/issues/9888
                 if deps_lhs != deps_rhs:
-                    # Retain old run_spec and dependencies; rerun them if necessary.
-                    # This sweeps the issue of collision under the carpet as long as the
-                    # old and new task produce the same output - such as in
-                    # dask/dask#9888.
-                    # We're just updating this below
-
+                    collisions.add(k)
                     colliding_task_count += 1
                     if ts.group not in tgs_with_bad_run_spec:
                         tgs_with_bad_run_spec.add(ts.group)
@@ -5012,8 +5012,6 @@ class Scheduler(SchedulerState, ServerNode):
                             "two consecutive calls to `update_graph`."
                         )
 
-            if ts.run_spec:
-                runnable.append(ts)
             touched_keys.add(k)
             touched_tasks.append(ts)
             if tspec := dsk.get(k, ()):
@@ -5022,7 +5020,7 @@ class Scheduler(SchedulerState, ServerNode):
         # Add dependencies
         for key, tspec in dsk.items():
             ts = self.tasks.get(key)
-            if ts is None or ts.dependencies:
+            if ts is None or key in collisions:
                 continue
             for dep in tspec.dependencies:
                 dts = self.tasks[dep]

--- a/distributed/stealing.py
+++ b/distributed/stealing.py
@@ -289,7 +289,9 @@ class WorkStealing(SchedulerPlugin):
             assert ts in ts.processing_on.long_running
             return None, None
 
-        nbytes = ts.get_nbytes_deps()
+        nbytes = sum(
+            self.scheduler.tasks[dts_key].get_nbytes() for dts_key in ts.dependencies
+        )
         transfer_time = nbytes / self.scheduler.bandwidth + LATENCY
         cost_multiplier = transfer_time / compute_time
 

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2263,6 +2263,32 @@ async def test_dont_forget_released_keys(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_dont_recompute_if_erred_transition_log(c, s, a, b):
+    """This is a more low level version of test_dont_recompute_if_erred
+    that verifies that there are indeed no transition logs.
+
+    At the time of https://github.com/dask/distributed/pull/9036 it was not
+    entirely safe to run pre-computed tasks through the state machine since
+    there was something wrong with queued tasks. This was triggered by, e.g.
+    `test_threadsafe_get`. If this issue goes away, this test can be safely
+    removed in favor of `test_dont_recompute_if_erred`.
+    """
+    x = delayed(inc)(1, dask_key_name="x")
+    y = delayed(div)(x, 0, dask_key_name="y")
+
+    yy = c.persist(y)
+    await wait(yy)
+
+    old = list(s.transition_log)
+
+    yyy = c.persist(y)
+    await wait(yyy)
+
+    await asyncio.sleep(0.100)
+    assert list(s.transition_log) == old
+
+
+@gen_cluster(client=True)
 async def test_dont_recompute_if_erred(c, s, a, b):
 
     x = delayed(inc_only_once("x"))(1, dask_key_name="x")

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -37,6 +37,7 @@ from distributed import (
     SchedulerPlugin,
     Worker,
     fire_and_forget,
+    get_client,
     wait,
 )
 from distributed.comm.addressing import parse_host_port
@@ -2169,78 +2170,81 @@ async def test_missing_data_errant_worker(c, s, w1, w2, w3):
         await wait(y)
 
 
+def inc_only_once(key):
+    def inc(x):
+        k = f"{x}-{key}"
+        if (c := get_client()).get_metadata(k, default=None):
+            raise RuntimeError("Must only be called once")
+        c.set_metadata(k, True)
+        return x + 1
+
+    return inc
+
+
+def div_only_once(key):
+    def div(x, y):
+        k = f"{x}-{y}-{key}"
+        if (c := get_client()).get_metadata(k, default=None):
+            raise RuntimeError("Must only be called once")
+        c.set_metadata(k, True)
+        return x / y
+
+    return div
+
+
 @gen_cluster(client=True)
 async def test_dont_recompute_if_persisted(c, s, a, b):
-    x = delayed(inc)(1, dask_key_name="x")
-    y = delayed(inc)(x, dask_key_name="y")
+    x = delayed(inc_only_once("x"))(1, dask_key_name="x")
+    y = delayed(inc_only_once("y"))(x, dask_key_name="y")
 
     yy = c.persist(y)
-    await wait(yy)
-
-    old = list(s.transition_log)
+    await c.compute(yy)
 
     yyy = c.persist(y)
-    await wait(yyy)
-
-    await asyncio.sleep(0.100)
-    assert list(s.transition_log) == old
+    await c.compute(yyy)
 
 
 @gen_cluster(client=True)
 async def test_dont_recompute_if_persisted_2(c, s, a, b):
-    x = delayed(inc)(1, dask_key_name="x")
-    y = delayed(inc)(x, dask_key_name="y")
-    z = delayed(inc)(y, dask_key_name="z")
+    x = delayed(inc_only_once("x"))(1, dask_key_name="x")
+    y = delayed(inc_only_once("y"))(x, dask_key_name="y")
+    z = delayed(inc_only_once("z"))(y, dask_key_name="z")
 
     yy = c.persist(y)
-    await wait(yy)
-
-    old = s.story("x", "y")
+    await c.compute(yy)
 
     zz = c.persist(z)
-    await wait(zz)
-
-    await asyncio.sleep(0.100)
-    assert s.story("x", "y") == old
+    await c.compute(zz)
 
 
 @gen_cluster(client=True)
 async def test_dont_recompute_if_persisted_3(c, s, a, b):
-    x = delayed(inc)(1, dask_key_name="x")
-    y = delayed(inc)(2, dask_key_name="y")
-    z = delayed(inc)(y, dask_key_name="z")
+    x = delayed(inc_only_once("x"))(1, dask_key_name="x")
+    y = delayed(inc_only_once("y"))(2, dask_key_name="y")
+    z = delayed(inc_only_once("z"))(y, dask_key_name="z")
     w = delayed(operator.add)(x, z, dask_key_name="w")
 
     ww = c.persist(w)
-    await wait(ww)
-
-    old = list(s.transition_log)
+    await c.compute(ww)
 
     www = c.persist(w)
-    await wait(www)
-    await asyncio.sleep(0.100)
-    assert list(s.transition_log) == old
+    await c.compute(www)
 
 
 @gen_cluster(client=True)
 async def test_dont_recompute_if_persisted_4(c, s, a, b):
     x = delayed(inc)(1, dask_key_name="x")
-    y = delayed(inc)(x, dask_key_name="y")
-    z = delayed(inc)(x, dask_key_name="z")
+    y = delayed(inc_only_once("y"))(x, dask_key_name="y")
+    z = delayed(inc_only_once("z"))(x, dask_key_name="z")
 
     yy = c.persist(y)
-    await wait(yy)
-
-    old = s.story("x")
+    await c.compute(yy)
 
     while s.tasks["x"].state == "memory":
         await asyncio.sleep(0.01)
 
     yyy, zzz = c.persist([y, z])
-    await wait([yyy, zzz])
-
-    new = s.story("x")
-    assert len(new) > len(old)
+    await c.gather(c.compute([yyy, zzz]))
 
 
 @gen_cluster(client=True)
@@ -2260,19 +2264,20 @@ async def test_dont_forget_released_keys(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_dont_recompute_if_erred(c, s, a, b):
-    x = delayed(inc)(1, dask_key_name="x")
-    y = delayed(div)(x, 0, dask_key_name="y")
+
+    x = delayed(inc_only_once("x"))(1, dask_key_name="x")
+    y = delayed(div_only_once("y"))(x, 0, dask_key_name="y")
 
     yy = c.persist(y)
-    await wait(yy)
-
-    old = list(s.transition_log)
+    await c.compute(yy)
 
     yyy = c.persist(y)
-    await wait(yyy)
+    await c.compute(yyy)
 
-    await asyncio.sleep(0.100)
-    assert list(s.transition_log) == old
+    with pytest.raises(RuntimeError, match="Must only be called once"):
+        inc_only_once("x")(1)
+    with pytest.raises(RuntimeError, match="Must only be called once"):
+        div_only_once("y")(1, 1)
 
 
 @gen_cluster()

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -2269,11 +2269,14 @@ async def test_dont_recompute_if_erred(c, s, a, b):
     y = delayed(div_only_once("y"))(x, 0, dask_key_name="y")
 
     yy = c.persist(y)
-    await c.compute(yy)
+    with pytest.raises(ZeroDivisionError):
+        await c.compute(yy)
 
     yyy = c.persist(y)
-    await c.compute(yyy)
+    with pytest.raises(ZeroDivisionError):
+        await c.compute(yyy)
 
+    # If they did run a second time, the error would be different
     with pytest.raises(RuntimeError, match="Must only be called once"):
         inc_only_once("x")(1)
     with pytest.raises(RuntimeError, match="Must only be called once"):


### PR DESCRIPTION
This is a follow up to https://github.com/dask/distributed/pull/9036 and builds directly on top

This replaces the elements in `TaskState.dependencies` with the keys instead of the `TaskState` objects themselves. This has a few benefits

1. It is a step towards making `TaskState` overhead lighter. A few months ago we were investigating GC overhead on the scheduler and the `TaskState` objects are adding to this in a non-trivial way. The fewer references we keep around the easier. Besides, these dependencies/dependents links are cycles that have to be followed by the GC. I don't expect this change to have a measurable impact but I believe this direction is healthy for the scheduler as a whole.
2. More importantly, this paves the way to drop the dedicated dependencies set altogether in favor of the frozenset of the `Task` class (`TaskState.run_spec`) and reduce update_graph runtime and reduces memory overhead a little (c.f. a simple, _empty_ set needs already 216B on py3.10, see also https://github.com/dask/distributed/pull/8331)