### PR TITLE
Fix masked array deserialization overflow for integer dtypes

### DIFF
--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -216,4 +216,12 @@ def deserialize_numpy_maskedarray(header, frames):
     if pickled_fv:
         fill_value = pickle.loads(fill_value)
 
+       # Ensure fill_value is compatible with dtype
+    if fill_value is not None:
+        try:
+            fill_value = np.array(fill_value, dtype=data.dtype).item()
+        except (OverflowError, ValueError, TypeError):
+            fill_value = np.ma.default_fill_value(data.dtype)
+
     return np.ma.masked_array(data, mask=mask, fill_value=fill_value)
+

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -224,4 +224,3 @@ def deserialize_numpy_maskedarray(header, frames):
             fill_value = np.ma.default_fill_value(data.dtype)
 
     return np.ma.masked_array(data, mask=mask, fill_value=fill_value)
-

--- a/distributed/protocol/numpy.py
+++ b/distributed/protocol/numpy.py
@@ -216,7 +216,7 @@ def deserialize_numpy_maskedarray(header, frames):
     if pickled_fv:
         fill_value = pickle.loads(fill_value)
 
-       # Ensure fill_value is compatible with dtype
+    # Ensure fill_value is compatible with dtype
     if fill_value is not None:
         try:
             fill_value = np.array(fill_value, dtype=data.dtype).item()


### PR DESCRIPTION
NumPy masked arrays default to a fill value of 999999, which cannot be
represented by small integer dtypes such as uint8 or uint16.

During distributed deserialization, this raises a TypeError when
reconstructing the masked array and may cause tasks to hang indefinitely.

Ensure that fill values are safely cast to the target dtype, falling back
to NumPy's default fill value when necessary.

Closes dask/dask#12260

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
