### PR TITLE
`pynvml` -> `nvidia-ml-py` in CI

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -32,7 +32,7 @@ dependencies:
   - prometheus_client
   - psutil
   - pyarrow
-  - pynvml  # Only tested here
+  - nvidia-ml-py  # Only tested here
   - pytest<8.4  # Pin due to https://github.com/pytest-dev/pytest-cov/issues/693
   - pytest-cov
   - pytest-faulthandler


### PR DESCRIPTION
Attempt to resolve #9110 

The warning in #9110 is about a failure to parse the warning to parse the warning from `pynvml` `FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.`

This PR resolves it by following the advice of the warning and switching to the `nvidia-ml-py` package, rather than digging into the parsing error. We could look at this too, but this PR resolves the immediate issue.

The `nvidia-ml-py` package also provides the `pynvml` library and still uses `import pynvml` but is more officially maintained than the `pynvml` package on PyPI/conda-forge. Recent releases of `pynvml` just depend on `nvidia-ml-py` and raise this warning when imported.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
