### PR TITLE
Improve error when submitting work from a closed client

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -734,6 +734,10 @@ class AllExit(Exception):
     """Custom exception class to exit All(...) early."""
 
 
+class ClosedClientError(Exception):
+    """Raised when an action with a closed client can't be performed"""
+
+
 def _handle_print(event):
     _, msg = event
     if not isinstance(msg, dict):
@@ -1419,9 +1423,8 @@ class Client(SyncMethodMixin):
         if self.status in ("running", "closing", "connecting", "newly-created"):
             self.loop.add_callback(self._send_to_scheduler_safe, msg)
         else:
-            raise Exception(
-                "Tried sending message after closing.  Status: %s\n"
-                "Message: %s" % (self.status, msg)
+            raise ClosedClientError(
+                f"Client is {self.status}. Can't send {msg['op']} message."
             )
 
     async def _start(self, timeout=no_default, **kwargs):


### PR DESCRIPTION
Today if someone accidentally does `client.submit` or `client.map` with a closed client, they get a huge, not super meaningful error:

```python
Exception: Tried sending message after closing.  Status: closed
Message: {'op': 'update-graph', 'graph_header': {'serializer': 'pickle', 'writeable': ()}, 'graph_frames': 
[b'\x80\x05\x95\x9bJ\x00\x00\x00\x00\x00\x00\x8c\x1edistributed.protocol.serialize\x94\x8c\x08ToPickle\x94\x93\x94)\x81\x94}\x94\x8c\x04data\x94\x8c\x13
dask.highlevelgraph\x94\x8c\x0eHighLevelGraph............... # this bytestring goes on for a long time
```

This PR update the error in this case to be more concise:

```python
ClosedClientError: Client is closed. Can't send update-graph message.
```