### PR TITLE
Typehint and documentation for Future.status

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -302,13 +302,13 @@ class Future(TaskRef, Generic[_T]):
     # Make sure this stays unique even across multiple processes or hosts
     _uid = uuid.uuid4().hex
 
-    def __init__(self, key, client=None, state=None, _id=None):
+    def __init__(self, key: str | tuple, client=None, state=None, _id=None):
         self.key = key
         self._cleared = False
         self._client = client
         self._id = _id or (Future._uid, next(Future._counter))
         self._input_state = state
-        self._state = None
+        self._state: FutureState | None = None
         self._bind_late()
 
     @property
@@ -358,13 +358,17 @@ class Future(TaskRef, Generic[_T]):
         return self.client
 
     @property
-    def status(self):
-        """Returns the status
+    def status(
+        self,
+    ) -> Literal["cancelled", "error", "finished", "lost", "pending"] | None:
+        """The status of the future.
 
         Returns
         -------
-        str
-            The status
+        {"cancelled", "error", "finished", "lost", "pending"}
+            The current status. This may be None if the future has not been
+            bound to a client.
+
         """
         if self._state:
             return self._state.status
@@ -640,6 +644,8 @@ class FutureState:
     """
 
     __slots__ = ("_event", "key", "status", "type", "exception", "traceback")
+
+    status: Literal["cancelled", "error", "finished", "lost", "pending"]
 
     def __init__(self, key: str):
         self._event = None


### PR DESCRIPTION
Added some type hinting for `distributed.client.FutureState.status` and the `distributed.client.Future.status` property that returns it.

Updated the docstring of `Future.status` to also include these states. The type hint has to include `None` as an option as technically the state may not be set until `_bind_late()` runs. I have mentioned this in the docstring currently; this may be an unlikely case that doesn't make sense to include in the docstring. I have enabled the *allow edits by maintainers* option so feel free to remove the None case from the docstring.

No mypy errors are raised on existing code which sets the state so I believe all the options are captured in the Literal.

With these changes, the API section of the documentation now mentions the possible statuses both from the hints and from the docstring.

Closes #9157

- [ ] ~~Tests added / passed~~
- [x] Passes `pre-commit run --all-files`
