### PR TITLE
Partially forgotten dependencies

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4672,9 +4672,9 @@ class Scheduler(SchedulerState, ServerNode):
     def _find_lost_dependencies(
         self,
         dsk: dict[Key, T_runspec],
-        dependencies: dict[Key, set[Key]],
         keys: set[Key],
     ) -> set[Key]:
+        # FIXME: There is typically no need to walk the entire graph
         lost_keys = set()
         seen: set[Key] = set()
         sadd = seen.add
@@ -4696,8 +4696,6 @@ class Scheduler(SchedulerState, ServerNode):
                             k,
                             d,
                         )
-                        dependencies.pop(d, None)
-                        keys.discard(k)
                     continue
                 wupdate(dsk[d].dependencies)
         return lost_keys
@@ -4954,21 +4952,10 @@ class Scheduler(SchedulerState, ServerNode):
             # has to happen in the same event loop.
             # *************************************
 
-            lost_keys = self._find_lost_dependencies(dsk, dependencies, keys)
+            lost_keys = self._find_lost_dependencies(dsk, keys)
 
             if lost_keys:
-                self.report(
-                    {
-                        "op": "cancelled-keys",
-                        "keys": lost_keys,
-                        "reason": "lost dependencies",
-                    },
-                    client=client,
-                )
-                self.client_releases_keys(
-                    keys=lost_keys, client=client, stimulus_id=stimulus_id
-                )
-
+                raise RuntimeError(f"Lost dependencies for keys {lost_keys & keys}.")
             before = len(self.tasks)
 
             self._remove_done_tasks_from_dsk(dsk, dependencies)

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -3138,7 +3138,7 @@ async def test_compute_partially_forgotten(c, s, *workers, validate):
 
     res = c.get({task.key: task}, keys, sync=False)
     assert res[1].key == lost_dep_of_key
