### PR TITLE
WIP 3.14t support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,15 +88,15 @@ jobs:
             task: test-noqueue
             partition: not ci1
 
-          # Free-threading (WIP - tests don't pass yet)
-          # - os: ubuntu-latest
-          #   environment: py314t
-          #   task: test-ci
-          #   partition: ci1
-          # - os: ubuntu-latest
-          #   environment: py314t
-          #   task: test-ci
-          #   partition: not ci1
+          # Free-threading
+          - os: ubuntu-latest
+            environment: py314t
+            task: test-ci
+            partition: ci1
+          - os: ubuntu-latest
+            environment: py314t
+            task: test-ci
+            partition: not ci1
 
     steps:
       - name: Checkout source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 1 - Unstable",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing",
 ]


### PR DESCRIPTION
Warning-related test failures:
These are due to a difference between 3.14 and 3.14t, which causes warnings to be contextvars-based. This causes `pytest.warns` and `pytest.mark.filterwarnings` not to catch warnings emitted by a thread which was started before the filter was set - such as in workers started by the `c` fixture. So it should just be a matter of tweaking the tests.
```
FAILED distributed/diagnostics/tests/test_nanny_plugin.py::test_duck_typed_register_nanny_plugin_is_deprecated - Exception: DeprecationWarning('Registering duck-typed plugins has been deprecated. Please make sure your plugin inherits from `NannyPlugin`.')
FAILED distributed/diagnostics/tests/test_scheduler_plugin.py::test_register_plugin - Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
FAILED distributed/diagnostics/tests/test_worker_plugin.py::test_duck_typed_register_worker_plugin_is_deprecated - Exception: DeprecationWarning('Registering duck-typed plugins has been deprecated. Please make sure your plugin subclasses `WorkerPlugin`.')
FAILED distributed/tests/test_client.py::test_warn_manual - Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
FAILED distributed/tests/test_client.py::test_warn_remote - Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,) were emitted.
FAILED distributed/tests/test_semaphore.py::test_close_async - Failed: DID NOT WARN. No warnings of type (<class 'RuntimeWarning'>,) were emitted.
FAILED distributed/protocol/tests/test_protocol.py::test_fallback_to_pickle - assert "can not serialize 'numpy.int64'" in 'Failed to serialize (Cannot serialize np.int64(1)); falling back to pickle. Be aware that this may de...
```

Other test failures, which I have not investigated yet:
```
FAILED distributed/deploy/tests/test_old_ssh.py::test_cluster - AttributeError: 'SSHCluster' object has no attribute 'status'
FAILED distributed/deploy/tests/test_ssh.py::test_old_ssh_with_local_dir - AttributeError: 'SSHCluster' object has no attribute 'status'
ERROR distributed/deploy/tests/test_old_ssh.py::test_cluster - Failed: 3 thread(s) were leaked from test
ERROR distributed/deploy/tests/test_old_ssh.py::test_old_ssh_nprocs_renamed_to_n_workers - ExceptionGroup: multiple thread exception warnings (2 sub-exceptions)
ERROR distributed/deploy/tests/test_ssh.py::test_defer_to_old - Failed: 2 thread(s) were leaked from test
ERROR distributed/deploy/tests/test_ssh.py::test_old_ssh_with_local_dir - Failed: 3 thread(s) were leaked from test

FAILED distributed/dashboard/tests/test_scheduler_bokeh.py::test_FinePerformanceMetrics - KeyError: 'evict(): dictionary is empty'
FAILED distributed/tests/test_spans.py::test_task_groups[False] - AssertionError: assert 272 == 240
FAILED distributed/tests/test_spans.py::test_task_groups[True] - AssertionError: assert 272 == 240
FAILED distributed/tests/test_spill.py::test_spillbuffer - AssertionError: assert {'b': 'bbbbbb...bbbbbbbbbbbb'} == {'a': 'aaaaaa...bbbbbbbbbbbb'}
FAILED distributed/tests/test_steal.py::test_new_worker_steals - TimeoutError: Test timeout (30) hit after 30.001825239000027s.
FAILED distributed/tests/test_steal.py::test_steal_twice - assert 33 < 30
FAILED distributed/tests/test_steal.py::test_cleanup_repeated_tasks - AssertionError: assert not [<test_steal.test_cleanup_repeated_tasks.<locals>.Foo object at 0x57d202a7400>, <test_steal.test_cleanup_repeated_tasks...
```
