### PR TITLE
Overhaul `publish_dataset` extension

### DIFF
--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import logging
-from collections import deque
-from typing import Any
+from collections import defaultdict, deque
+from typing import TYPE_CHECKING, Any
 
 from tornado import gen, locks
 from tornado.ioloop import IOLoop
@@ -13,6 +14,10 @@ from dask.utils import parse_timedelta
 
 from distributed.core import CommClosedError
 from distributed.metrics import time
+from distributed.utils import log_errors
+
+if TYPE_CHECKING:
+    from distributed.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -195,3 +200,57 @@ class BatchedSend:
         self.waker.set()
         if not self.comm.closed():
             self.comm.abort()
+
+
+class FlushBatchedSendExtension:
+    """A scheduler extension to allow clients to synchronize their batched send stream
+    with subsequent RPC calls.
+
+    See matching client method :func:`Client.flush_batched_send`.
+    """
+
+    scheduler: Scheduler
+    _flush_received: defaultdict[bytes, asyncio.Event]
+
+    def __init__(self, scheduler: Scheduler):
+        self.scheduler = scheduler
+        scheduler.stream_handlers["flush_batched_send"] = self.flush_batched_send
+        scheduler.handlers["wait_flush_batched_send"] = self.wait_flush_batched_send
+        self._flush_received = defaultdict(asyncio.Event)
+
+    @log_errors
+    def flush_batched_send(self, client: str, uid: bytes) -> None:
+        """Batched send op: inform RPC call wait_flush_batched_send that the batched
+        send stream has been flushed.
+
+        This function may be executed before or after wait_flush_batched_send.
+        """
+        self._flush_received[uid].set()
+        self._client_disconnected_cleanup(client, uid)
+
+    @log_errors
+    async def wait_flush_batched_send(self, client: str, uid: bytes) -> None:
+        """Client RPC call: block until batched op flush_batched_send
+        has been executed.
+
+        This function may start before or after flush_batched_send.
+        """
+        ev_flush = self._flush_received[uid]
+        self._client_disconnected_cleanup(client, uid)
+        try:
+            await ev_flush.wait()
+        finally:
+            self._flush_received.pop(uid, None)
+
+    def _client_disconnected_cleanup(self, client: str, uid: bytes) -> None:
+        """Clean up event if client disconnects between flush_batched_send
+        and wait_flush_batched_send.
+        """
+        if uid not in self._flush_received:
+            return
+        if client in self.scheduler.clients:
+            loop = asyncio.get_event_loop()
+            loop.call_later(1, self._client_disconnected_cleanup, client, uid)
+        else:
+            self._flush_received[uid].set()
+            del self._flush_received[uid]

--- a/distributed/batched.py
+++ b/distributed/batched.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
-from collections import defaultdict, deque
-from typing import TYPE_CHECKING, Any
+from collections import deque
+from typing import Any
 
 from tornado import gen, locks
 from tornado.ioloop import IOLoop
@@ -14,10 +13,6 @@ from dask.utils import parse_timedelta
 
 from distributed.core import CommClosedError
 from distributed.metrics import time
-from distributed.utils import log_errors
-
-if TYPE_CHECKING:
-    from distributed.scheduler import Scheduler
 
 logger = logging.getLogger(__name__)
 
@@ -200,57 +195,3 @@ class BatchedSend:
         self.waker.set()
         if not self.comm.closed():
             self.comm.abort()
-
-
-class FlushBatchedSendExtension:
-    """A scheduler extension to allow clients to synchronize their batched send stream
-    with subsequent RPC calls.
-
-    See matching client method :func:`Client.flush_batched_send`.
-    """
-
-    scheduler: Scheduler
-    _flush_received: defaultdict[bytes, asyncio.Event]
-
-    def __init__(self, scheduler: Scheduler):
-        self.scheduler = scheduler
-        scheduler.stream_handlers["flush_batched_send"] = self.flush_batched_send
-        scheduler.handlers["wait_flush_batched_send"] = self.wait_flush_batched_send
-        self._flush_received = defaultdict(asyncio.Event)
-
-    @log_errors
-    def flush_batched_send(self, client: str, uid: bytes) -> None:
-        """Batched send op: inform RPC call wait_flush_batched_send that the batched
-        send stream has been flushed.
-
-        This function may be executed before or after wait_flush_batched_send.
-        """
-        self._flush_received[uid].set()
-        self._client_disconnected_cleanup(client, uid)
-
-    @log_errors
-    async def wait_flush_batched_send(self, client: str, uid: bytes) -> None:
-        """Client RPC call: block until batched op flush_batched_send
-        has been executed.
-
-        This function may start before or after flush_batched_send.
-        """
-        ev_flush = self._flush_received[uid]
-        self._client_disconnected_cleanup(client, uid)
-        try:
-            await ev_flush.wait()
-        finally:
-            self._flush_received.pop(uid, None)
-
-    def _client_disconnected_cleanup(self, client: str, uid: bytes) -> None:
-        """Clean up event if client disconnects between flush_batched_send
-        and wait_flush_batched_send.
-        """
-        if uid not in self._flush_received:
-            return
-        if client in self.scheduler.clients:
-            loop = asyncio.get_event_loop()
-            loop.call_later(1, self._client_disconnected_cleanup, client, uid)
-        else:
-            self._flush_received[uid].set()
-            del self._flush_received[uid]

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2890,17 +2890,17 @@ class Client(SyncMethodMixin):
             names.extend(args[0])
             data.extend(args[0].values())
 
+        # Prevent race condition where the client persists the collection immediately
+        # before publish_dataset, but the persist command hasn't landed on the scheduler
+        # yet when the publish_put RPC call arrives asynchronously.
         uid = uuid.uuid4().hex
-        self._send_to_scheduler(
-            {"op": "publish_flush_batched_send", "client": self.id, "uid": uid}
-        )
+        self._send_to_scheduler({"op": "publish_flush_batched_send", "uid": uid})
 
         await self.scheduler.publish_put(
             names=names,
             keys=[[f.key for f in futures_of(data_i)] for data_i in data],
             data=[to_serialize(data_i) for data_i in data],
             override=override,
-            client=self.id,
             uid=uid,
         )
 
@@ -2984,10 +2984,8 @@ class Client(SyncMethodMixin):
         # This method can't be made into just a batched send command as it would
         # create another race condition, where unpublish_dataset() followed by
         # get_dataset() would return the just-deleted data.