-    with pytest.raises(Exception, match="Lost dependencies"):
+    with pytest.raises(CancelledError, match="lost dependencies"):
         await res[1].result()
 
     while (

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -2665,18 +2665,18 @@ async def test_futures_of_cancelled_raises(c, s, a, b):
     while x.key in s.tasks:
         await asyncio.sleep(0.01)
 
-    with pytest.raises(CancelledError, match="reason: lost dependencies"):
+    with pytest.raises(RuntimeError, match="Lost dependencies"):
         get_obj = c.get({"x": (inc, x), "y": (inc, 2)}, ["x", "y"], sync=False)
         gather_obj = c.gather(get_obj)
         await gather_obj
 
-    with pytest.raises(CancelledError, match="reason: lost dependencies"):
+    with pytest.raises(RuntimeError, match="Lost dependencies"):
         await c.submit(inc, x)
 
-    with pytest.raises(CancelledError, match="reason: lost dependencies"):
+    with pytest.raises(RuntimeError, match="Lost dependencies"):
         await c.submit(add, 1, y=x)
 
-    with pytest.raises(CancelledError, match="reason: lost dependencies"):
+    with pytest.raises(RuntimeError, match="Lost dependencies"):
         await c.gather(c.map(add, [1], y=x))
 
 
@@ -3106,7 +3106,7 @@ async def test_submit_on_cancelled_future(c, s, a, b):
 
     await c.cancel(x)
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(RuntimeError, match="Lost dependencies"):
         await c.submit(inc, x)
 
 
@@ -3138,7 +3138,7 @@ async def test_compute_partially_forgotten(c, s, *workers, validate):
 
     res = c.get({task.key: task}, keys, sync=False)
     assert res[1].key == lost_dep_of_key
-    with pytest.raises(Exception, match="lost"):
+    with pytest.raises(Exception, match="Lost dependencies"):
         await res[1].result()
 
     while (
@@ -6033,7 +6033,7 @@ async def test_mixing_clients_different_scheduler(s, a, b):
         Client(s2.address, asynchronous=True) as c2,
     ):
         future = c1.submit(inc, 1)
-        with pytest.raises(CancelledError):
+        with pytest.raises(RuntimeError, match="Lost dependencies"):
             await c2.submit(inc, future)
 
 
@@ -8218,7 +8218,7 @@ async def test_release_persisted_collection(c, s, a, b):
     while s.tasks:
         await asyncio.sleep(0.01)
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(RuntimeError, match="Lost dependencies"):
         await c.compute(arr)
 
 
@@ -8233,7 +8233,7 @@ def test_release_persisted_collection_sync(c):
     while c.run_on_scheduler(lambda dask_scheduler: len(dask_scheduler.tasks)) > 0:
         sleep(0.01)
 
-    with pytest.raises(CancelledError):
+    with pytest.raises(RuntimeError, match="Lost dependencies for keys"):
         # Note: dask.compute is actually calling client.get, i.e. what we are
         # submitting to the scheduler is different to what we are in
         # client.compute

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -8267,7 +8267,6 @@ def test_submit_persisted_collection_as_argument(c, do_wait):
     [
         (True, True),
         (False, True),
-        (False, False),
     ],
 )
 def test_worker_clients_do_not_claim_ownership_of_serialize_futures(
@@ -8275,8 +8274,6 @@ def test_worker_clients_do_not_claim_ownership_of_serialize_futures(
 ):
     da = pytest.importorskip("dask.array", exc_type=ImportError)
 
-    if not store_variable and not do_wait:
-        pytest.skip("This test is not making sense")
     # Note: sending collections like this should be considered an anti-pattern
     # but it is possible. As long as the user ensures the futures stay alive
     # this is fine but the cluster will not take over this responsibility. The
@@ -8319,7 +8316,7 @@ def test_worker_clients_do_not_claim_ownership_of_serialize_futures(
     while c.run_on_scheduler(lambda dask_scheduler: len(dask_scheduler.tasks)) > 1:
         sleep(0.1)
     ev.set()
-    with pytest.raises(FutureCancelledError):
+    with pytest.raises(RuntimeError, match="Lost dependencies for keys"):
         future.result()
 
 


### PR DESCRIPTION
This raises transition errors as

```python
2025-05-06 13:23:15,012 - distributed.scheduler - INFO - User asked for computation on lost data. Final key is foo with missing dependency bar
2025-05-06 13:23:15,015 - distributed.scheduler - ERROR - Error transitioning 'bar' from 'waiting' to 'processing'
Traceback (most recent call last):
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2037, in _transition
    recommendations, client_msgs, worker_msgs = func(
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2488, in _transition_waiting_processing
    return self._add_to_processing(ts, ws, stimulus_id=stimulus_id)
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 3410, in _add_to_processing
    return {}, {}, {ws.address: [self._task_to_msg(ts)]}
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 3578, in _task_to_msg
    assert ts.priority, ts
AssertionError: <TaskState 'bar' processing>
2025-05-06 13:23:15,018 - distributed.scheduler - ERROR - <TaskState 'bar' processing>
2025-05-06 13:23:15,018 - distributed.protocol.pickle - ERROR - Failed to serialize <TaskState 'bar' processing>.
Traceback (most recent call last):
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 4936, in update_graph
    metrics = self._create_taskstate_from_graph(
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 4809, in _create_taskstate_from_graph
    self.transitions(recommendations, stimulus_id)
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 8294, in transitions
    self._transitions(recommendations, client_msgs, worker_msgs, stimulus_id)
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2154, in _transitions
    new_recs, new_cmsgs, new_wmsgs = self._transition(key, finish, stimulus_id)
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2037, in _transition
    recommendations, client_msgs, worker_msgs = func(
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2488, in _transition_waiting_processing
    return self._add_to_processing(ts, ws, stimulus_id=stimulus_id)
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 3410, in _add_to_processing
    return {}, {}, {ws.address: [self._task_to_msg(ts)]}
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 3578, in _task_to_msg
    assert ts.priority, ts
AssertionError: <TaskState 'bar' processing>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fjetter/workspace/distributed/distributed/protocol/pickle.py", line 60, in dumps
    result = pickle.dumps(x, **dump_kwargs)
TypeError: cannot pickle 'weakref.ReferenceType' object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fjetter/workspace/distributed/distributed/protocol/pickle.py", line 65, in dumps
    pickler.dump(x)
TypeError: cannot pickle 'weakref.ReferenceType' object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/fjetter/workspace/distributed/distributed/protocol/pickle.py", line 77, in dumps
    result = cloudpickle.dumps(x, **dump_kwargs)
  File "/Users/fjetter/miniforge3/envs/dask-distributed/lib/python3.10/site-packages/cloudpickle/cloudpickle.py", line 1537, in dumps
    cp.dump(obj)
  File "/Users/fjetter/miniforge3/envs/dask-distributed/lib/python3.10/site-packages/cloudpickle/cloudpickle.py", line 1303, in dump
    return super().dump(obj)
TypeError: cannot pickle 'weakref.ReferenceType' object
```

If `validate` is enabled, as in our test suite, the error is simply

```python
2025-05-06 13:19:47,262 - distributed.scheduler - ERROR - Error transitioning 'bar' from 'released' to 'waiting'
Traceback (most recent call last):
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2037, in _transition
    recommendations, client_msgs, worker_msgs = func(
  File "/Users/fjetter/workspace/distributed/distributed/scheduler.py", line 2172, in _transition_released_waiting
    assert ts.run_spec
AssertionError
```