### PR TITLE
Add more threading configs

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -193,10 +193,14 @@ distributed:
     pre-spawn-environ:
       # See https://distributed.dask.org/en/stable/worker-memory.html#automatically-trim-memory
       MALLOC_TRIM_THRESHOLD_: 65536
-      # Numpy configuration
+      # See https://github.com/joblib/joblib/blob/ed0806a497268005ad7dad30f79e1d563927d7c6/joblib/_parallel_backends.py#L59-L67
       OMP_NUM_THREADS: 1
       MKL_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
+      BLIS_NUM_THREADS: 1
+      VECLIB_MAXIMUM_THREADS: 1
+      NUMBA_NUM_THREADS: 1
+      NUMEXPR_NUM_THREADS: 1
 
   client:
     heartbeat: 5s  # Interval between client heartbeats


### PR DESCRIPTION
Big question: is this even correct? Dasks’s docs mention the three env variables mentioned here, but why “1”?

What does `threads_per_worker` in `LocalCluster` mean?

Ideally I’d start my workers, run 1 Python thread in each of them, and configure each of them so all these parallelization engines use a certain number of threads. 

Closes #9075

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

no tests, since you also don’t test `OMP_NUM_THREADS` and the other documented env variables.