-        self._send_to_scheduler(
-            {"op": "publish_flush_batched_send", "client": self.id, "uid": uid}
-        )
-        await self.scheduler.publish_delete(names=names, client=self.id, uid=uid)
+        self._send_to_scheduler({"op": "publish_flush_batched_send", "uid": uid})
+        await self.scheduler.publish_delete(names=names, uid=uid)
 
     def unpublish_dataset(self, name: Key | list[Key], **kwargs):
         """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2924,8 +2924,9 @@ class Client(SyncMethodMixin):
         on the scheduler.  These references are available to other Clients
         which can download the collections or futures with ``get_dataset``.
 
-        Datasets are not immediately computed. You must call ``persist`` prior to
-        publishing a dataset.
+        Datasets are not immediately computed. You should call ``persist`` prior to
+        publishing a dataset. Any unpersisted keys will be stored on the scheduler
+        uncomputed and returned as-is to the user when calling ``get_dataset``.
 
         Parameters
         ----------

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -1457,16 +1457,6 @@ class Client(SyncMethodMixin):
                 f"Client is {self.status}. Can't send {msg['op']} message."
             )
 
-    async def flush_batched_send(self):
-        """Block until the batched send queue has been processed by the scheduler.
-        This prevents race conditions in any subsequent RPC calls.
-        """
-        uid = uuid.uuid4().bytes
-        self._send_to_scheduler(
-            {"op": "flush_batched_send", "client": self.id, "uid": uid}
-        )
-        await self.scheduler.wait_flush_batched_send(client=self.id, uid=uid)
-
     async def _start(self, timeout=no_default, **kwargs):
         self.status = "connecting"
 
@@ -2900,18 +2890,18 @@ class Client(SyncMethodMixin):
             names.extend(args[0])
             data.extend(args[0].values())
 
-        # Prevent race condition where the client persists the collection immediately
-        # before publish_dataset, but the persist command hasn't landed on the scheduler
-        # yet when the publish_put RPC call arrives asynchronously. This also guarantees
-        # that, by the time publish_dataset returns, it is safe to shut the client down
-        # or to have a remote task that called publish_dataset return.
-        await self.flush_batched_send()
+        uid = uuid.uuid4().hex
+        self._send_to_scheduler(
+            {"op": "publish_flush_batched_send", "client": self.id, "uid": uid}
+        )
 
         await self.scheduler.publish_put(
             names=names,
             keys=[[f.key for f in futures_of(data_i)] for data_i in data],
             data=[to_serialize(data_i) for data_i in data],
             override=override,
+            client=self.id,
+            uid=uid,
         )
 
     @overload
@@ -2985,6 +2975,8 @@ class Client(SyncMethodMixin):
         )
 
     async def _unpublish_dataset(self, name: Key | list[Key]) -> None:
+        names = name if isinstance(name, list) else [name]
+        uid = uuid.uuid4().hex
         # Prevent race condition where the user calls get_dataset() and immediately
         # afterwards unpublish_dataset(), thinking that they are holding a reference
         # to the futures locally, but the futures haven't been registered on the
@@ -2992,10 +2984,10 @@ class Client(SyncMethodMixin):
         # This method can't be made into just a batched send command as it would
         # create another race condition, where unpublish_dataset() followed by
         # get_dataset() would return the just-deleted data.
-        await self.flush_batched_send()
-
-        names = name if isinstance(name, list) else [name]
-        await self.scheduler.publish_delete(names=names)
+        self._send_to_scheduler(
+            {"op": "publish_flush_batched_send", "client": self.id, "uid": uid}
+        )
+        await self.scheduler.publish_delete(names=names, client=self.id, uid=uid)
 
     def unpublish_dataset(self, name: Key | list[Key], **kwargs):
         """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2901,6 +2901,7 @@ class Client(SyncMethodMixin):
             keys=[[f.key for f in futures_of(data_i)] for data_i in data],
             data=[to_serialize(data_i) for data_i in data],
             override=override,
+            client=self.id,
             uid=uid,
         )
 
@@ -2986,7 +2987,7 @@ class Client(SyncMethodMixin):
         # create another race condition, where unpublish_dataset() followed by
         # get_dataset() would return the just-deleted data.
         self._send_to_scheduler({"op": "publish_flush_batched_send", "uid": uid})
-        await self.scheduler.publish_delete(names=names, uid=uid)
+        await self.scheduler.publish_delete(names=names, client=self.id, uid=uid)
 
     def unpublish_dataset(self, name: Key | list[Key], **kwargs):
         """

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -23,6 +23,7 @@ from collections.abc import (
     Coroutine,
     Iterable,
     Iterator,
+    Mapping,
     Sequence,
 )
 from concurrent.futures import ThreadPoolExecutor
@@ -43,6 +44,7 @@ from typing import (
     TypedDict,
     TypeVar,
     cast,
+    overload,
 )
 
 from packaging.version import parse as parse_version
@@ -1455,6 +1457,16 @@ class Client(SyncMethodMixin):
                 f"Client is {self.status}. Can't send {msg['op']} message."
             )
 
+    async def flush_batched_send(self):
+        """Block until the batched send queue has been processed by the scheduler.
+        This prevents race conditions in any subsequent RPC calls.
+        """
+        uid = uuid.uuid4().bytes
+        self._send_to_scheduler(
+            {"op": "flush_batched_send", "client": self.id, "uid": uid}
+        )
+        await self.scheduler.wait_flush_batched_send(client=self.id, uid=uid)
+
     async def _start(self, timeout=no_default, **kwargs):
         self.status = "connecting"
 
@@ -2864,57 +2876,76 @@ class Client(SyncMethodMixin):
         """
         return self.sync(self._retry, futures, asynchronous=asynchronous)
 
-    @log_errors
-    async def _publish_dataset(self, *args, name=None, override=False, **kwargs):
-        coroutines = []
-        uid = uuid.uuid4().hex
-        self._send_to_scheduler({"op": "publish_flush_batched_send", "uid": uid})
-
-        def add_coro(name, data):
-            keys = [f.key for f in futures_of(data)]
-
-            async def _():
-                await self.scheduler.publish_wait_flush(uid=uid)
-                await self.scheduler.publish_put(
-                    keys=keys,
-                    name=name,
-                    data=to_serialize(data),
-                    override=override,
-                    client=self.id,
-                )
-
-            coroutines.append(_())
+    async def _publish_dataset(
+        self, *args: Any, name: Key | None = None, override: bool = False, **kwargs: Any
+    ):
+        names: list[Key] = list(kwargs)
+        data = list(kwargs.values())
 
         if name:
-            if len(args) == 0:
+            if not args:
                 raise ValueError(
                     "If name is provided, expecting call signature like"
                     " publish_dataset(df, name='ds')"
                 )
             # in case this is a singleton, collapse it
