### PR TITLE
Clean up setuptools-specific configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,6 @@ dask-ssh = "distributed.cli.dask_ssh:main"
 dask-scheduler = "distributed.cli.dask_scheduler:main"
 dask-worker = "distributed.cli.dask_worker:main"
 
-[tool.setuptools]
-include-package-data = true
-zip-safe = false
-
 [tool.setuptools.packages.find]
 exclude = ["*tests*"]
 namespaces = false


### PR DESCRIPTION
* `include-package-data` is True by default
* `zip-safe` is obsolete, only relevant for `pkg_resources`, `easy_install` and `setup.py install` in the context of eggs (deprecated)

https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration