### PR TITLE
Clean up info parameters in transition to memory

### DIFF
--- a/distributed/diagnostics/eventstream.py
+++ b/distributed/diagnostics/eventstream.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 
 
 class EventStream(SchedulerPlugin):
-    """Maintain a copy of worker events"""
+    """Maintain a copy of processing->memory and processing->erred
+    task transition events
+    """
 
     def __init__(self, scheduler=None):
         self.name = "EventStream"
@@ -19,10 +21,9 @@ class EventStream(SchedulerPlugin):
             scheduler.add_plugin(self)
 
     def transition(self, key, start, finish, *args, **kwargs):
-        if start == "processing":
+        if start == "processing" and finish in ("memory", "erred"):
             kwargs["key"] = key
-            if finish == "memory" or finish == "erred":
-                self.buffer.append(kwargs)
+            self.buffer.append(kwargs)
 
 
 def swap_buffer(scheduler, es):

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2509,7 +2509,6 @@ class SchedulerState:
         typename: str,
         worker: str,
         startstops: list[StartStop],
-        metadata: dict,
     ) -> RecsMsgs:
         ts = self.tasks[key]
 
@@ -5497,9 +5496,7 @@ class Scheduler(SchedulerState, ServerNode):
                 if ts.metadata is None:
                     ts.metadata = {}
                 ts.metadata.update(metadata)
-            return self._transition(
-                key, "memory", stimulus_id, worker=worker, metadata=metadata, **kwargs
-            )
+            return self._transition(key, "memory", stimulus_id, worker=worker, **kwargs)
 
         return recommendations, client_msgs, worker_msgs
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2510,6 +2510,9 @@ class SchedulerState:
         typename: str,
         worker: str,
         startstops: list[StartStop],
+        # Other fields such as thread. They are unused here but are passed to
+        # SchedulerPlugin.transition and might be consumed by third-party plugins.
+        **kwargs: Any,
     ) -> RecsMsgs:
         ts = self.tasks[key]
 
@@ -2761,6 +2764,10 @@ class SchedulerState:
         traceback: Serialized | None = None,
         exception_text: str | None = None,
         traceback_text: str | None = None,
+        # Other fields such as startstops and thread. They are unused here but are
+        # passed to SchedulerPlugin.transition and might be consumed by third-party
+        # plugins.
+        **kwargs: Any,
     ) -> RecsMsgs:
         """Processed a recommended transition processing -> erred.
 
@@ -5433,7 +5440,9 @@ class Scheduler(SchedulerState, ServerNode):
         key: Key,
         run_id: int,
         metadata: dict,
-        **kwargs: Any,  # nbytes, type, typename, worker, startstops
+        # nbytes, type, etc. Passed as-is to the transitions as well as
+        # to SchedulerPlugin.transition().
+        **kwargs: Any,
     ) -> RecsMsgs:
         """Mark that a task has finished execution on a particular worker"""
         logger.debug("Stimulus task finished %s[%d] %s", key, run_id, worker)
@@ -5497,7 +5506,9 @@ class Scheduler(SchedulerState, ServerNode):
                 if ts.metadata is None:
                     ts.metadata = {}
                 ts.metadata.update(metadata)
-            return self._transition(key, "memory", stimulus_id, worker=worker, **kwargs)
+            return self._transition(
+                key, "memory", stimulus_id, worker=worker, metadata=metadata, **kwargs
+            )
 
         return recommendations, client_msgs, worker_msgs
 
@@ -5508,10 +5519,9 @@ class Scheduler(SchedulerState, ServerNode):
         # Fields of worker_state_machine.TaskErredMsg
         key: Key,
         run_id: int,
-        exception: Any,
-        traceback: Any,
-        exception_text: str,
-        traceback_text: str,
+        # exception, traceback, etc. Passed as-is to the transitions as well as to
+        # SchedulerPlugin.transition().
+        **kwargs: Any,
     ) -> RecsMsgs:
         """Mark that a task has erred on a particular worker"""
         logger.debug("Stimulus task erred %s, %s", key, worker)
@@ -5534,11 +5544,8 @@ class Scheduler(SchedulerState, ServerNode):
                 "erred",
                 stimulus_id,
                 cause=key,
-                exception=exception,
-                traceback=traceback,
-                exception_text=exception_text,
-                traceback_text=traceback_text,
                 worker=worker,
+                **kwargs,
             )
 
     def stimulus_retry(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -5493,9 +5493,10 @@ class Scheduler(SchedulerState, ServerNode):
         elif ts.state == "memory":
             self.add_keys(worker=worker, keys=[key])
         else:
-            if ts.metadata is None:
-                ts.metadata = {}
-            ts.metadata.update(metadata)
+            if metadata:
+                if ts.metadata is None:
+                    ts.metadata = {}
+                ts.metadata.update(metadata)
             return self._transition(
                 key, "memory", stimulus_id, worker=worker, metadata=metadata, **kwargs
             )

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2760,7 +2760,6 @@ class SchedulerState:
         traceback: Serialized | None = None,
         exception_text: str | None = None,
         traceback_text: str | None = None,
-        **kwargs: Any,
     ) -> RecsMsgs:
         """Processed a recommended transition processing -> erred.
 
