### PR TITLE
Fix CI Multiple aliased keys in file /Users/runner/.condarc

### DIFF
--- a/continuous_integration/condarc
+++ b/continuous_integration/condarc
@@ -2,7 +2,6 @@ channels:
   - conda-forge
   - defaults
 channel_priority: true
-auto_activate_base: false
 remote_backoff_factor: 20
 remote_connect_timeout_secs: 20.0
 remote_max_retries: 10


### PR DESCRIPTION
Closes #9135 

There seems to be a conflict between auto activating the CI environment, and disabling the auto activation of the base environment. I'm a little confused as to why this happened because we pin the conda action to a specific version. 

Trying out this quick fix to remove the disable base activation setting given that we specify which environment should be activated anyway.