-            elif len(args) == 1:
-                args = args[0]
-            add_coro(name, args)
+            names.append(name)
+            data.append(args[0] if len(args) == 1 else args)
+        elif args:
+            if len(args) != 1 or not isinstance(args[0], Mapping):
+                raise ValueError(
+                    "If name is omitted, positional argument must be "
+                    "a {name: value} dict"
+                )
+            names.extend(args[0])
+            data.extend(args[0].values())
 
-        for name, data in kwargs.items():
-            add_coro(name, data)
+        # Prevent race condition where the client persists the collection immediately
+        # before publish_dataset, but the persist command hasn't landed on the scheduler
+        # yet when the publish_put RPC call arrives asynchronously. This also guarantees
+        # that, by the time publish_dataset returns, it is safe to shut the client down
+        # or to have a remote task that called publish_dataset return.
+        await self.flush_batched_send()
 
-        await asyncio.gather(*coroutines)
+        await self.scheduler.publish_put(
+            names=names,
+            keys=[[f.key for f in futures_of(data_i)] for data_i in data],
+            data=[to_serialize(data_i) for data_i in data],
+            override=override,
+        )
 
-    def publish_dataset(self, *args, **kwargs):
+    @overload
+    def publish_dataset(
+        self, *args: Any, name: Key, override: bool = False, **kwargs
+    ): ...
+
+    @overload
+    def publish_dataset(
+        self, *args: Mapping[Key, Any], override: bool = False, **kwargs
+    ): ...
+
+    def publish_dataset(
+        self, *args: Any, name: Key | None = None, override: bool = False, **kwargs
+    ):
         """
-        Publish named datasets to scheduler
+        Publish named persisted datasets to scheduler
 
-        This stores a named reference to a dask collection or list of futures
+        This stores a named reference to one or more dask collections or futures
         on the scheduler.  These references are available to other Clients
-        which can download the collection or futures with ``get_dataset``.
+        which can download the collections or futures with ``get_dataset``.
 
-        Datasets are not immediately computed.  You may wish to call
-        ``Client.persist`` prior to publishing a dataset.
+        Datasets are not immediately computed. You must call ``persist`` prior to
+        publishing a dataset.
 
         Parameters
         ----------
-        args : list of objects to publish as name
+        args : One or more objects to publish as `name`.
+            Alternatively, a single dict of {name: object} pairs.
+        name : Dask key (str, int, float, or tuple thereof)
+            Name to publish `args` under
+        override: bool
+            False (default) to raise KeyError if a dataset with the same name already
+            exists on the scheduler; True to overwrite it.
         kwargs : dict
             named collections to publish on the scheduler
 
@@ -2924,7 +2955,10 @@ class Client(SyncMethodMixin):
 
         >>> df = dd.read_csv('s3://...')  # doctest: +SKIP
         >>> df = c.persist(df) # doctest: +SKIP
-        >>> c.publish_dataset(my_dataset=df)  # doctest: +SKIP
+        >>> c.publish_dataset({"my_dataset": df})  # doctest: +SKIP
+
+        Alternative invocation
+        >>> c.publish_dataset(my_dataset=df)
 
         Alternative invocation
         >>> c.publish_dataset(df, name='my_dataset')
@@ -2946,30 +2980,50 @@ class Client(SyncMethodMixin):
         Client.unpublish_dataset
         Client.persist
         """
-        return self.sync(self._publish_dataset, *args, **kwargs)
+        return self.sync(
+            self._publish_dataset, *args, name=name, override=override, **kwargs
+        )
 
-    def unpublish_dataset(self, name, **kwargs):
+    async def _unpublish_dataset(self, name: Key | list[Key]) -> None:
+        # Prevent race condition where the user calls get_dataset() and immediately
+        # afterwards unpublish_dataset(), thinking that they are holding a reference
+        # to the futures locally, but the futures haven't been registered on the
+        # scheduler yet by the time unpublish_dataset lands on the scheduler.
+        # This method can't be made into just a batched send command as it would
+        # create another race condition, where unpublish_dataset() followed by
+        # get_dataset() would return the just-deleted data.
+        await self.flush_batched_send()
+
+        names = name if isinstance(name, list) else [name]
+        await self.scheduler.publish_delete(names=names)
+
+    def unpublish_dataset(self, name: Key | list[Key], **kwargs):
         """
         Remove named datasets from scheduler
 
         Parameters
         ----------
-        name : str
-            The name of the dataset to unpublish
+        name : Dask key (str, int, float, or tuple thereof), or list of keys
+            Name(s) of the dataset(s) to unpublish.
 
         Examples
         --------
         >>> c.list_datasets()  # doctest: +SKIP
-        ['my_dataset']
-        >>> c.unpublish_dataset('my_dataset')  # doctest: +SKIP
+        ['foo', 'bar', 'baz']
+        >>> c.unpublish_dataset('foo')  # doctest: +SKIP
+        >>> c.list_datasets()  # doctest: +SKIP
+        ['bar', 'baz']
+        >>> c.unpublish_dataset(['bar', 'baz'])  # doctest: +SKIP
         >>> c.list_datasets()  # doctest: +SKIP
         []
 
         See Also
         --------
         Client.publish_dataset
+        Client.list_datasets
+        Client.get_dataset
         """
-        return self.sync(self.scheduler.publish_delete, name=name, **kwargs)
+        return self.sync(self._unpublish_dataset, name=name, **kwargs)
 
     def list_datasets(self, **kwargs):
         """
@@ -2978,46 +3032,52 @@ class Client(SyncMethodMixin):
         See Also
         --------
         Client.publish_dataset
+        Client.unpublish_dataset
         Client.get_dataset
         """
         return self.sync(self.scheduler.publish_list, **kwargs)
 
-    async def _get_dataset(self, name, default=no_default):
-        with self.as_current():
-            out = await self.scheduler.publish_get(name=name, client=self.id)
-        if out is None:
-            if default is no_default:
-                raise KeyError(f"Dataset '{name}' not found")
-            else:
-                return default
-        for fut in futures_of(out["data"]):
-            fut.bind_client(self)
-        self._inform_scheduler_of_futures()
-        return out["data"]
+    async def _get_dataset(self, name: Key | list[Key], default=no_default):
+        names = name if isinstance(name, list) else [name]
+        raw_outs = await self.scheduler.publish_get(names=names)
 
