### PR TITLE
Skip hanging SSH tests on Windows

### DIFF
--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from time import sleep
 
 import pytest
@@ -32,6 +33,8 @@ def test_cluster(loop):
                 assert time() < start + 5
 
 
+# https://github.com/dask/distributed/issues/9114
+@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows in CI")
 def test_old_ssh_nprocs_renamed_to_n_workers():
     with pytest.warns(FutureWarning, match="renamed to n_workers"):
         with SSHCluster(

--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -7,6 +7,9 @@ import pytest
 
 pytest.importorskip("paramiko")
 
+# https://github.com/dask/distributed/issues/9114
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows in CI")
+
 from distributed import Client
 from distributed.deploy.old_ssh import SSHCluster
 from distributed.metrics import time
@@ -33,8 +36,6 @@ def test_cluster(loop):
                 assert time() < start + 5
 
 
-# https://github.com/dask/distributed/issues/9114
-@pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows in CI")
 def test_old_ssh_nprocs_renamed_to_n_workers():
     with pytest.warns(FutureWarning, match="renamed to n_workers"):
         with SSHCluster(

--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -7,13 +7,13 @@ import pytest
 
 pytest.importorskip("paramiko")
 
-# https://github.com/dask/distributed/issues/9114
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows in CI")
-
 from distributed import Client
 from distributed.deploy.old_ssh import SSHCluster
 from distributed.metrics import time
 
+
+# https://github.com/dask/distributed/issues/9114
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows in CI")
 
 @pytest.mark.avoid_ci
 def test_cluster(loop):

--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -11,9 +11,11 @@ from distributed import Client
 from distributed.deploy.old_ssh import SSHCluster
 from distributed.metrics import time
 
-
 # https://github.com/dask/distributed/issues/9114
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="Hangs on Windows in CI")
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="Hangs on Windows in CI"
+)
+
 
 @pytest.mark.avoid_ci
 def test_cluster(loop):


### PR DESCRIPTION
Closes #9114

Old SSH tests are hanging on Windows. Given that these tests are for a deprecated API I think we are safe to just skip on Windows. We should probably consider removing this old API at some point too.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
