### PR TITLE
Fix ``pyarrow`` ``FileInfo`` import

### DIFF
--- a/distributed/protocol/arrow.py
+++ b/distributed/protocol/arrow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import pyarrow
+import pyarrow.fs
 
 from distributed.protocol.serialize import dask_deserialize, dask_serialize
 


### PR DESCRIPTION
Custom serialization for `pyarrow.fs.FileInfo` was recently added to help with Parquet in Dask DataFrame (xref https://github.com/dask/distributed/pull/9025) but this import isn't quite right

```python
In [1]: import pyarrow

In [2]: pyarrow.fs.FileInfo
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 pyarrow.fs.FileInfo

AttributeError: module 'pyarrow' has no attribute 'fs'
```

I think this went unnoticed because in the Dask DataFrame case we trigger this correct import first

https://github.com/dask/dask/blob/c8ef947bd38e2b739ad3eccdbcce42e08d8c3f4a/dask/dataframe/dask_expr/io/parquet.py#L21

first which allows the import here to work. 

However in the non-Dask DataFrame parquet case, that correct import doesn't happen and folks hit the `AttributeError`