### PR TITLE
Plugin registration status

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5456,6 +5456,57 @@ class Client(SyncMethodMixin):
         """
         return self.sync(self._unregister_worker_plugin, name=name, nanny=nanny)
 
+    def has_plugin(
+        self, 
+        name: str | list[str], 
+        plugin_type: str = "worker"
+    ) -> bool | dict[str, bool]:
+        """Check if plugin(s) are registered
+        
+        Checks whether plugin(s) are registered in the scheduler's plugin registry.
+        This only verifies registration - not whether plugins are actually running
+        or functioning correctly.
+        
+        Parameters
+        ----------
+        name : str or list[str]
+            Plugin name(s) to check
+        plugin_type : str, optional  
+            Type of plugin: 'worker', 'scheduler', or 'nanny'. Defaults to 'worker'.
+            
+        Returns
+        -------
+        bool or dict[str, bool]
+            If name is str: True if plugin is registered, False otherwise
+            If name is list: dict mapping names to registration status
+            
+        See Also
+        --------
+        register_plugin
+        unregister_worker_plugin
+        """
+        if isinstance(name, str):
+            result = self.sync(
+                self._get_plugin_registration_status, 
+                names=[name], 
+                plugin_type=plugin_type
+            )
+            return result[name]
+        else:
+            return self.sync(
+                self._get_plugin_registration_status,
+                names=name,
+                plugin_type=plugin_type
+            )
+
+    async def _get_plugin_registration_status(
+        self, names: list[str], plugin_type: str
+    ) -> dict[str, bool]:
+        """Async implementation for checking plugin registration"""
+        return await self.scheduler.get_plugin_registration_status(
+            names=names, plugin_type=plugin_type
+        )
+
     @property
     def amm(self):
         """Convenience accessors for the :doc:`active_memory_manager`"""

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4039,6 +4039,7 @@ class Scheduler(SchedulerState, ServerNode):
             "unregister_worker_plugin": self.unregister_worker_plugin,
             "register_nanny_plugin": self.register_nanny_plugin,
             "unregister_nanny_plugin": self.unregister_nanny_plugin,
+            "get_plugin_registration_status": self.get_plugin_registration_status,
             "adaptive_target": self.adaptive_target,
             "workers_to_close": self.workers_to_close,
             "subscribe_worker_status": self.subscribe_worker_status,
@@ -8696,6 +8697,41 @@ class Scheduler(SchedulerState, ServerNode):
         )
         return dict(zip(self.workers, results))
 
+    async def get_plugin_registration_status(
+        self, names: list[str], plugin_type: str = "worker"
+    ) -> dict[str, bool]:
+        """Check if plugins are registered
+        
+        Parameters
+        ----------
+        names : list[str]
+            List of plugin names to check
+        plugin_type : str, optional
+            Type of plugin to check: 'worker', 'scheduler', or 'nanny'
+            
+        Returns
+        -------
+        dict[str, bool]
+            Dict mapping plugin names to their registration status
+            
+        Raises
+        ------
+        ValueError
+            If plugin_type is not one of 'worker', 'scheduler', 'nanny'
+        """
+        if plugin_type == "worker":
+            plugin_dict = self.worker_plugins
+        elif plugin_type == "scheduler":
+            plugin_dict = self.plugins
+        elif plugin_type == "nanny":
+            plugin_dict = self.nanny_plugins
+        else:
+            raise ValueError(
+                f"plugin_type must be 'worker', 'scheduler', or 'nanny', got {plugin_type!r}"
+            )
+        
+        return {name: name in plugin_dict for name in names}
+        
     ###########
     # Cleanup #
     ###########

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -8697,41 +8697,50 @@ class Scheduler(SchedulerState, ServerNode):
         )
         return dict(zip(self.workers, results))
 
-    async def get_plugin_registration_status(
-        self, names: list[str], plugin_type: str = "worker"
-    ) -> dict[str, bool]:
-        """Check if plugins are registered
-        
+    async def get_plugin_registration_status(self, names: list[str]) -> dict[str, bool]:
+        """Check if plugins are registered in any plugin registry
+
+        Checks all plugin registries (worker, scheduler, nanny) and returns True
+        if the plugin is found in any of them.
+
         Parameters
         ----------
         names : list[str]
             List of plugin names to check
-        plugin_type : str, optional
-            Type of plugin to check: 'worker', 'scheduler', or 'nanny'
-            
+
         Returns
         -------
         dict[str, bool]
-            Dict mapping plugin names to their registration status
-            
-        Raises
-        ------
-        ValueError
-            If plugin_type is not one of 'worker', 'scheduler', 'nanny'
+            Dict mapping plugin names to their registration status across all registries
         """
-        if plugin_type == "worker":
-            plugin_dict = self.worker_plugins
-        elif plugin_type == "scheduler":
-            plugin_dict = self.plugins
-        elif plugin_type == "nanny":
-            plugin_dict = self.nanny_plugins
-        else:
-            raise ValueError(
-                f"plugin_type must be 'worker', 'scheduler', or 'nanny', got {plugin_type!r}"
+        result = {}
+        for name in names:
+            # Check if plugin exists in any registry
+            result[name] = (
+                name in self.worker_plugins
+                or name in self.plugins
+                or name in self.nanny_plugins
             )
-        
-        return {name: name in plugin_dict for name in names}
-        
+        return result
+
+    async def get_worker_plugin_registration_status(
+        self, names: list[str]
+    ) -> dict[str, bool]:
+        """Check if worker plugins are registered"""
+        return {name: name in self.worker_plugins for name in names}
+
+    async def get_scheduler_plugin_registration_status(
+        self, names: list[str]
+    ) -> dict[str, bool]:
+        """Check if scheduler plugins are registered"""
+        return {name: name in self.plugins for name in names}
+
+    async def get_nanny_plugin_registration_status(
+        self, names: list[str]
+    ) -> dict[str, bool]:
+        """Check if nanny plugins are registered"""
+        return {name: name in self.nanny_plugins for name in names}
+
     ###########
     # Cleanup #
     ###########


### PR DESCRIPTION
Closes #9106 

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Adds a client side function to check if a plugin is registered on either the scheduler, worker or nanny registries.  The plugin names seem to be unique enough to ignore the edge case where two different plugin types such as a `WorkerPlugin` and a `SchedulerPlugin` have the same name. The `scheduler` has separate functions added for this use case but will need to add extra `client` functions to separate the `has_plugin` function into `has_worker_plugin` etc. 

Apart from checking if a plugin is registered by passing its name, also added the functionality of passing the plugin object itself with name extraction handled by the function. This is especially useful while using built-in plugins for users who do not know about the `plugin.name` attribute. Also added an error check for plugins whose name is not set. 

CC: @jacobtomlinson 
