### PR TITLE
Use stable crick for py310

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - asyncssh
   - bokeh
+  - crick  # Only tested here; also a dependency of dask
   - click
   - cloudpickle
   - coverage
@@ -58,5 +59,4 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
-      - git+https://github.com/dask/crick  # Only tested here
       - keras


### PR DESCRIPTION
The build seems to be failing. I don't see a reason to build the wheels on the fly. Crick doesn't see much development so we should be fine running against a stable build