### PR TITLE
setproctitle: avoid being caught by dask.config; add to test envs

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -44,6 +44,7 @@ dependencies:
   - requests
   - scikit-learn
   - scipy
+  - setproctitle
   - sortedcollections
   - tblib
   - toolz

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -38,6 +38,7 @@ dependencies:
   - requests
   - scikit-learn
   - scipy
+  - setproctitle
   - sortedcollections
   - tblib
   - toolz

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -38,6 +38,7 @@ dependencies:
   - requests
   - scikit-learn
   - scipy
+  - setproctitle
   - sortedcollections
   - tblib
   - toolz

--- a/continuous_integration/environment-3.13.yaml
+++ b/continuous_integration/environment-3.13.yaml
@@ -37,6 +37,7 @@ dependencies:
   - requests
   - scikit-learn
   - scipy
+  - setproctitle
   - sortedcollections
   - tblib
   - toolz

--- a/continuous_integration/environment-3.14.yaml
+++ b/continuous_integration/environment-3.14.yaml
@@ -37,6 +37,7 @@ dependencies:
   - requests
   - scikit-learn
   - scipy
+  - setproctitle
   - sortedcollections
   - tblib
   - toolz

--- a/distributed/proctitle.py
+++ b/distributed/proctitle.py
@@ -16,7 +16,7 @@ def enable_proctitle_on_children():
     Enable setting the process title on this process' children and
     grandchildren.
     """
-    os.environ["DASK_PARENT"] = str(os.getpid())
+    os.environ["__DASK_PARENT_PID"] = str(os.getpid())
 
 
 def enable_proctitle_on_current():
@@ -37,7 +37,7 @@ def setproctitle(title):
     enabled = _enabled
     if not enabled:
         try:
-            enabled = int(os.environ.get("DASK_PARENT", "")) != os.getpid()
+            enabled = int(os.environ.get("__DASK_PARENT_PID", "")) != os.getpid()
         except ValueError:  # pragma: no cover
             pass
     if enabled:


### PR DESCRIPTION
proctitle is a subsystem added 8 years ago and then forgotten by all.
It is always on if the necessary dependency is installed.
As the dependency was not installed in any test environment, it went quietly untested.
This PR adds it to the test envs.

Also fix an issue where `dask.config.refresh` would accidentally pick up a `process` key due to a collision with the naming convention of dask env variables (this is why I stumbled on this module, btw).