### PR TITLE
Add more threading configs

### DIFF
--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -193,10 +193,14 @@ distributed:
     pre-spawn-environ:
       # See https://distributed.dask.org/en/stable/worker-memory.html#automatically-trim-memory
       MALLOC_TRIM_THRESHOLD_: 65536
-      # Numpy configuration
+      # See https://github.com/joblib/joblib/blob/ed0806a497268005ad7dad30f79e1d563927d7c6/joblib/_parallel_backends.py#L59-L67
       OMP_NUM_THREADS: 1
       MKL_NUM_THREADS: 1
       OPENBLAS_NUM_THREADS: 1
+      BLIS_NUM_THREADS: 1
+      VECLIB_MAXIMUM_THREADS: 1
+      NUMBA_NUM_THREADS: 1
+      NUMEXPR_NUM_THREADS: 1
 
   client:
     heartbeat: 5s  # Interval between client heartbeats


### PR DESCRIPTION
Closes #9075

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

no tests, since you also don’t test `OMP_NUM_THREADS` and the other documented env variables.

If this is a deja-vu, that’s because #9076 was closed with no real reason:
this *should* be merged! It’s a much better default than “use all cores”.