### PR TITLE
add support for grouped workers in `SpecCluster._update_worker_status`

### DIFF
--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -402,7 +402,9 @@ class SpecCluster(Cluster):
             # Closure to handle removal of a worker from the cluster
             def f():
                 # Check if worker is truly gone from scheduler
-                active_workers = {d["name"] for d in self.scheduler_info.get("workers", {}).values()}
+                active_workers = {
+                    d["name"] for d in self.scheduler_info.get("workers", {}).values()
+                }
                 if removed_worker_name in active_workers:
                     return
 

--- a/distributed/deploy/spec.py
+++ b/distributed/deploy/spec.py
@@ -429,11 +429,17 @@ class SpecCluster(Cluster):
                 if worker_spec_name and worker_spec_name in self.worker_spec:
                     # Close and remove the worker object
                     if worker_spec_name in self.workers:
-                        self._futures.add(asyncio.ensure_future(self.workers[worker_spec_name].close()))
+                        self._futures.add(
+                            asyncio.ensure_future(
+                                self.workers[worker_spec_name].close()
+                            )
+                        )
                         del self.workers[worker_spec_name]
                     del self.worker_spec[worker_spec_name]
 
-            delay = parse_timedelta(dask.config.get("distributed.deploy.lost-worker-timeout"))
+            delay = parse_timedelta(
+                dask.config.get("distributed.deploy.lost-worker-timeout")
+            )
             asyncio.get_running_loop().call_later(delay, f)
 
         super()._update_worker_status(op, msg)

--- a/distributed/deploy/tests/test_spec_cluster.py
+++ b/distributed/deploy/tests/test_spec_cluster.py
@@ -588,16 +588,15 @@ async def test_adaptive_grouped_workers():
                 ]
                 assert len(first_group_workers) == 2
                 
-                # Close one worker from the group
-                # We need to close the worker from the cluster's worker object, not the scheduler's
+                # Close one worker from the group to simulate partial failure
+                # Strategy:
+                #   - get the MultiWorker instance
+                #   - close one of its internal workers
                 worker_to_kill_name = first_group_workers[0][1]
                 spec_name_to_kill = worker_to_kill_name.split('-')[0]
                 if spec_name_to_kill.isdigit():
                     spec_name_to_kill = int(spec_name_to_kill)
-                
-                # Get the MultiWorker instance and close one of its internal workers
                 multi_worker = cluster.workers[spec_name_to_kill]
-                # Close one of the internal workers to simulate partial failure
                 await multi_worker.workers[0].close()
                 
                 # Wait for the group to be removed


### PR DESCRIPTION
This PR adds missing support for grouped workers in `SpecCluster._update_worker_status` and fixes #9102 

Initial support for grouped workers was added in #3013 by @mrocklin
This support is documented and implemented in other parts of `SpecCluster` so I have assumed that improved support is the right path forwards.

https://github.com/dask/distributed/blob/0f0adefd2ad3dc69ace3aecf77a259c98feacbe5/distributed/deploy/spec.py#L222-L237


repro using `LocalCluster` from `dask-jobqueue` as an implementation of `SpecCluster` with grouped workers
(`LocalCluster` from `distributed` does not implement the grouped worker spec)

```python
import time
from dask.distributed import Client, LocalCluster
from dask_jobqueue.local import LocalCluster as JobQueueLocalCluster

from distributed import as_completed

# work func
def job(x):
    time.sleep(1)
    return x + 1


if __name__ == "__main__":
    # cluster setup

    # this works, LocalCluster does not use grouped workers
    # cluster = LocalCluster(
    #     n_workers=2,
    #     threads_per_worker=1,
    #     processes=True,
    #     lifetime="10s",
    #     lifetime_stagger="3s"
    # )

    cluster = JobQueueLocalCluster(
        cores=1,
        processes=2,
        memory="2GiB",
        walltime='0:30:00',
        # uncomment the line below to simulate graceful worker closure
        # c.f. https://jobqueue.dask.org/en/latest/clusters-advanced-tips-and-tricks.html#how-to-handle-job-queueing-system-walltime-killing-workers
        worker_extra_args=["--lifetime", "10s", "--lifetime-stagger", "3s"],
    )
    client = Client(cluster)

    cluster.adapt(
        maximum=4,
        interval='100ms',
        wait_count=1
    )

    njobs = 1000
    futures = client.map(job, range(njobs))

    print("Running test...")
    for future in as_completed(futures):
        print("cluster.workers keys: ", list(cluster.workers.keys()))
        print("cluster.worker_spec keys: ", list(cluster.worker_spec.keys()))

```

output before this PR with print statements to show what's going on, duplicate lines removed:

```txt
Running test...
target=4, len(self.plan)=0, len(self.observed)=0, len(self.requested)=0
target=4, len(self.plan)=4, len(self.observed)=1, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=4, len(self.requested)=4
...
target=4, len(self.plan)=4, len(self.observed)=4, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-0', 'LocalCluster-1']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']
remove signal received for: LocalCluster-0-1
target=4, len(self.plan)=4, len(self.observed)=3, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-0', 'LocalCluster-1']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']
remove signal received for: LocalCluster-1-0
target=4, len(self.plan)=4, len(self.observed)=2, len(self.requested)=4
remove signal received for: LocalCluster-0-0
target=4, len(self.plan)=4, len(self.observed)=1, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-0', 'LocalCluster-1']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']
remove signal received for: LocalCluster-1-1
target=4, len(self.plan)=4, len(self.observed)=0, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=0, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=0, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=0, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=0, len(self.requested)=4
...
# never recovers
```

output after this PR with the same print statements
```txt
Running test...
target=4, len(self.plan)=0, len(self.observed)=0, len(self.requested)=0
target=4, len(self.plan)=4, len(self.observed)=1, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=4, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-1', 'LocalCluster-0']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']

remove signal received for: LocalCluster-0-1
target=4, len(self.plan)=4, len(self.observed)=3, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-1', 'LocalCluster-0']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']

remove signal received for: LocalCluster-1-0
target=4, len(self.plan)=4, len(self.observed)=2, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-1', 'LocalCluster-0']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']

remove signal received for: LocalCluster-0-0
target=4, len(self.plan)=4, len(self.observed)=1, len(self.requested)=4
cluster.workers keys:  ['LocalCluster-1', 'LocalCluster-0']
cluster.worker_spec keys:  ['LocalCluster-0', 'LocalCluster-1']

remove signal received for: LocalCluster-1-1
target=4, len(self.plan)=4, len(self.observed)=0, len(self.requested)=4

# recovers!
target=4, len(self.plan)=2, len(self.observed)=0, len(self.requested)=2
target=4, len(self.plan)=4, len(self.observed)=1, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=2, len(self.requested)=4
target=4, len(self.plan)=2, len(self.observed)=2, len(self.requested)=2
target=4, len(self.plan)=4, len(self.observed)=3, len(self.requested)=4
target=4, len(self.plan)=4, len(self.observed)=4, len(self.requested)=4
```