### PR TITLE
Fix #9175: Remove reference to non-existent Scheduler.cleanup

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4329,12 +4329,8 @@ class Scheduler(SchedulerState, ServerNode):
         timeout: float | None = None,
         reason: str = "unknown",
     ) -> None:
-        """Send cleanup signal to all coroutines then wait until finished
-
-        See Also
-        --------
-        Scheduler.cleanup
-        """
+        """Send cleanup signal to all coroutines then wait until finished"""
+        
         if self.status in (Status.closing, Status.closed):
             await self.finished()
             return


### PR DESCRIPTION
This PR removes a reference to `Scheduler.cleanup` in the `Scheduler.close` docstring, as the cleanup method does not exist. Fixes #9175