### PR TITLE
Fix empty progress bar

### DIFF
--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -427,8 +427,7 @@ class MultiProgressWidget(MultiProgressBar):
         else:
             self.elapsed_time.value = (
                 '<div style="padding: 0px 10px 5px 10px">'
-                f"<b>Finished:</b> {format_time(self.elapsed)}"
-                f"{' (no tasks given)' if not self.keys else ''}"
+                f"<b>Finished:</b> {format_time(self.elapsed) if self.keys else 'no tasks given'}</div>"
                 "</div>"
             )
 


### PR DESCRIPTION
Closes #9143

- Calls `MultiProgressWidget.make_widget(tasks)` even if progress is given an empty iterable of tasks
- If there are no tasks display `no tasks given` instead of the completion time

<img width="560" height="460" alt="image" src="https://github.com/user-attachments/assets/600227cb-b0e8-4612-a011-7f28179c9694" />