-    def get_dataset(self, name, default=no_default, **kwargs):
+        outs = []
+        for out in raw_outs:
+            if out is None:
+                if default is no_default:
+                    raise KeyError(f"Dataset '{name}' not found")
+                outs.append(default)
+            else:
+                for fut in futures_of(out["data"]):
+                    fut.bind_client(self)
+                outs.append(out["data"])
+
+        self._inform_scheduler_of_futures()
+        return outs if isinstance(name, list) else outs[0]
+
+    def get_dataset(self, name: Key | list[Key], default=no_default, **kwargs):
         """
         Get named dataset from the scheduler if present.
         Return the default or raise a KeyError if not present.
 
         Parameters
         ----------
-        name : str
-            name of the dataset to retrieve
-        default : str
+        name : Dask key (str, int, float, or tuple thereof), or list of keys
+            name(s) of the dataset(s) to retrieve
+        default : Any
             optional, not set by default
             If set, do not raise a KeyError if the name is not present but
             return this default
-        kwargs : dict
-            additional keyword arguments to _get_dataset
 
         Returns
         -------
-        The dataset from the scheduler, if present
+        The dataset from the scheduler, if present.
+        If name is a list of keys, return a list of datasets in the same order.
 
         See Also
         --------
         Client.publish_dataset
+        Client.unpublish_dataset
         Client.list_datasets
         """
         return self.sync(self._get_dataset, name, default=default, **kwargs)

--- a/distributed/client.py
+++ b/distributed/client.py
@@ -2918,7 +2918,7 @@ class Client(SyncMethodMixin):
         self, *args: Any, name: Key | None = None, override: bool = False, **kwargs
     ):
         """
-        Publish named persisted datasets to scheduler
+        Publish named datasets to scheduler
 
         This stores a named reference to one or more dask collections or futures
         on the scheduler.  These references are available to other Clients

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, TypedDict
-
+from contextlib import suppress
 from dask.typing import Key
 from dask.utils import stringify
 
@@ -29,6 +31,7 @@ class PublishExtension:
 
     scheduler: Scheduler
     datasets: dict[Key, PublishedDataset]
+    _flush_received: defaultdict[bytes, tuple[asyncio.Event, asyncio.Event]]
 
     def __init__(self, scheduler):
         self.scheduler = scheduler
@@ -40,7 +43,39 @@ class PublishExtension:
             "publish_get": self.get,
             "publish_delete": self.delete,
         }
+        stream_handlers = {
+            "publish_flush_batched_send": self.flush_batched_send,
+        }
+
         self.scheduler.handlers.update(handlers)
+        self.scheduler.stream_handlers.update(stream_handlers)
+        self._flush_received = defaultdict(lambda: (asyncio.Event(), asyncio.Event()))
+
+    async def flush_batched_send(self, client: str, uid: bytes) -> None:
+        ev_flush, ev_sync = self._flush_received[uid]
+        ev_flush.set()
+        while client in self.scheduler.clients:
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(ev_sync.wait(), timeout=1)
+                return
+
+        # Client disconnected between flush and sync
+        del self._flush_received[uid]  # pragma: no cover
+
+    async def sync_batched_send(self, client: str, uid: bytes) -> bool:
+        """Wait for the client's batched-send to catch up with the same client's RPC
+        calls. Return True if the client is still connected; False otherwise.
+        """
+        ev_flush, ev_sync = self._flush_received[uid]
+        ev_sync.set()
+        try:
+            while client in self.scheduler.clients:
+                with suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(ev_flush.wait(), timeout=1)
+                    return True
+            return False
+        finally:
+            del self._flush_received[uid]
 
     @log_errors
     async def put(
@@ -49,18 +84,30 @@ class PublishExtension:
         keys: tuple[tuple[Key, ...], ...],
         data: tuple[Serialized, ...],
         override: bool,
-        client: str | None = None,
+        client: str,
+        uid: bytes,
     ) -> None:
-        if override:
-            self.delete(names)
+        if not await self.sync_batched_send(client, uid):
+            return
+
         for name, keys_i, data_i in zip(names, keys, data, strict=True):
-            if not override and name in self.datasets:
-                raise KeyError("Dataset %s already exists" % name)
+            if name in self.datasets:
+                if override:
+                    old = self.datasets.pop(name)
+                    self.scheduler.client_releases_keys(
+                        old["keys"], f"published-{stringify(name)}"
+                    )
+                else:
+                    raise KeyError("Dataset %s already exists" % name)
+
             self.scheduler.client_desires_keys(keys_i, f"published-{stringify(name)}")
             self.datasets[name] = {"data": data_i, "keys": keys_i}
 
     @log_errors
-    def delete(self, names: tuple[Key, ...]) -> None:
+    async def delete(self, names: tuple[Key, ...], client: str, uid: bytes) -> None:
+        if not await self.sync_batched_send(client, uid):
+            return
+
         for name in names:
             out = self.datasets.pop(name, None)
             if out is not None:

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -52,6 +52,15 @@ class PublishExtension:
         self._flush_received = defaultdict(asyncio.Event)
 
     def flush_batched_send(self, client: str, uid: bytes) -> None:
+        # Note that `self._flush_received` is a defaultdict.
+        # Either:
+        # - `flush_batched_send` runs first. The line below creates the event and
+        #   immediately sets it. When `_sync_batched_send` runs later on, it won't
+        #   block.
+        # Or:
+        # - `_sync_batched_send` runs first; it creates the event and leaves it unset,
+        #   then blocks. Later on, `flush_batched_send` retrieves the event and sets it,
+        #   which unblocks `_sync_batched_send`.
         self._flush_received[uid].set()
 
     async def _sync_batched_send(self, uid: bytes) -> None:

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
-import asyncio
-from collections import defaultdict
 from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, TypedDict
 
+from dask.typing import Key
 from dask.utils import stringify
 
+from distributed.protocol.serialize import Serialized
 from distributed.utils import log_errors
+
+if TYPE_CHECKING:
+    from distributed.scheduler import Scheduler
+
+
+class PublishedDataset(TypedDict):
+    data: Serialized
+    keys: tuple[Key, ...]
 
 
 class PublishExtension:
@@ -18,51 +27,54 @@ class PublishExtension:
     *  publish_delete
     """
 
+    scheduler: Scheduler
+    datasets: dict[Key, PublishedDataset]
+
     def __init__(self, scheduler):
         self.scheduler = scheduler
-        self.datasets = dict()
+        self.datasets = {}
 
         handlers = {
             "publish_list": self.list,
             "publish_put": self.put,
             "publish_get": self.get,
             "publish_delete": self.delete,
-            "publish_wait_flush": self.flush_wait,
         }
-        stream_handlers = {
-            "publish_flush_batched_send": self.flush_receive,
-        }
-
         self.scheduler.handlers.update(handlers)
-        self.scheduler.stream_handlers.update(stream_handlers)
-        self._flush_received = defaultdict(asyncio.Event)
-
-    def flush_receive(self, uid, **kwargs):
-        self._flush_received[uid].set()
-
-    async def flush_wait(self, uid):
-        await self._flush_received[uid].wait()
 
     @log_errors
