### PR TITLE
Reuse Comm objects in Scheduler.broadcast

### DIFF
--- a/distributed/distributed-schema.yaml
+++ b/distributed/distributed-schema.yaml
@@ -63,6 +63,15 @@ properties:
 
               This is used by the scheduler in some scheduling decisions
 
+          reuse-broadcast-comm:
+            type: boolean
+            description: |
+              Whether to reuse the Scheduler to Worker Comm for repeated broadcasts.
+
+              This can be useful to avoid the overhead of creating and destroying Comms when sending multiple
+              small messages in methods like ``Client.run``. The scheduler will persist an open
+              Comm object for each worker. Set this to False if you want to close the Comm after each broadcast.
+
           events-cleanup-delay:
             type: string
             description: |

--- a/distributed/distributed.yaml
+++ b/distributed/distributed.yaml
@@ -15,6 +15,8 @@ distributed:
     blocked-handlers: []
     contact-address: null
     default-data-size: 1kiB
+    # Whether to reuse the same Scheduler to Worker comm for repeated broadcasts.
+    reuse-broadcast-comm: True
     # Number of seconds to wait until workers or clients are removed from the events log
     # after they have been removed from the scheduler
     events-cleanup-delay: 1h

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -6747,13 +6747,18 @@ class Scheduler(SchedulerState, ServerNode):
 
         ERROR = object()
 
+        reuse_broadcast_comm = dask.config.get(
+            "distributed.scheduler.reuse-broadcast-comm", False
+        )
+        close = not reuse_broadcast_comm
+
         async def send_message(addr: str) -> Any:
             try:
                 comm = await self.rpc.connect(addr)
                 comm.name = "Scheduler Broadcast"
                 try:
                     resp = await send_recv(
-                        comm, close=True, serializers=serializers, **msg
+                        comm, close=close, serializers=serializers, **msg
                     )
                 finally:
                     self.rpc.reuse(addr, comm)


### PR DESCRIPTION
This updates Scheduler.broadcast to reuse (i.e. *not* close) the Comm object that sends the message to the worker. This is motivated by the UCX comms, which are relatively expensive to create and destroy. We noticed that a simple ``client.run`` (which uses ``Scheduler.broadcast`` internally) took ~100s of ms to complete with UCX, most of which was spent creating and destroying Comm objects. With this change, subsequent ``client.run`` calls take <10ms.

I've provided a new config option `distributed.scheduler.reuse-broadcast-comm` for users who want the previous behavior. But based on https://github.com/dask/distributed/pull/3766/files, folks agreed that this was a better default behavior. That change didn't quite get the desired behavior because of the `close=True` passed to `send_recv`.
