### PR TITLE
Add ForwardLoggingPlugin and ForwardOutput to built-in worker plugins documentation

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -116,6 +116,8 @@ Built-In Worker Plugins
 -----------------------
 
 .. autoclass:: distributed.diagnostics.plugin.UploadFile
+.. autoclass:: distributed.diagnostics.plugin.ForwardLoggingPlugin
+.. autoclass:: distributed.diagnostics.plugin.ForwardOutput
 
 
 Nanny Plugins


### PR DESCRIPTION
`ForwardLoggingPlugin` and `ForwardOutput` were missing from the "Built-In Worker Plugins" section. This PR adds them.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