-    def put(self, keys=None, data=None, name=None, override=False, client=None):
-        if not override and name in self.datasets:
-            raise KeyError("Dataset %s already exists" % name)
-        self.scheduler.client_desires_keys(keys, f"published-{stringify(name)}")
-        self.datasets[name] = {"data": data, "keys": keys}
-        return {"status": "OK", "name": name}
+    async def put(
+        self,
+        names: tuple[Key, ...],
+        keys: tuple[tuple[Key, ...], ...],
+        data: tuple[Serialized, ...],
+        override: bool,
+        client: str | None = None,
+    ) -> None:
+        if override:
+            self.delete(names)
+        for name, keys_i, data_i in zip(names, keys, data, strict=True):
+            if not override and name in self.datasets:
+                raise KeyError("Dataset %s already exists" % name)
+            self.scheduler.client_desires_keys(keys_i, f"published-{stringify(name)}")
+            self.datasets[name] = {"data": data_i, "keys": keys_i}
 
     @log_errors
-    def delete(self, name=None):
-        out = self.datasets.pop(name, {"keys": []})
-        self.scheduler.client_releases_keys(out["keys"], f"published-{stringify(name)}")
+    def delete(self, names: tuple[Key, ...]) -> None:
+        for name in names:
+            out = self.datasets.pop(name, None)
+            if out is not None:
+                self.scheduler.client_releases_keys(
+                    out["keys"], f"published-{stringify(name)}"
+                )
 
     @log_errors
-    def list(self, *args):
-        return list(sorted(self.datasets.keys(), key=str))
+    def list(self) -> list[Key]:
+        return list(sorted(self.datasets, key=str))
 
     @log_errors
-    def get(self, name=None, client=None):
-        return self.datasets.get(name, None)
+    def get(self, names: tuple[Key, ...]) -> list[PublishedDataset | None]:  # type: ignore[valid-type]
+        return [self.datasets.get(name, None) for name in names]
 
 
 class Datasets(MutableMapping):

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -31,7 +31,7 @@ class PublishExtension:
 
     scheduler: Scheduler
     datasets: dict[Key, PublishedDataset]
-    _flush_received: defaultdict[bytes, tuple[asyncio.Event, asyncio.Event]]
+    _flush_received: defaultdict[bytes, asyncio.Event]
 
     def __init__(self, scheduler):
         self.scheduler = scheduler
@@ -49,31 +49,17 @@ class PublishExtension:
 
         self.scheduler.handlers.update(handlers)
         self.scheduler.stream_handlers.update(stream_handlers)
-        self._flush_received = defaultdict(lambda: (asyncio.Event(), asyncio.Event()))
+        self._flush_received = defaultdict(asyncio.Event)
 
-    async def flush_batched_send(self, client: str, uid: bytes) -> None:
-        ev_flush, ev_sync = self._flush_received[uid]
-        ev_flush.set()
-        while client in self.scheduler.clients:
-            with suppress(asyncio.TimeoutError):
-                await asyncio.wait_for(ev_sync.wait(), timeout=1)
-                return
+    def flush_batched_send(self, client: str, uid: bytes) -> None:
+        self._flush_received[uid].set()
 
-        # Client disconnected between flush and sync
-        del self._flush_received[uid]  # pragma: no cover
-
-    async def sync_batched_send(self, client: str, uid: bytes) -> bool:
+    async def _sync_batched_send(self, uid: bytes) -> None:
         """Wait for the client's batched-send to catch up with the same client's RPC
         calls. Return True if the client is still connected; False otherwise.
         """
-        ev_flush, ev_sync = self._flush_received[uid]
-        ev_sync.set()
         try:
-            while client in self.scheduler.clients:
-                with suppress(asyncio.TimeoutError):
-                    await asyncio.wait_for(ev_flush.wait(), timeout=1)
-                    return True
-            return False
+            await self._flush_received[uid].wait()
         finally:
             del self._flush_received[uid]
 
@@ -84,11 +70,9 @@ class PublishExtension:
         keys: tuple[tuple[Key, ...], ...],
         data: tuple[Serialized, ...],
         override: bool,
-        client: str,
         uid: bytes,
     ) -> None:
-        if not await self.sync_batched_send(client, uid):
-            return
+        await self._sync_batched_send(uid)
 
         for name, keys_i, data_i in zip(names, keys, data, strict=True):
             if name in self.datasets:
@@ -104,9 +88,8 @@ class PublishExtension:
             self.datasets[name] = {"data": data_i, "keys": keys_i}
 
     @log_errors
-    async def delete(self, names: tuple[Key, ...], client: str, uid: bytes) -> None:
-        if not await self.sync_batched_send(client, uid):
-            return
+    async def delete(self, names: tuple[Key, ...], uid: bytes) -> None:
+        await self._sync_batched_send(uid)
 
         for name in names:
             out = self.datasets.pop(name, None)

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -9,7 +9,7 @@ from dask.typing import Key
 from dask.utils import stringify
 
 from distributed.protocol.serialize import Serialized
-from distributed.utils import log_errors
+from distributed.utils import log_errors, wait_for
 
 if TYPE_CHECKING:
     from distributed.scheduler import Scheduler
@@ -71,7 +71,7 @@ class PublishExtension:
         try:
             while True:
                 try:
-                    await asyncio.wait_for(ev.wait(), timeout=30)
+                    await wait_for(ev.wait(), timeout=30)
                     return
                 except asyncio.TimeoutError:
                     if client not in self.scheduler.clients:

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -63,12 +63,19 @@ class PublishExtension:
         #   which unblocks `_sync_batched_send`.
         self._flush_received[uid].set()
 
-    async def _sync_batched_send(self, uid: bytes) -> None:
+    async def _sync_batched_send(self, client: str, uid: bytes) -> None:
         """Wait for the client's batched-send to catch up with the same client's RPC
         calls. Return True if the client is still connected; False otherwise.
         """
+        ev = self._flush_received[uid]
         try:
-            await self._flush_received[uid].wait()
+            while True:
+                try:
+                    await asyncio.wait_for(ev.wait(), timeout=30)
+                    return
+                except asyncio.TimeoutError:
+                    if client not in self.scheduler.clients:
+                        raise
         finally:
             del self._flush_received[uid]
 
@@ -79,9 +86,10 @@ class PublishExtension:
         keys: tuple[tuple[Key, ...], ...],
         data: tuple[Serialized, ...],
         override: bool,
+        client: str,
         uid: bytes,
     ) -> None:
-        await self._sync_batched_send(uid)
+        await self._sync_batched_send(client, uid)
 
         for name, keys_i, data_i in zip(names, keys, data, strict=True):
             if name in self.datasets:
@@ -97,8 +105,8 @@ class PublishExtension:
             self.datasets[name] = {"data": data_i, "keys": keys_i}
 
     @log_errors