@@ -5427,9 +5426,10 @@ class Scheduler(SchedulerState, ServerNode):
 
     def stimulus_task_finished(
         self,
-        key: Key,
         worker: str,
         stimulus_id: str,
+        # Fields of worker_state_machine.TaskFinishedMsg
+        key: Key,
         run_id: int,
         metadata: dict,
         **kwargs: Any,  # nbytes, type, typename, worker, startstops
@@ -5502,13 +5502,15 @@ class Scheduler(SchedulerState, ServerNode):
 
     def stimulus_task_erred(
         self,
-        key: Key,
         worker: str,
-        exception: Any,
         stimulus_id: str,
-        traceback: Any,
+        # Fields of worker_state_machine.TaskErredMsg
+        key: Key,
         run_id: int,
-        **kwargs: Any,
+        exception: Any,
+        traceback: Any,
+        exception_text: str,
+        traceback_text: str,
     ) -> RecsMsgs:
         """Mark that a task has erred on a particular worker"""
         logger.debug("Stimulus task erred %s, %s", key, worker)
@@ -5533,8 +5535,9 @@ class Scheduler(SchedulerState, ServerNode):
                 cause=key,
                 exception=exception,
                 traceback=traceback,
+                exception_text=exception_text,
+                traceback_text=traceback_text,
                 worker=worker,
-                **kwargs,
             )
 
     def stimulus_retry(

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -144,6 +144,7 @@ from distributed.utils_comm import (
     scatter_to_workers,
 )
 from distributed.variable import VariableExtension
+from distributed.worker_state_machine import StartStop
 
 if TYPE_CHECKING:
     from typing import TypeAlias, TypeVar
@@ -1335,7 +1336,7 @@ class TaskState:
 
     #: The type of the object as a string. Only present for tasks that have been
     #: computed.
-    type: str
+    type: str | None
 
     #: If this task failed executing, the exception object is stored here.
     exception: Serialized | None
@@ -1471,7 +1472,7 @@ class TaskState:
         self.resource_restrictions = None
         self.loose_restrictions = False
         self.actor = False
-        self.type = None  # type: ignore
+        self.type = None
         self.metadata = None
         self.annotations = None
         self.erred_on = None
@@ -2479,11 +2480,6 @@ class SchedulerState:
         self,
         key: Key,
         stimulus_id: str,
-        *,
-        nbytes: int | None = None,
-        type: bytes | None = None,
-        typename: str | None = None,
-        worker: str,
         **kwargs: Any,
     ) -> RecsMsgs:
         """This transition exclusively happens in a race condition where the scheduler
@@ -2508,12 +2504,12 @@ class SchedulerState:
         key: Key,
         stimulus_id: str,
         *,
-        nbytes: int | None = None,
-        type: bytes | None = None,
-        typename: str | None = None,
+        nbytes: int,
+        type: bytes,
+        typename: str,
         worker: str,
-        startstops: list[dict] | None = None,
-        **kwargs: Any,
+        startstops: list[StartStop],
+        metadata: dict,
     ) -> RecsMsgs:
         ts = self.tasks[key]
 
@@ -2546,19 +2542,17 @@ class SchedulerState:
         #############################
         # Update Timing Information #
         #############################
-        if startstops:
-            for startstop in startstops:
-                ts.group.add_duration(
-                    stop=startstop["stop"],
-                    start=startstop["start"],
-                    action=startstop["action"],
-                )
+        for startstop in startstops:
+            ts.group.add_duration(
+                stop=startstop["stop"],
+                start=startstop["start"],
+                action=startstop["action"],
+            )
 
         ############################
         # Update State Information #
         ############################
-        if nbytes is not None:
-            ts.set_nbytes(nbytes)
+        ts.set_nbytes(nbytes)
 
         self._exit_processing_common(ts)
 
@@ -3469,8 +3463,8 @@ class SchedulerState:
         ws: WorkerState,
         recommendations: Recs,
         client_msgs: Msgs,
-        type: bytes | None = None,
-        typename: str | None = None,
+        type: bytes,
+        typename: str,
     ) -> None:
         """Add ts to the set of in-memory tasks"""
         if self.validate:
@@ -3500,14 +3494,13 @@ class SchedulerState:
             recommendations[ts.key] = "released"
         else:
             report_msg: dict[str, Any] = {"op": "key-in-memory", "key": ts.key}
-            if type is not None:
-                report_msg["type"] = type
+            report_msg["type"] = type
             for cs in ts.who_wants or ():
                 client_msgs[cs.client_key] = [report_msg]
 
         ts.state = "memory"
-        ts.type = typename  # type: ignore
-        ts.group.add_type(typename)  # type: ignore
+        ts.type = typename
+        ts.group.add_type(typename)
 
         cs = self.clients["fire-and-forget"]
         if ts in cs.wants_what:
@@ -5434,7 +5427,13 @@ class Scheduler(SchedulerState, ServerNode):
                 assert not self.queued or self.queued.peek() != qts
 
     def stimulus_task_finished(
-        self, key: Key, worker: str, stimulus_id: str, run_id: int, **kwargs: Any
+        self,
+        key: Key,
+        worker: str,
+        stimulus_id: str,
+        run_id: int,
+        metadata: dict,
+        **kwargs: Any,  # nbytes, type, typename, worker, startstops
     ) -> RecsMsgs:
         """Mark that a task has finished execution on a particular worker"""
         logger.debug("Stimulus task finished %s[%d] %s", key, run_id, worker)
@@ -5494,11 +5493,12 @@ class Scheduler(SchedulerState, ServerNode):
         elif ts.state == "memory":
             self.add_keys(worker=worker, keys=[key])
         else:
-            if kwargs["metadata"]:
-                if ts.metadata is None:
-                    ts.metadata = dict()
-                ts.metadata.update(kwargs["metadata"])
-            return self._transition(key, "memory", stimulus_id, worker=worker, **kwargs)
+            if ts.metadata is None:
+                ts.metadata = {}
+            ts.metadata.update(metadata)
+            return self._transition(
+                key, "memory", stimulus_id, worker=worker, metadata=metadata, **kwargs
+            )
 
         return recommendations, client_msgs, worker_msgs
 

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2480,7 +2480,7 @@ class SchedulerState:
         self,
         key: Key,
         stimulus_id: str,
-        **kwargs: Any,
+        **kwargs: Any,  # Fields of worker_state_machine.TaskFinishedMsg
     ) -> RecsMsgs:
         """This transition exclusively happens in a race condition where the scheduler
         believes that the only copy of a dependency task has just been lost, so it
