### PR TITLE
Fix `Client.register_plugin` inferred as `NoReturn`

### DIFF
--- a/distributed/client.py
+++ b/distributed/client.py
@@ -5095,7 +5095,7 @@ class Client(SyncMethodMixin):
         plugin: NannyPlugin | SchedulerPlugin | WorkerPlugin,
         name: str,
         idempotent: bool,
-    ):
+    ) -> Any:
         if isinstance(plugin, type):
             raise TypeError("Please provide an instance of a plugin, not a type.")
         if any(


### PR DESCRIPTION
Closes #9176

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
