### PR TITLE
Make module name logic more resilient in ``_always_use_pickle_for``

### DIFF
--- a/distributed/protocol/pickle.py
+++ b/distributed/protocol/pickle.py
@@ -29,7 +29,10 @@ class _DaskPickler(pickle.Pickler):
 
 
 def _always_use_pickle_for(x):
-    mod, _, _ = x.__class__.__module__.partition(".")
+    try:
+        mod, _, _ = x.__class__.__module__.partition(".")
+    except Exception:
+        return False
     if mod == "numpy":
         import numpy as np
 


### PR DESCRIPTION
Companion PR to this change over in `dask/dask` https://github.com/dask/dask/pull/11974