-    async def delete(self, names: tuple[Key, ...], uid: bytes) -> None:
-        await self._sync_batched_send(uid)
+    async def delete(self, names: tuple[Key, ...], client: str, uid: bytes) -> None:
+        await self._sync_batched_send(client, uid)
 
         for name in names:
             out = self.datasets.pop(name, None)

--- a/distributed/publish.py
+++ b/distributed/publish.py
@@ -4,7 +4,7 @@ import asyncio
 from collections import defaultdict
 from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, TypedDict
-from contextlib import suppress
+
 from dask.typing import Key
 from dask.utils import stringify
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -83,7 +83,7 @@ from distributed import versions as version_module
 from distributed._asyncio import RLock
 from distributed._stories import scheduler_story
 from distributed.active_memory_manager import ActiveMemoryManagerExtension, RetireWorker
-from distributed.batched import BatchedSend
+from distributed.batched import BatchedSend, FlushBatchedSendExtension
 from distributed.broker import Broker
 from distributed.client import SourceCode
 from distributed.collections import HeapSet
@@ -187,6 +187,7 @@ DEFAULT_DATA_SIZE = parse_bytes(
 STIMULUS_ID_UNSET = "<stimulus_id unset>"
 
 DEFAULT_EXTENSIONS = {
+    "flush_batched_send": FlushBatchedSendExtension,
     "multi_locks": MultiLockExtension,
     "publish": PublishExtension,
     "replay-tasks": ReplayTaskScheduler,
@@ -5660,7 +5661,9 @@ class Scheduler(SchedulerState, ServerNode):
         for k in keys:
             ts = self.tasks.get(k)
             if ts is None:
-                warnings.warn(f"Client desires key {k!r} but key is unknown.")
+                warnings.warn(
+                    f"Client {client!r} desires key {k!r} but key is unknown."
+                )
                 continue
             if ts.who_wants is None:
                 ts.who_wants = set()

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -83,7 +83,7 @@ from distributed import versions as version_module
 from distributed._asyncio import RLock
 from distributed._stories import scheduler_story
 from distributed.active_memory_manager import ActiveMemoryManagerExtension, RetireWorker
-from distributed.batched import BatchedSend, FlushBatchedSendExtension
+from distributed.batched import BatchedSend
 from distributed.broker import Broker
 from distributed.client import SourceCode
 from distributed.collections import HeapSet
@@ -187,7 +187,6 @@ DEFAULT_DATA_SIZE = parse_bytes(
 STIMULUS_ID_UNSET = "<stimulus_id unset>"
 
 DEFAULT_EXTENSIONS = {
-    "flush_batched_send": FlushBatchedSendExtension,
     "multi_locks": MultiLockExtension,
     "publish": PublishExtension,
     "replay-tasks": ReplayTaskScheduler,

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -86,7 +86,7 @@ async def test_unpublish(c, s, a, b):
     key = data[0].key
     del data
 
-    await c.scheduler.publish_delete(name="data")
+    await c.unpublish_dataset(name="data")
 
     assert "data" not in s.extensions["publish"].datasets
 

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -41,6 +41,8 @@ async def test_publish_non_string_names(c, s, a, b, name):
     await c.publish_dataset(future, name=name)
     datasets = await c.scheduler.publish_list()
     assert datasets == (name,)
+    # Note: name=("a", "b") tests that get_dataset and unpublish_dataset don't
+    # treat a single tuple name as a sequence of names.
     future = await c.get_dataset(name)
     await c.unpublish_dataset(name)
     assert await c.scheduler.publish_list() == ()

--- a/distributed/tests/test_publish.py
+++ b/distributed/tests/test_publish.py
@@ -11,15 +11,11 @@ from distributed.client import futures_of
 from distributed.metrics import time
 from distributed.protocol import Serialized
 from distributed.utils_test import gen_cluster, inc
-from distributed.worker import get_worker
 
 
-@gen_cluster()
-async def test_publish_simple(s, a, b):
-    async with (
-        Client(s.address, asynchronous=True) as c,
-        Client(s.address, asynchronous=True) as f,
-    ):
+@gen_cluster(client=True)
+async def test_publish_simple(c, s, a, b):
+    async with Client(s.address, asynchronous=True) as c2:
         data = await c.scatter(range(3))
         await c.publish_dataset(data=data)
         assert "data" in s.extensions["publish"].datasets
@@ -34,45 +30,57 @@ async def test_publish_simple(s, a, b):
         result = await c.scheduler.publish_list()
         assert result == ("data",)
 
-        result = await f.scheduler.publish_list()
+        result = await c2.scheduler.publish_list()
         assert result == ("data",)
 
 
-@gen_cluster()
-async def test_publish_non_string_key(s, a, b):
-    async with Client(s.address, asynchronous=True) as c:
-        for name in [("a", "b"), 9.0, 8]:
-            data = await c.scatter(range(3))
-            await c.publish_dataset(data, name=name)
-            assert name in s.extensions["publish"].datasets
-            assert isinstance(
-                s.extensions["publish"].datasets[name]["data"], Serialized
-            )
-
-            datasets = await c.scheduler.publish_list()
-            assert name in datasets
+@gen_cluster(client=True)
+@pytest.mark.parametrize("name", [("a", "b"), 9.0, 8])
+async def test_publish_non_string_names(c, s, a, b, name):
+    future = c.submit(lambda: 123, key="x")
+    await c.publish_dataset(future, name=name)
+    datasets = await c.scheduler.publish_list()
+    assert datasets == (name,)
+    future = await c.get_dataset(name)
+    await c.unpublish_dataset(name)
+    assert await c.scheduler.publish_list() == ()
+    assert await future == 123
 
 
-@gen_cluster()
-async def test_publish_roundtrip(s, a, b):
-    async with (
-        Client(s.address, asynchronous=True) as c,
-        Client(s.address, asynchronous=True) as f,
-    ):
+@gen_cluster(client=True)
+async def test_publish_multiple_names(c, s, a, b):
+    f1 = c.submit(lambda: 1, key="x")
+    f2 = c.submit(lambda: 2, key="y")
+    f3 = c.submit(lambda: 3, key="z")
+    await c.publish_dataset({("a", "b"): f1, 8: f2}, n3=f3)
+    # publish_list sorts output; test that it copes with sorting non-sortable names.
+    datasets = await c.scheduler.publish_list()
+    assert datasets == (("a", "b"), 8, "n3")
+    f1, f2, f3 = await c.get_dataset([("a", "b"), 8, "n3"])
+    await c.unpublish_dataset([("a", "b"), 8, "n3"])
+    assert await c.scheduler.publish_list() == ()
+    assert await f1 == 1
+    assert await f2 == 2
+    assert await f3 == 3
+
+
+@gen_cluster(client=True)
+async def test_publish_roundtrip(c, s, a, b):
+    async with Client(s.address, asynchronous=True) as c2:
         data = await c.scatter([0, 1, 2])
         await c.publish_dataset(data=data)
 
         assert any(
             cs.client_key == "published-data" for cs in s.tasks[data[0].key].who_wants
         )
-        result = await f.get_dataset(name="data")
+        result = await c2.get_dataset(name="data")
 
         assert len(result) == len(data)
-        out = await f.gather(result)
+        out = await c2.gather(result)
         assert out == [0, 1, 2]
 
         with pytest.raises(KeyError) as exc_info:
-            await f.get_dataset(name="nonexistent")
+            await c2.get_dataset(name="nonexistent")
 
         assert "not found" in str(exc_info.value)
         assert "nonexistent" in str(exc_info.value)
@@ -115,19 +123,34 @@ def test_unpublish_sync(client):
 
 
 @gen_cluster(client=True)
-async def test_publish_multiple_datasets(c, s, a, b):
-    x = delayed(inc)(1)
-    y = delayed(inc)(2)
+async def test_unpublish_nonexistent(c, s, a, b):
+    """Unpublishing a dataset that does not exist quietly succeeds.
+    This is important when unpublish_dataset is executed by a task that may be run twice.
+    """
+    await c.unpublish_dataset(name="nonexistent")
 
-    await c.publish_dataset(x=x, y=y)
+
+@gen_cluster(client=True)
+async def test_publish_multiple_datasets(c, s, a, b):
+    await c.publish_dataset(x=1, y=2)
     datasets = await c.scheduler.publish_list()
-    assert set(datasets) == {"x", "y"}
+    assert datasets == ("x", "y")
+
+
+@gen_cluster(client=True)
+async def test_publish_multiple_collections_one_name(c, s, a, b):
+    x = c.submit(lambda: 1, key="x")
+    y = c.submit(lambda: 2, key="y")
+    await c.publish_dataset(x, y, name="n")
+    datasets = await c.scheduler.publish_list()
+    assert datasets == ("n",)
+    x, y = await c.get_dataset("n")
+    assert await x == 1
+    assert await y == 2
 
 
 def test_unpublish_multiple_datasets_sync(client):
-    x = delayed(inc)(1)
-    y = delayed(inc)(2)
-    client.publish_dataset(x=x, y=y)
+    client.publish_dataset(x=1, y=2)
     client.unpublish_dataset(name="x")
 
     with pytest.raises(KeyError) as exc_info:
@@ -148,13 +171,10 @@ def test_unpublish_multiple_datasets_sync(client):
     assert "y" in str(exc_info.value)
 
 
-@gen_cluster()
-async def test_publish_bag(s, a, b):
+@gen_cluster(client=True)
+async def test_publish_bag(c, s, a, b):
     db = pytest.importorskip("dask.bag")
-    async with (
-        Client(s.address, asynchronous=True) as c,
-        Client(s.address, asynchronous=True) as f,
-    ):
+    async with Client(s.address, asynchronous=True) as c2:
         bag = db.from_sequence([0, 1, 2])
         bagp = c.persist(bag)
 
@@ -167,13 +187,13 @@ async def test_publish_bag(s, a, b):
         # check that serialization didn't affect original bag's dask
         assert len(futures_of(bagp)) == 3
 
-        result = await f.get_dataset("data")
+        result = await c2.get_dataset("data")
         assert set(result.dask.keys()) == set(bagp.dask.keys())
         assert {f.key for f in result.dask.values()} == {
             f.key for f in bagp.dask.values()
         }
 
-        out = await f.compute(result)
+        out = await c2.compute(result)
         assert out == [0, 1, 2]
 
 
@@ -195,7 +215,7 @@ def test_datasets_getitem(client):
 
 
 def test_datasets_getitem_default(client):
-    with pytest.raises(KeyError) as exc_info:
+    with pytest.raises(KeyError):
         client.get_dataset("key")
 
     assert client.datasets.get("key", default="value") == "value"
@@ -223,7 +243,7 @@ def test_datasets_contains(client):
     assert key in client.datasets
 
 
-def test_datasets_republish(client):
+def test_publish_dataset_override(client):
     key, value, value2 = "key", "value", "value2"
     client.publish_dataset(key=value)
     assert client.get_dataset(key) == value
@@ -233,6 +253,63 @@ def test_datasets_republish(client):
 
     client.publish_dataset(key=value2, override=True)
     assert client.get_dataset(key) == value2
+
+
+@gen_cluster(client=True)
+async def test_publish_dataset_override_releases_old_keys(c, s, a, b):
+    """Test that publish_dataset(..., override=True) releases any keys in
+    the old dataset that are not also in the new dataset
+    """
+    key = "key"
+    d1 = delayed(inc)(0)
+    d2 = delayed(inc)(1)
+    d3 = delayed(inc)(2)
+    d1, d2, d3 = c.persist([d1, d2, d3])
+
+    await c.publish_dataset(key=[d1, d2])
+    assert (await c.gather(c.compute(await c.get_dataset(key)))) == [1, 2]
+    # New keys only partially overlap with old keys
+    await c.publish_dataset(key=[d2, d3], override=True)
+    assert (await c.gather(c.compute(await c.get_dataset(key)))) == [2, 3]
+
+    futures = futures_of([d1, d2, d3])
+    for future in futures:
+        future.release()
+    # d1 has been unpublished so is dereferenced on the cluster;
+    # d2 and d3 are still published so they remain live.
+    while d1.key in s.tasks:
+        await asyncio.sleep(0.01)
+    assert d2.key in s.tasks
+    assert d3.key in s.tasks
+    assert set(s.tasks) == {d2.key, d3.key}
+
+
+@gen_cluster(client=True)
+async def test_publish_dataset_override_partial(c, s, a, b):
+    """Test override=True but no all datasets already exist"""
+    d1 = delayed(inc)(0)
+    d2 = delayed(inc)(1)
+    d3 = delayed(inc)(2)
+    d4 = delayed(inc)(3)
+    d5 = delayed(inc)(4)
+    d1, d2, d3, d4, d5 = c.persist([d1, d2, d3, d4, d5])
+
+    await c.publish_dataset(a=d1, b=d2, c=d3)
+    # Do not override a
+    # Override b with same futures
+    # Override c with new futures
+    # d is new
+    with pytest.raises(KeyError):
+        await c.publish_dataset(b=d2, c=d4, d=d5)
+    await c.publish_dataset(b=d2, c=d4, d=d5, override=True)
+
+    values = await c.gather(c.compute(await c.get_dataset(["a", "b", "c", "d"])))
+    assert values == [1, 2, 4, 5]
+
+    futures_of(d3)[0].release()
+    while d3.key in s.tasks:
+        await asyncio.sleep(0.01)
+    assert set(s.tasks) == {d1.key, d2.key, d4.key, d5.key}
 
 
 def test_datasets_iter(client):
@@ -307,28 +384,88 @@ async def test_deserialize_client(c, s, a, b):
     assert _current_client.get() is c
 
 
-@gen_cluster(client=True, worker_kwargs={"resources": {"A": 1}})
-async def test_publish_submit_ordering(c, s, a, b):
-    RESOURCES = {"A": 1}
+@gen_cluster(client=True)
+async def test_publish_unpublish_wait_for_batched_comms(c, s, a, b):
+    """Test two race conditions in publish_dataset and unpublish_dataset respectively:
 
-    def _retrieve_annotations():
-        worker = get_worker()
-        task = worker.state.tasks.get(worker.get_current_task())
-        return task.annotations
+    1. submit/persist sends new future(s) through batched comms
+    2. publish_dataset sends an asynchronous RPC call to the scheduler, which may land
+       before the batched comms from step 1
+    3. As soon as publish_dataset returns, the user immediately releases the future(s).
+       This is a typical use case when publish_dataset is called by a task which then
+       returns None.
+    4. The publish dataset now holds a reference to forgotten future(s).
 
-    # If publish does not take the same comm channel as the submit, it can
-    # happen that the publish message reaches the scheduler before the submit
-    # such that the state of the published future is not the one that has been
-    # requested from the submit. Particularly, this lets us drop annotations
-    # The current implementation does in fact not use the same channel due to
-    # serialization issue (including Futures in BatchedSend appends them to the
-    # "recent messages" log which screws with the refcounting) but ensure that
-    # all queued up messages are flushed and received by the scheduler before
-    # publishing
-    future = c.submit(_retrieve_annotations, resources=RESOURCES, pure=False)
+    1. get_dataset internally calls future.bind_client() to notify the scheduler that
+       the client now holds a reference to the future(s). This uses batched comms.
+    2. The user calls unpublish_dataset immediately after get_dataset returns. This uses
+       an asynchronous RPC call, which may land on the scheduler before the batched
+       comms from step 1.
+    3. The client now holds a reference to a forgotten future.
+    """
+    x = c.submit(lambda: 123, key="x")
+    await c.publish_dataset(x=x)
+    # First race condition: unless publish_dataset waited for submit to flush through
+    # the batched comms, both submit and release may hit the scheduler before
+    # publish_dataset.
+    x.release()
 
-    await c.publish_dataset(future, name="foo")
-    assert await c.list_datasets() == ("foo",)
+    while s.clients[c.id] in s.tasks["x"].who_wants:
+        await asyncio.sleep(0.01)
 
-    result = await future.result()
-    assert result == {"resources": RESOURCES}
+    x = await c.get_dataset("x")
+    # Second race condition: unless unpublish_dataset waits for the batched comms to
+    # flush future.bind_client (called by get_dataset), unpublish_dataset may hit the
+    # scheduler before bind_client and the client will end up with a reference to a
+    # forgotten future.
+    await c.unpublish_dataset("x")
+
+    assert s.tasks["x"].who_wants == {s.clients[c.id]}
+    assert await x == 123
+
+    x.release()
+    while "x" in s.tasks:
+        await asyncio.sleep(0.01)
+
+    # Test that the synchronization events weren't leaked
+    assert not s.extensions["publish"]._flush_received
+
+
+@gen_cluster(client=True)
+async def test_publish_bad_syntax(c, s, a, b):
+    with pytest.raises(
+        ValueError, match="If name is provided, expecting call signature"
+    ):
+        await c.publish_dataset(name="x")
+
+    with pytest.raises(
+        ValueError, match="If name is omitted, positional argument must be"
+    ):
+        await c.publish_dataset(1)
+
+    with pytest.raises(
+        ValueError, match="If name is omitted, positional argument must be"
+    ):
+        await c.publish_dataset(1, "x")
+
+    with pytest.raises(
+        ValueError, match="If name is omitted, positional argument must be"
+    ):
+        await c.publish_dataset({"x": 1}, {"y": 2})
+
+
+@gen_cluster(client=True)
+async def test_publish_unpersisted(c, s, a, b):
+    """Test that unpersisted keys are returned as-is by get_dataset and not
+    published by the scheduler.
+    """
+    x = delayed(inc)(1)
+    await c.publish_dataset(x=x)
+    assert not s.tasks
+
+    x = await c.get_dataset("x")
+    assert not futures_of(x)
+    assert not s.tasks
+    assert x.compute(scheduler="sync") == 2
+
+    await c.unpublish_dataset("x")  # Don't try releasing unpublished keys


### PR DESCRIPTION
This PR thoroughly reviews the `publish_dataset` API:

## Bugfixes
- Fixed bug where `publish_dataset(..., override=True)` would cause any keys from the original dataset to become immortal unless they were also present in the new dataset
- Fixed race condition where the user calls `get_dataset()` and immediately afterwards `unpublish_dataset()`, thinking that they are holding a reference to the futures locally, but the scheduler hasn't noted it by the time `unpublish_dataset` lands on the scheduler. This caused the client to end up holding a reference to forgotten keys. This is symmetrical to what #8577 fixed for `publish_dataset`.
- Fixed memory leak, introduced by #8577, where each call to `publish_dataset` would create an immortal `asyncio.Event` instance on the scheduler.

## New features
- Added syntax `publish_dataset({name: value, ...})`. Note that this is the only way one can publish multiple datasets with non-string names at once.
- `get_dataset` and `unpublish_dataset` can now get/delete multiple datasets at once.

## Performance improvements
- `publish_dataset` was previously performing 2 RPC calls per dataset, had a latency of 2x RTT, and was typically opening additional TCP/IP connections equal to the number of datasets beyond the first. Changed to a single RPC call and 1x RTT regardless of the number of datasets being published. 

This, together with the new features, should offer a significant speedup for users that were previously publishing/getting/retrieving many datasets at once (and, for all cases other than publishing string-named datasets, were forced to use a tight for loop of RPC calls). This is particularly significant when the client-scheduler comms suffers from high latency, e.g. in Coiled.

## Minor tweaks
- The `override` flag was undocumented. Added documentation.
- Support for names other than strings was undocumented. Added documentation.
- Clarified documentation of `publish_dataset` in regards to keys that have not been persisted. Added test coverage for the use case.
- Syntax for publishing a tuple of collections as a single name `publish_dataset(x, y, name="foo")` was untested. Added test coverage.
- Cleaned up test suite
- Achieved 100% test coverage
- Added type annotations
