### PR TITLE
Skip TLS functional tests `test_nanny` and `test_retire_workers` on linux

### DIFF
--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from tlz import merge
 
 from distributed import Client, Nanny, Queue, Scheduler, Worker, wait, worker_client
+from distributed.compatibility import LINUX
 from distributed.core import Status
 from distributed.metrics import time
 from distributed.utils_test import (
@@ -89,6 +91,7 @@ async def test_scatter(c, s, a, b):
     assert yy == [20]
 
 
+@pytest.mark.skipif(LINUX, reason="https://github.com/dask/distributed/issues/9052")
 @gen_tls_cluster(client=True, Worker=Nanny)
 async def test_nanny(c, s, a, b):
     assert s.address.startswith("tls://")
@@ -188,6 +191,7 @@ async def test_worker_client_executor(c, s, a, b):
     assert result == 30 * 29
 
 
+@pytest.mark.skipif(LINUX, reason="https://github.com/dask/distributed/issues/9052")
 @gen_tls_cluster(client=True, Worker=Nanny)
 async def test_retire_workers(c, s, a, b):
     assert set(s.workers) == {a.worker_address, b.worker_address}


### PR DESCRIPTION
I am not able to reproduce this. I'm working on OSX and on CI this only happens on linux. This is currently quite bad so I suggest to skip this for now.


![image](https://github.com/user-attachments/assets/7ce32017-47d8-454e-abc4-a0c5e0a3f34f)
