### PR TITLE
Fix ``test_resubmit_nondeterministic_task_different_deps``

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -355,7 +355,10 @@ class Future(TaskRef):
         str
             The status
         """
-        return self._state.status
+        if self._state:
+            return self._state.status
+        else:
+            return None
 
     def done(self):
         """Returns whether or not the computation completed.
@@ -554,7 +557,10 @@ class Future(TaskRef):
     @property
     def type(self):
         """Returns the type"""
-        return self._state.type
+        if self._state:
+            return self._state.type
+        else:
+            return None
 
     def release(self):
         """


### PR DESCRIPTION
So this should fix ``test_resubmit_nondeterministic_task_different_deps`` (it does for me locally). I'll admit that I don't fully understand what change in https://github.com/dask/dask/pull/11945 is causing this test to fail...

Currently `Future._state` isn't being set, but our code expects it to be, so the change here might actually just be mask over something (why `_state` isn't being set in the first place) instead of fixing the underlying issue

cc @jacobtomlinson @TomAugspurger for vis and thoughts (if you happen have any here) 

Closes https://github.com/dask/distributed/issues/9080