@@ -2504,6 +2504,7 @@ class SchedulerState:
         key: Key,
         stimulus_id: str,
         *,
+        # Fields of worker_state_machine.TaskFinishedMsg
         nbytes: int,
         type: bytes,
         typename: str,

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -440,8 +440,14 @@ class TaskFinishedMsg(SendMessageToScheduler):
     type: bytes  # serialized class
     typename: str
     metadata: dict
+    thread: int | None
     startstops: list[StartStop]
     __slots__ = tuple(__annotations__)
+
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["status"] = "OK"
+        return d
 
 
 @dataclass
@@ -454,10 +460,19 @@ class TaskErredMsg(SendMessageToScheduler):
     traceback: Serialize | None
     exception_text: str
     traceback_text: str
+    thread: int | None
+    startstops: list[StartStop]
     __slots__ = tuple(__annotations__)
 
+    def to_dict(self) -> dict[str, Any]:
+        d = super().to_dict()
+        d["status"] = "error"
+        return d
+
     @staticmethod
-    def from_task(ts: TaskState, run_id: int, stimulus_id: str) -> TaskErredMsg:
+    def from_task(
+        ts: TaskState, run_id: int, stimulus_id: str, thread: int | None = None
+    ) -> TaskErredMsg:
         assert ts.exception
         return TaskErredMsg(
             key=ts.key,
@@ -466,6 +481,8 @@ class TaskErredMsg(SendMessageToScheduler):
             traceback=ts.traceback,
             exception_text=ts.exception_text,
             traceback_text=ts.traceback_text,
+            thread=thread,
+            startstops=ts.startstops,
             stimulus_id=stimulus_id,
         )
 
