### PR TITLE
Adapt worker and nanny to ipv6

### DIFF
--- a/distributed/comm/tcp.py
+++ b/distributed/comm/tcp.py
@@ -39,7 +39,7 @@ from distributed.comm.utils import (
 )
 from distributed.protocol.utils import host_array, pack_frames_prelude, unpack_frames
 from distributed.system import MEMORY_LIMIT
-from distributed.utils import ensure_ip, ensure_memoryview, get_ip, get_ipv6, nbytes
+from distributed.utils import ensure_ip, ensure_memoryview, get_ip, nbytes
 
 logger = logging.getLogger(__name__)
 
@@ -759,10 +759,7 @@ class BaseTCPBackend(Backend):
     def get_local_address_for(self, loc):
         host, port = parse_host_port(loc)
         host = ensure_ip(host)
-        if ":" in host:
-            local_host = get_ipv6(host)
-        else:
-            local_host = get_ip(host)
+        local_host = get_ip(host)
         return unparse_host_port(local_host, None)
 
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -27,7 +27,7 @@ from dask.utils import parse_timedelta
 from distributed import preloading
 from distributed._async_taskgroup import AsyncTaskGroupClosedError
 from distributed.comm import get_address_host
-from distributed.comm.addressing import address_from_user_args
+from distributed.comm.addressing import address_from_user_args, unparse_host_port
 from distributed.compatibility import asyncio_run
 from distributed.config import get_loop_factory
 from distributed.core import (
@@ -276,7 +276,7 @@ class Nanny(ServerNode):
             and not interface
             and not self.scheduler_addr.startswith("inproc://")
         ):
-            host = get_ip(get_address_host(self.scheduler.address))
+            host = unparse_host_port(get_ip(get_address_host(self.scheduler.address)))
 
         self._start_port = port
         self._start_host = host

--- a/distributed/node.py
+++ b/distributed/node.py
@@ -176,7 +176,8 @@ class ServerNode(Server):
         bound_addresses = get_tcp_server_addresses(self.http_server)
 
         # If more than one address is configured we just use the first here
-        self.http_server.address, self.http_server.port = bound_addresses[0]
+        # Socket addresses representation: https://docs.python.org/3/library/socket.html#socket-families
+        self.http_server.address, self.http_server.port = bound_addresses[0][:2]
         self.services["dashboard"] = self.http_server
 
         # Warn on port changes

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -67,6 +67,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop
 
 import dask
+from dask.utils import _deprecated
 from dask.utils import ensure_bytes as _ensure_bytes
 from dask.utils import key_split
 from dask.utils import parse_timedelta as _parse_timedelta
@@ -213,12 +214,18 @@ def get_ip(host="8.8.8.8", port=80):
     """
     Get the local IP address through which the *host* is reachable.
 
+    It will try to get ipv4 or ipv6 adaptively depending on the *host* to reach.
+
     *host* defaults to a well-known Internet host (one of Google's public
     DNS servers).
     """
-    return _get_ip(host, port, family=socket.AF_INET)
+    if ":" in host:
+        return _get_ip(host, port, family=socket.AF_INET6)
+    else:
+        return _get_ip(host, port, family=socket.AF_INET)
 
 
+@_deprecated(use_instead="get_ip")
 def get_ipv6(host="2001:4860:4860::8888", port=80):
     """
     The same as get_ip(), but for IPv6.


### PR DESCRIPTION
We found we failed to create SSH Cluster in ipv6 only machines and it's because some codes in worker, nanny modules work only for ipv4 environment. 

This pr tries to adapt worker and annny to ipv6 and we have verified it works in our ipv6 only environment.

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
