### PR TITLE
Fix uncaught error during CI startup debug info

### DIFF
--- a/continuous_integration/scripts/host_info.py
+++ b/continuous_integration/scripts/host_info.py
@@ -33,7 +33,7 @@ def main() -> None:
     try:
         freqs = psutil.cpu_freq(percpu=True)
     # https://github.com/giampaolo/psutil/issues/2382
-    except RuntimeError:
+    except (AttributeError, RuntimeError):
         print("CPU frequency: not available")
     else:
         print("CPU frequency:")


### PR DESCRIPTION
With the latest release of `psutil==7.1.0` there seems to be a change in exception on macOS. 

I noticed a [CI failure](https://github.com/dask/distributed/actions/runs/17854350762/job/50769871393?pr=9109) in #9109 that was during some debug info printing during CI startup. This PR makes the error handling more flexible.