### PR TITLE
Truncate large coro repr in retry log output

### DIFF
--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -229,6 +229,50 @@ def test_retry_does_retry_and_sleep(cleanup):
     assert sleep_calls == [0.0, 1.0, 3.0, 6.0, 6.0]
 
 
+def test_retry_truncates_large_coro_repr(cleanup):
+    """Test that retry truncates excessively large string representations of coro."""
+
+    class MyEx(Exception):
+        pass
+
+    class LargeReprCallable:
+        def __repr__(self):
+            return "x" * 500
+
+        async def __call__(self):
+            raise MyEx("fail")
+
+    log_messages = []
+
+    async def f():
+        return await retry(
+            LargeReprCallable(),
+            retry_on_exceptions=(MyEx,),
+            count=1,
+            delay_min=0,
+            delay_max=0,
+            jitter_fraction=0,
+        )
+
+    import logging
+
+    handler = logging.Handler()
+    handler.emit = lambda record: log_messages.append(record.getMessage())
+
+    logger = logging.getLogger("distributed.utils_comm")
+    logger.addHandler(handler)
+    try:
+        with pytest.raises(MyEx):
+            asyncio_run(f(), loop_factory=get_loop_factory())
+    finally:
+        logger.removeHandler(handler)
+
+    assert len(log_messages) == 1
+    # The 500-char repr should be truncated to 200 + "..."
+    assert len(log_messages[0]) < 500
+    assert "..." in log_messages[0]
+
+
 def test_unpack_remotedata():
     def assert_eq(keys1: set[TaskRef], keys2: set[TaskRef]) -> None:
         if len(keys1) != len(keys2):

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -268,9 +268,12 @@ def test_retry_truncates_large_coro_repr(cleanup):
         logger.removeHandler(handler)
 
     assert len(log_messages) == 1
-    # The 500-char repr should be truncated to 200 + "..."
+    # reprlib truncates the 500-char repr to maxother (200) chars
     assert len(log_messages[0]) < 500
+    # reprlib uses "..." to indicate truncation
     assert "..." in log_messages[0]
+    # Verify the full 500-char repr is NOT present
+    assert "x" * 500 not in log_messages[0]
 
 
 def test_unpack_remotedata():

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import random
 from unittest import mock
 
@@ -229,7 +230,7 @@ def test_retry_does_retry_and_sleep(cleanup):
     assert sleep_calls == [0.0, 1.0, 3.0, 6.0, 6.0]
 
 
-def test_retry_truncates_large_coro_repr(cleanup):
+def test_retry_truncates_large_coro_repr(cleanup, caplog):
     """Test that retry truncates excessively large string representations of coro."""
 
     class MyEx(Exception):
@@ -242,8 +243,6 @@ def test_retry_truncates_large_coro_repr(cleanup):
         async def __call__(self):
             raise MyEx("fail")
 
-    log_messages = []
-
     async def f():
         return await retry(
             LargeReprCallable(),
@@ -254,26 +253,18 @@ def test_retry_truncates_large_coro_repr(cleanup):
             jitter_fraction=0,
         )
 
-    import logging
-
-    handler = logging.Handler()
-    handler.emit = lambda record: log_messages.append(record.getMessage())
-
-    logger = logging.getLogger("distributed.utils_comm")
-    logger.addHandler(handler)
-    try:
+    with caplog.at_level(logging.INFO, logger="distributed.utils_comm"):
         with pytest.raises(MyEx):
             asyncio_run(f(), loop_factory=get_loop_factory())
-    finally:
-        logger.removeHandler(handler)
 
-    assert len(log_messages) == 1
+    assert len(caplog.records) == 1
+    msg = caplog.records[0].getMessage()
     # reprlib truncates the 500-char repr to maxother (200) chars
-    assert len(log_messages[0]) < 500
+    assert len(msg) < 500
     # reprlib uses "..." to indicate truncation
-    assert "..." in log_messages[0]
+    assert "..." in msg
     # Verify the full 500-char repr is NOT present
-    assert "x" * 500 not in log_messages[0]
+    assert "x" * 500 not in msg
 
 
 def test_unpack_remotedata():

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -20,7 +20,14 @@ from distributed.utils_comm import (
     subs_multiple,
     unpack_remotedata,
 )
-from distributed.utils_test import BarrierGetData, BrokenComm, gen_cluster, inc
+from distributed.utils_test import (
+    BarrierGetData,
+    BrokenComm,
+    captured_logger,
+    gen_cluster,
+    gen_test,
+    inc,
+)
 
 
 def test_pack_data():
@@ -230,7 +237,9 @@ def test_retry_does_retry_and_sleep(cleanup):
     assert sleep_calls == [0.0, 1.0, 3.0, 6.0, 6.0]
 
 
-def test_retry_truncates_large_coro_repr(cleanup, caplog, monkeypatch):
+@gen_test()
+@pytest.mark.parametrize("count", [1, 2])
+async def test_retry_truncates_large_coro_repr(count):
     """Test that retry truncates excessively large string representations of coro."""
 
     class MyEx(Exception):
