### PR TITLE
Fix workers / threads / memory displayed in client repr

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1343,18 +1343,16 @@ class Client(SyncMethodMixin):
         info = self._scheduler_identity
         addr = info.get("address")
         if addr:
-            workers = info.get("workers", {})
-            nworkers = len(workers)
-            nthreads = sum(w["nthreads"] for w in workers.values())
+            nworkers = info.get("n_workers", 0)
+            nthreads = info.get("total_threads", 0)
             text = "<%s: %r processes=%d threads=%d" % (
                 self.__class__.__name__,
                 addr,
                 nworkers,
                 nthreads,
             )
-            memory = [w["memory_limit"] for w in workers.values()]
-            if all(memory):
-                text += ", memory=" + format_bytes(sum(memory))
+            memory = info.get("total_memory", 0)
+            text += ", memory=" + format_bytes(memory)
             text += ">"
             return text
 


### PR DESCRIPTION
The client repr is currently getting the number of workers, threads, and memory from `client.scheduler_info()["workers"]`. However in https://github.com/dask/distributed/pull/9045 we truncated the number of workers included in `scheduler_info()` by default (which didn't scale well). 

Luckily we're tracking the info displayed in the client repr separately from `scheduler_info()["workers"]` (e.g. `scheduler_info()["total_threads"]`. This PR updates the repr to not rely on the `"workers"` info (also updates a test accordingly). 

Closes https://github.com/dask/distributed/issues/9065