### PR TITLE
docs: fix Scheduler.close docstring

### DIFF
--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -4329,12 +4329,7 @@ class Scheduler(SchedulerState, ServerNode):
         timeout: float | None = None,
         reason: str = "unknown",
     ) -> None:
-        """Send cleanup signal to all coroutines then wait until finished
-
-        See Also
-        --------
-        Scheduler.cleanup
-        """
+        """Send cleanup signal to all coroutines then wait until finished."""
         if self.status in (Status.closing, Status.closed):
             await self.finished()
             return


### PR DESCRIPTION
## Summary
- remove reference to non-existent Scheduler.cleanup and tighten Scheduler.close docstring

## Rationale
- docstring pointed to a method that doesn't exist (issue #9175)

## Changes
- distributed/scheduler.py: docstring now accurately describes close

## Tests
- not run (docs-only)

Closes #9175