### PR TITLE
Prevent Task stream dashboard showing date

### DIFF
--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -25,7 +25,6 @@ from bokeh.models import (
     ColumnDataSource,
     CustomJSHover,
     DataRange1d,
-    DatetimeTickFormatter,
     FactorRange,
     GroupFilter,
     HelpTool,
@@ -2193,7 +2192,7 @@ def task_stream_figure(clear_interval="20s", **kwargs):
         x_range=x_range,
         y_range=y_range,
         toolbar_location="above",
-        x_axis_type="datetime",
+        x_axis_type="timedelta",
         y_axis_location=None,
         tools="",
         min_border_bottom=50,
@@ -2217,7 +2216,6 @@ def task_stream_figure(clear_interval="20s", **kwargs):
     root.yaxis.major_label_text_alpha = 0
     root.yaxis.minor_tick_line_alpha = 0
     root.yaxis.major_tick_line_alpha = 0
-    root.xaxis[0].formatter = DatetimeTickFormatter(context=None)
     root.xgrid.visible = False
 
     hover = HoverTool(

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -25,6 +25,7 @@ from bokeh.models import (
     ColumnDataSource,
     CustomJSHover,
     DataRange1d,
+    DatetimeTickFormatter,
     FactorRange,
     GroupFilter,
     HelpTool,
@@ -52,6 +53,7 @@ from bokeh.plotting import figure
 from bokeh.themes import Theme
 from bokeh.transform import cumsum, factor_cmap, linear_cmap, stack
 from jinja2 import Environment, FileSystemLoader
+from packaging.version import parse as parse_version
 from tlz import curry, pipe, second, valmap
 from tlz.curried import concat, groupby, map
 
@@ -76,6 +78,7 @@ from distributed.dashboard.components.shared import (
 )
 from distributed.dashboard.utils import (
     _DATATABLE_STYLESHEETS_KWARGS,
+    BOKEH_VERSION,
     PROFILING,
     transpose,
     update,
@@ -2192,7 +2195,7 @@ def task_stream_figure(clear_interval="20s", **kwargs):
         x_range=x_range,
         y_range=y_range,
         toolbar_location="above",
-        x_axis_type="timedelta",
+        x_axis_type="timedelta" if BOKEH_VERSION >= parse_version("3.8.0") else "datetime",
         y_axis_location=None,
         tools="",
         min_border_bottom=50,
@@ -2216,6 +2219,8 @@ def task_stream_figure(clear_interval="20s", **kwargs):
     root.yaxis.major_label_text_alpha = 0
     root.yaxis.minor_tick_line_alpha = 0
     root.yaxis.major_tick_line_alpha = 0
+    if BOKEH_VERSION < parse_version("3.8.0") and BOKEH_VERSION >= parse_version("3.5.2"):
+        root.xaxis[0].formatter = DatetimeTickFormatter(boundary_scaling =False, context=None) #remove full date context misleading for users
     root.xgrid.visible = False
 
     hover = HoverTool(

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -25,6 +25,7 @@ from bokeh.models import (
     ColumnDataSource,
     CustomJSHover,
     DataRange1d,
+    DatetimeTickFormatter,
     FactorRange,
     GroupFilter,
     HelpTool,
@@ -2216,6 +2217,7 @@ def task_stream_figure(clear_interval="20s", **kwargs):
     root.yaxis.major_label_text_alpha = 0
     root.yaxis.minor_tick_line_alpha = 0
     root.yaxis.major_tick_line_alpha = 0
+    root.xaxis[0].formatter = DatetimeTickFormatter(context=None)
     root.xgrid.visible = False
 
     hover = HoverTool(

--- a/distributed/dashboard/components/scheduler.py
+++ b/distributed/dashboard/components/scheduler.py
@@ -2195,7 +2195,9 @@ def task_stream_figure(clear_interval="20s", **kwargs):
         x_range=x_range,
         y_range=y_range,
         toolbar_location="above",
-        x_axis_type="timedelta" if BOKEH_VERSION >= parse_version("3.8.0") else "datetime",
+        x_axis_type=(
+            "timedelta" if BOKEH_VERSION >= parse_version("3.8.0") else "datetime"
+        ),
         y_axis_location=None,
         tools="",
         min_border_bottom=50,
@@ -2219,8 +2221,12 @@ def task_stream_figure(clear_interval="20s", **kwargs):
     root.yaxis.major_label_text_alpha = 0
     root.yaxis.minor_tick_line_alpha = 0
     root.yaxis.major_tick_line_alpha = 0
-    if BOKEH_VERSION < parse_version("3.8.0") and BOKEH_VERSION >= parse_version("3.5.2"):
-        root.xaxis[0].formatter = DatetimeTickFormatter(boundary_scaling =False, context=None) #remove full date context misleading for users
+    if BOKEH_VERSION < parse_version("3.8.0") and BOKEH_VERSION >= parse_version(
+        "3.5.2"
+    ):
+        root.xaxis[0].formatter = DatetimeTickFormatter(
+            boundary_scaling=False, context=None
+        )  # remove full date context misleading for users
     root.xgrid.visible = False
 
     hover = HoverTool(


### PR DESCRIPTION
Closes #9055

- No test added
- [x ] Passes `pre-commit run --all-files`

At first, I tried to configure Bokeh `DatetimeTickFormatter` to avoid showing context. I guess this looks the same than task stream a few months ago:
<img width="1418" height="526" alt="image" src="https://github.com/user-attachments/assets/117cc24e-bb6e-4973-9986-120c6eb08264" />

From what I could tell, there already was this `01/01` legend, which annoyed me. 

Then I became aware of the `timedelta` formatter, which in the end is what Task stream information is showing, so just switching to this:

<img width="1429" height="547" alt="image" src="https://github.com/user-attachments/assets/8661ed93-d7d1-4943-ad5a-d7bbb11b2072" />

I feel the second solution is better.

Some considerations:

- I really don't know how to add test for that and if it's possible.
- There is probably some checks to do on Bokeh version, it seems `timedelta` x_axis_type was only integrated in Bokeh 3.8 last version... Not sure how it should be handled.