@@ -247,29 +256,23 @@ def test_retry_truncates_large_coro_repr(cleanup, caplog, monkeypatch):
         return await retry(
             LargeReprCallable(),
             retry_on_exceptions=(MyEx,),
-            count=1,
+            count=count,
             delay_min=0,
             delay_max=0,
             jitter_fraction=0,
         )
 
-    # distributed.config sets propagate=False on the top-level "distributed"
-    # logger, so caplog (attached to root) won't see records without re-enabling
-    # propagation on the parent for the duration of the test.
-    monkeypatch.setattr(logging.getLogger("distributed"), "propagate", True)
+    with (
+        captured_logger("distributed.utils_comm", level=logging.INFO) as caplog,
+        pytest.raises(MyEx),
+    ):
+        await f()
 
-    with caplog.at_level(logging.INFO, logger="distributed.utils_comm"):
-        with pytest.raises(MyEx):
-            asyncio_run(f(), loop_factory=get_loop_factory())
-
-    assert len(caplog.records) == 1
-    msg = caplog.records[0].getMessage()
-    # reprlib truncates the 500-char repr to maxother (200) chars
-    assert len(msg) < 500
+    msg = caplog.getvalue()
     # reprlib uses "..." to indicate truncation
-    assert "..." in msg
+    assert "xxxxx..." in msg
     # Verify the full 500-char repr is NOT present
-    assert "x" * 500 not in msg
+    assert 200 * count < len(msg) < 300 * count
 
 
 def test_unpack_remotedata():

--- a/distributed/tests/test_utils_comm.py
+++ b/distributed/tests/test_utils_comm.py
@@ -230,7 +230,7 @@ def test_retry_does_retry_and_sleep(cleanup):
     assert sleep_calls == [0.0, 1.0, 3.0, 6.0, 6.0]
 
 
-def test_retry_truncates_large_coro_repr(cleanup, caplog):
+def test_retry_truncates_large_coro_repr(cleanup, caplog, monkeypatch):
     """Test that retry truncates excessively large string representations of coro."""
 
     class MyEx(Exception):
@@ -252,6 +252,11 @@ def test_retry_truncates_large_coro_repr(cleanup, caplog):
             delay_max=0,
             jitter_fraction=0,
         )
+
+    # distributed.config sets propagate=False on the top-level "distributed"
+    # logger, so caplog (attached to root) won't see records without re-enabling
+    # propagation on the parent for the duration of the test.
+    monkeypatch.setattr(logging.getLogger("distributed"), "propagate", True)
 
     with caplog.at_level(logging.INFO, logger="distributed.utils_comm"):
         with pytest.raises(MyEx):

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -386,7 +386,9 @@ async def retry(
             return await coro()
         except retry_on_exceptions as ex:
             if not operation:
-                operation = reprlib.Repr(maxother=200).repr(coro)
+                r = reprlib.Repr()
+                r.maxother = 200
+                operation = r.repr(coro)
             logger.info(
                 f"Retrying {operation} after exception in attempt {i_try}/{count}: {ex}"
             )

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -384,7 +384,10 @@ async def retry(
         try:
             return await coro()
         except retry_on_exceptions as ex:
-            operation = operation or str(coro)
+            if not operation:
+                operation = str(coro)
+                if len(operation) > 200:
+                    operation = operation[:200] + "..."
             logger.info(
                 f"Retrying {operation} after exception in attempt {i_try}/{count}: {ex}"
             )

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import reprlib
 from collections import defaultdict
 from collections.abc import Callable, Collection, Coroutine, Mapping
 from functools import partial
@@ -385,9 +386,9 @@ async def retry(
             return await coro()
         except retry_on_exceptions as ex:
             if not operation:
-                operation = str(coro)
-                if len(operation) > 200:
-                    operation = operation[:200] + "..."
+                aRepr = reprlib.Repr()
+                aRepr.maxother = 200
+                operation = aRepr.repr(coro)
             logger.info(
                 f"Retrying {operation} after exception in attempt {i_try}/{count}: {ex}"
             )

--- a/distributed/utils_comm.py
+++ b/distributed/utils_comm.py
@@ -386,9 +386,7 @@ async def retry(
             return await coro()
         except retry_on_exceptions as ex:
             if not operation:
-                aRepr = reprlib.Repr()
-                aRepr.maxother = 200
-                operation = aRepr.repr(coro)
+                operation = reprlib.Repr(maxother=200).repr(coro)
             logger.info(
                 f"Retrying {operation} after exception in attempt {i_try}/{count}: {ex}"
             )


### PR DESCRIPTION
## Summary
- When `retry()` falls back to `str(coro)` for log messages, truncate the representation to 200 characters to prevent excessively large logs
- This was observed in P2P shuffles where `functools.partial` repr includes serialized binary data (see #8511)
- Added test verifying truncation behavior

Closes #8529

## Test plan
- [x] New test `test_retry_truncates_large_coro_repr` verifies 500-char repr is truncated
- [x] Existing retry tests unaffected (no truncation when repr is small)
- [x] Explicit `operation` parameter bypasses truncation (preserves full user-provided descriptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)