### PR TITLE
Remove ``s3fs`` from testing CI environment

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -42,7 +42,6 @@ dependencies:
   - python-snappy  # Only tested here
   - pytorch  # Only tested here
   - requests
-  - s3fs
   - scikit-learn
   - scipy
   - sortedcollections

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -36,7 +36,6 @@ dependencies:
   - pytest-rerunfailures
   - pytest-timeout
   - requests
-  - s3fs  # overridden by git tip below
   - scikit-learn
   - scipy
   - sortedcollections
@@ -52,6 +51,5 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
-      - git+https://github.com/dask/s3fs
       - git+https://github.com/fsspec/filesystem_spec
       - keras

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -36,7 +36,6 @@ dependencies:
   - pytest-rerunfailures
   - pytest-timeout
   - requests
-  - s3fs  # overridden by git tip below
   - scikit-learn
   - scipy
   - sortedcollections
@@ -52,6 +51,5 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
-      - git+https://github.com/dask/s3fs
       - git+https://github.com/fsspec/filesystem_spec
       - keras

--- a/continuous_integration/environment-3.13.yaml
+++ b/continuous_integration/environment-3.13.yaml
@@ -35,7 +35,6 @@ dependencies:
   - pytest-rerunfailures
   - pytest-timeout
   - requests
-  - s3fs  # overridden by git tip below
   - scikit-learn
   - scipy
   - sortedcollections
@@ -51,6 +50,5 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
-      - git+https://github.com/dask/s3fs
       - git+https://github.com/fsspec/filesystem_spec
       - keras


### PR DESCRIPTION
Currently we're seeing CI build failures ([example build](https://github.com/dask/distributed/actions/runs/15434776081/job/43438922123)) due to us trying to install the nightly dev version of `fsspec` and `s3fs` (xref https://github.com/fsspec/s3fs/issues/969). 

I noticed that we don't actually use `s3fs` in the test suite here (we do in `dask/dask` though). This PR proposes we just remove `s3fs` from the CI environments here. 