### PR TITLE
Clean up `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,5 +13,7 @@ recursive-exclude distributed **/tests/*
 
 exclude distributed/pytest_resourceleaks.py
 
+prune .github
+prune continuous_integration
 prune docs/_build
 include distributed/_version.py


### PR DESCRIPTION
From [Controlling files in the distribution](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html):

> For the most common use cases, `setuptools` will automatically find out which files are necessary for distributing the package. More precisely, the following files are included in a source distribution by default:
> * All files specified by the `license-files` configuration parameter in `pyproject.toml` [...]; note that if you don’t explicitly set this parameter, `setuptools` will include any files that match the following glob patterns: `LICEN[CS]E*`, `COPYING*`, `NOTICE*`, `AUTHORS**`;
> * `pyproject.toml`;
> * `setup.py`;
> * `README`, `README.txt`, `README.rst` or `README.md`;
> * `MANIFEST.in`

Source distributions should include tests:
https://github.com/dask/distributed/blob/c7d9c55e5e9ee5fa7052477c5a7f136bd011fa1a/MANIFEST.in#L12
See [Provide complete source distributions](https://packaging.python.org/en/latest/discussions/downstream-packaging/#provide-complete-source-distributions) in the [Python Packaging User Guide](https://packaging.python.org/en/latest/):
> Ideally, **a source distribution archive published on PyPI should include all the files from the package’s Git repository** that are necessary to build the package itself, run its test suite, build and install its documentation, and any other files that may be useful to end users, such as shell completions, editor support files, and so on.