@@ -1764,6 +1781,7 @@ class WorkerState:
             type=type_serialized,
             typename=typename(ts.type),
             metadata=ts.metadata,
+            thread=self.threads.get(ts.key),
             startstops=ts.startstops,
             stimulus_id=stimulus_id,
         )
@@ -1987,7 +2005,12 @@ class WorkerState:
         ts.exception_text = exception_text
         ts.traceback_text = traceback_text
         ts.state = "error"
-        smsg = TaskErredMsg.from_task(ts, run_id=run_id, stimulus_id=stimulus_id)
+        smsg = TaskErredMsg.from_task(
+            ts,
+            run_id=run_id,
+            stimulus_id=stimulus_id,
+            thread=self.threads.get(ts.key),
+        )
 
         return {}, [smsg]
 

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -1748,7 +1748,7 @@ class WorkerState:
             assert ts.state == "memory"
             assert ts.key in self.data or ts.key in self.actors
             assert ts.type is not None
-            assert ts.nbytes is not None
+        assert ts.nbytes is not None
 
         try:
             type_serialized = pickle.dumps(ts.type)
@@ -1760,7 +1760,7 @@ class WorkerState:
         return TaskFinishedMsg(
             key=ts.key,
             run_id=run_id,
-            nbytes=ts.nbytes,  # type: ignore[arg-type]
+            nbytes=ts.nbytes,
             type=type_serialized,
             typename=typename(ts.type),
             metadata=ts.metadata,

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -436,18 +436,12 @@ class TaskFinishedMsg(SendMessageToScheduler):
 
     key: Key
     run_id: int
-    nbytes: int | None
+    nbytes: int
     type: bytes  # serialized class
     typename: str
     metadata: dict
-    thread: int | None
     startstops: list[StartStop]
     __slots__ = tuple(__annotations__)
-
-    def to_dict(self) -> dict[str, Any]:
-        d = super().to_dict()
-        d["status"] = "OK"
-        return d
 
 
 @dataclass
@@ -460,19 +454,10 @@ class TaskErredMsg(SendMessageToScheduler):
     traceback: Serialize | None
     exception_text: str
     traceback_text: str
-    thread: int | None
-    startstops: list[StartStop]
     __slots__ = tuple(__annotations__)
 
-    def to_dict(self) -> dict[str, Any]:
-        d = super().to_dict()
-        d["status"] = "error"
-        return d
-
     @staticmethod
-    def from_task(
-        ts: TaskState, run_id: int, stimulus_id: str, thread: int | None = None
-    ) -> TaskErredMsg:
+    def from_task(ts: TaskState, run_id: int, stimulus_id: str) -> TaskErredMsg:
         assert ts.exception
         return TaskErredMsg(
             key=ts.key,
@@ -481,8 +466,6 @@ class TaskErredMsg(SendMessageToScheduler):
             traceback=ts.traceback,
             exception_text=ts.exception_text,
             traceback_text=ts.traceback_text,
-            thread=thread,
-            startstops=ts.startstops,
             stimulus_id=stimulus_id,
         )
 
@@ -1777,11 +1760,10 @@ class WorkerState:
         return TaskFinishedMsg(
             key=ts.key,
             run_id=run_id,
-            nbytes=ts.nbytes,
+            nbytes=ts.nbytes,  # type: ignore[arg-type]
             type=type_serialized,
             typename=typename(ts.type),
             metadata=ts.metadata,
-            thread=self.threads.get(ts.key),
             startstops=ts.startstops,
             stimulus_id=stimulus_id,
         )
@@ -2005,12 +1987,7 @@ class WorkerState:
         ts.exception_text = exception_text
         ts.traceback_text = traceback_text
         ts.state = "error"
-        smsg = TaskErredMsg.from_task(
-            ts,
-            run_id=run_id,
-            stimulus_id=stimulus_id,
-            thread=self.threads.get(ts.key),
-        )
+        smsg = TaskErredMsg.from_task(ts, run_id=run_id, stimulus_id=stimulus_id)
 
         return {}, [smsg]
 


### PR DESCRIPTION
Clean up transition to memory and to erred. Some parameters are always sent by the worker state. Other parameters are unused by the scheduler, but they are used by SchedulerPlugin.transition - this can lead to confusion; improve documentation for them.