### PR TITLE
Remove stale Scheduler.cleanup reference from Scheduler.close docstring

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4329,12 +4329,7 @@ class Scheduler(SchedulerState, ServerNode):
         timeout: float | None = None,
         reason: str = "unknown",
     ) -> None:
-        """Send cleanup signal to all coroutines then wait until finished
-
-        See Also
-        --------
-        Scheduler.cleanup
-        """
+        """Send cleanup signal to all coroutines then wait until finished"""
         if self.status in (Status.closing, Status.closed):
             await self.finished()
             return


### PR DESCRIPTION
## Summary
- Remove the `See Also` section in `Scheduler.close` docstring that references the non-existent `Scheduler.cleanup` method

Closes #9175

## Test plan
- [x] Verified no `cleanup` method exists on `Scheduler` or its base classes
- [x] Change is docstring-only — no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)