### PR TITLE
Refactor timeouts in start cluster

### DIFF
--- a/distributed/tests/test_tls_functional.py
+++ b/distributed/tests/test_tls_functional.py
@@ -7,11 +7,9 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 from tlz import merge
 
 from distributed import Client, Nanny, Queue, Scheduler, Worker, wait, worker_client
-from distributed.compatibility import LINUX
 from distributed.core import Status
 from distributed.metrics import time
 from distributed.utils_test import (
@@ -91,7 +89,6 @@ async def test_scatter(c, s, a, b):
     assert yy == [20]
 
 
-@pytest.mark.skipif(LINUX, reason="https://github.com/dask/distributed/issues/9052")
 @gen_tls_cluster(client=True, Worker=Nanny)
 async def test_nanny(c, s, a, b):
     assert s.address.startswith("tls://")
@@ -191,7 +188,6 @@ async def test_worker_client_executor(c, s, a, b):
     assert result == 30 * 29
 
 
-@pytest.mark.skipif(LINUX, reason="https://github.com/dask/distributed/issues/9052")
 @gen_tls_cluster(client=True, Worker=Nanny)
 async def test_retire_workers(c, s, a, b):
     assert set(s.workers) == {a.worker_address, b.worker_address}

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -983,9 +983,7 @@ def gen_cluster(
                                 Worker=Worker,
                                 scheduler_kwargs=scheduler_kwargs,
                                 worker_kwargs=worker_kwargs,
-                                # Cut this in half to allow for at least one
-                                # retry
-                                timeout=timeout // 2,
+                                timeout=timeout // 4,
                             )
                         except Exception as e:
                             logger.error(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -761,6 +761,7 @@ async def start_cluster(
     Worker: type[ServerNode] = Worker,
     scheduler_kwargs: dict[str, Any] | None = None,
     worker_kwargs: dict[str, Any] | None = None,
+    timeout: float = _TEST_TIMEOUT // 4,
 ) -> tuple[Scheduler, list[ServerNode]]:
     scheduler_kwargs = scheduler_kwargs or {}
     worker_kwargs = worker_kwargs or {}
@@ -797,13 +798,15 @@ async def start_cluster(
         or any(comm.comm is None for comm in s.stream_comms.values())
     ):
         await asyncio.sleep(0.01)
-        if time() > start + 30:
+        if time() > start + timeout:
             await asyncio.gather(*(w.close(timeout=1) for w in workers))
             await s.close()
             check_invalid_worker_transitions(s)
             check_invalid_task_states(s)
             check_worker_fail_hard(s)
-            raise TimeoutError("Cluster creation timeout")
+            raise TimeoutError(
+                "Cluster creation timeout. Workers did not come up and register in time."
+            )
     return s, workers
 
 
@@ -969,18 +972,20 @@ def gen_cluster(
                 workers = []
                 s = None
                 try:
-                    for _ in range(60):
+                    while True:
                         try:
+                            if not deadline.remaining:
+                                raise TimeoutError("Timeout on cluster creation")
                             s, ws = await start_cluster(
                                 nthreads,
                                 scheduler,
                                 security=security,
                                 Worker=Worker,
                                 scheduler_kwargs=scheduler_kwargs,
-                                worker_kwargs=merge(
-                                    {"death_timeout": min(15, int(deadline.remaining))},
-                                    worker_kwargs,
-                                ),
+                                worker_kwargs=worker_kwargs,
+                                # Cut this in half to allow for at least one
+                                # retry
+                                timeout=timeout // 2,
                             )
                         except Exception as e:
                             logger.error(
@@ -988,7 +993,6 @@ def gen_cluster(
                                 f"{e.__class__.__name__}: {e}; retrying",
                                 exc_info=True,
                             )
-                            await asyncio.sleep(1)
                         else:
                             workers[:] = ws
                             break


### PR DESCRIPTION
I ended up being able to reproduce the TLS errors after all. However, I cannot track the issue down. For some reason, the connections close and I cannot find the culprit.

One thing I'm attempting here is to refactor the timeout hierarchy to be more sensible.

On main

- The entire things is wrapped in an asyncio.wait_for(..., 2 * _TEST_TIMEOUT), i.e. 60s
- The cluster factory is retrying 60 times with a sleep of 1s, i.e. this is in practice longer than the outer timeout
- start_cluster itself is running for another +30s, hard coded until it times out. With some overhead, this very likely means that the second iteration is hitting the outermost timeout
- Yet deeper inside, we're timing out individual workers with a death_timeout of `min(15, deadline.remaining)`, i.e. this is shrinking and can even go down to 0s. This is not a big problem but it if obfuscating errors

This PR proposes

- keep the outer timeout as is
- Retry until the outer timeout is hit
- Don't wait between retries. In test scenarios we're not dealing with overloaded remote servers so this second sleep won't help
- Remove the hard coded 30s timeout in favor of a fraction of the outer timeout (in this case 25%). We might want to make this much more aggressive since 15s to start a couple of subprocesses is still insanely slow.
- Remove the death timeout entirely