### PR TITLE
Speed up process startup time by avoiding importing packages on version check

### DIFF
--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -6,6 +6,7 @@ import sys
 import pytest
 import tornado
 
+import distributed
 from distributed import Client, Worker
 from distributed.utils_test import gen_cluster
 from distributed.versions import error_message, get_versions
@@ -156,15 +157,15 @@ def test_version_custom_pkgs():
     out = get_versions(
         [
             # Use custom function
-            ("distributed", lambda mod: "123"),
+            "distributed",
             # Use version_of_package
             "notexist",
-            ("pytest", None),  # has __version__
-            "tornado",  # has version
-            "math",  # has nothing
+            "pytest",
+            "tornado",
+            "math",
         ]
     )["packages"]
-    assert out["distributed"] == "123"
+    assert out["distributed"] == distributed.__version__
     assert out["notexist"] is None
     assert out["pytest"] == pytest.__version__
     assert out["tornado"] == tornado.version

--- a/distributed/tests/test_versions.py
+++ b/distributed/tests/test_versions.py
@@ -156,9 +156,7 @@ def test_python_version():
 def test_version_custom_pkgs():
     out = get_versions(
         [
-            # Use custom function
             "distributed",
-            # Use version_of_package
             "notexist",
             "pytest",
             "tornado",

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -124,7 +124,7 @@ def get_mp_context():
 
         from distributed.versions import optional_packages, required_packages
 
-        for pkg, _ in required_packages + optional_packages:
+        for pkg in required_packages + optional_packages:
             try:
                 importlib.import_module(pkg)
             except ImportError:

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -1,13 +1,13 @@
-""" utilities for package version introspection """
+"""utilities for package version introspection"""
 
 from __future__ import annotations
 
-import importlib
 import os
 import platform
 import struct
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
+from importlib.metadata import version
 from itertools import chain
 from types import ModuleType
 from typing import Any
@@ -17,23 +17,23 @@ from packaging.requirements import Requirement
 BOKEH_REQUIREMENT = Requirement("bokeh>=3.1.0")
 
 required_packages = [
-    ("dask", lambda p: p.__version__),
-    ("distributed", lambda p: p.__version__),
-    ("msgpack", lambda p: ".".join([str(v) for v in p.version])),
-    ("cloudpickle", lambda p: p.__version__),
-    ("tornado", lambda p: p.version),
-    ("toolz", lambda p: p.__version__),
+    "dask",
+    "distributed",
+    "msgpack",
+    "cloudpickle",
+    "tornado",
+    "toolz",
 ]
 
 optional_packages = [
-    ("numpy", lambda p: p.__version__),
-    ("pandas", lambda p: p.__version__),
-    ("lz4", lambda p: p.__version__),
+    "numpy",
+    "pandas",
+    "lz4",
 ]
 
 
 # only these scheduler packages will be checked for version mismatch
-scheduler_relevant_packages = {pkg for pkg, _ in required_packages} | {
+scheduler_relevant_packages = set(required_packages) | {
     "lz4",
     "python",
 } - {"msgpack"}
@@ -44,9 +44,7 @@ notes_mismatch_package: dict[str, str] = {}
 
 
 def get_versions(
-    packages: (
-        Iterable[str | tuple[str, Callable[[ModuleType], str | None]]] | None
-    ) = None
+    packages: Iterable[str] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Return basic information on our software installation, and our installed versions
     of packages
@@ -87,27 +85,15 @@ def version_of_package(pkg: ModuleType) -> str | None:
     return None
 
 
-def get_package_info(
-    pkgs: Iterable[str | tuple[str, Callable[[ModuleType], str | None] | None]]
-) -> dict[str, str | None]:
+def get_package_info(pkgs: Iterable[str]) -> dict[str, str | None]:
     """get package versions for the passed required & optional packages"""
 
     pversions: dict[str, str | None] = {"python": ".".join(map(str, sys.version_info))}
     for pkg in pkgs:
-        if isinstance(pkg, (tuple, list)):
-            modname, ver_f = pkg
-            if ver_f is None:
-                ver_f = version_of_package
-        else:
-            modname = pkg
-            ver_f = version_of_package
-
         try:
-            mod = importlib.import_module(modname)
-            pversions[modname] = ver_f(mod)
+            pversions[pkg] = version(pkg)
         except Exception:
-            pversions[modname] = None
-
+            pversions[pkg] = None
     return pversions
 
 

--- a/distributed/versions.py
+++ b/distributed/versions.py
@@ -10,7 +10,6 @@ from collections.abc import Iterable
 from functools import cache
 from importlib.metadata import version
 from itertools import chain
-from types import ModuleType
 from typing import Any
 
 from packaging.requirements import Requirement
@@ -71,19 +70,6 @@ def get_system_info() -> dict[str, Any]:
         "LC_ALL": os.environ.get("LC_ALL", "None"),
         "LANG": os.environ.get("LANG", "None"),
     }
-
-
-def version_of_package(pkg: ModuleType) -> str | None:
-    """Try a variety of common ways to get the version of a package"""
-    from contextlib import suppress
-
-    with suppress(AttributeError):
-        return pkg.__version__
-    with suppress(AttributeError):
-        return str(pkg.version)
-    with suppress(AttributeError):
-        return ".".join(map(str, pkg.version_info))
-    return None
 
 
 @cache


### PR DESCRIPTION
`importlib.metadata` can check the version of a package without importing it. That makes our nanny and worker processes come up **much** faster, especially considering that the Nanny doesn't even have any usage for this (i.e. this also saves a bit on memory but that should be marginal in _most_ cases).

Launching a LocalCluster with 10 workers on my machine is 2-3x faster with this change.

```
# Main
▶ time python -c "import distributed; distributed.LocalCluster(n_workers=10)"
10.98s user 3.07s system 147% cpu 9.516 total
▶ time python -c "import distributed; distributed.LocalCluster(n_workers=10)"
10.31s user 2.67s system 158% cpu 8.166 total

# This PR
▶ time python -c "import distributed; distributed.LocalCluster(n_workers=10)"
6.73s user 1.89s system 216% cpu 3.976 total
▶ time python -c "import distributed; distributed.LocalCluster(n_workers=10)"
6.52s user 1.76s system 252% cpu 3.275 total
▶ time python -c "import distributed; distributed.LocalCluster(n_workers=10)"
6.61s user 1.79s system 268% cpu 3.125 total
```

I hope this helps speed up our CI infrastructure and helps us avoid a couple of flaky tests which are related to Nanny processes startup failures