### PR TITLE
Update ``def`` to ``class`` typo in actors docs

### DIFF
--- a/docs/source/actors.rst
+++ b/docs/source/actors.rst
@@ -193,7 +193,7 @@ will run on the Worker's event loop thread rather than a separate thread.
 
 .. code-block:: python
 
-   def Waiter:
+   class Waiter:
        def __init__(self):
            self.event = asyncio.Event()
 


### PR DESCRIPTION
A small typo fix for the documentation of Actors.
