### PR TITLE
Ensure actors set erred state properly in case of worker failure

### DIFF
--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -141,7 +141,7 @@ class Actor(TaskRef):
 
     def __getattr__(self, key):
         if self._future and self._future.status not in ("finished", "pending"):
-            raise ValueError(
+            raise RuntimeError(
                 "Worker holding Actor was lost.  Status: " + self._future.status
             )
         self._try_bind_worker_client()


### PR DESCRIPTION
If the worker the actor is living on closes, this can corrupt the state machine with errors like

```

distributed.scheduler - ERROR - SchedulerState._transition_processing_erred() missing 1 required positional argument: 'worker'
Traceback (most recent call last):
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/utils.py", line 805, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/scheduler.py", line 5539, in remove_worker
    self.transitions(recommendations, stimulus_id=stimulus_id)
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/scheduler.py", line 8231, in transitions
    self._transitions(recommendations, client_msgs, worker_msgs, stimulus_id)
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/scheduler.py", line 2124, in _transitions
    new_recs, new_cmsgs, new_wmsgs = self._transition(key, finish, stimulus_id)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/scheduler.py", line 2007, in _transition
    recommendations, client_msgs, worker_msgs = func(
                                                ^^^^^
TypeError: SchedulerState._transition_processing_erred() missing 1 required positional argument: 'worker'
2025-05-02 06:02:49.6990
scheduler

distributed.scheduler - ERROR - Error transitioning 'train_fold-ea3e90ffa6cd2aefdd048600a1929a31' from 'processing' to 'erred'
Traceback (most recent call last):
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/scheduler.py", line 2007, in _transition
    recommendations, client_msgs, worker_msgs = func(
                                                ^^^^^
TypeError: SchedulerState._transition_processing_erred() missing 1 required positional argument: 'worker'
2025-05-02 06:02:49.6980
```

This implements an appropriate transition for these cases and ensures that the result is properly set to erred.