### PR TITLE
`@contextmanager` should return `Generator[T]`

### DIFF
--- a/continuous_integration/scripts/test_report.py
+++ b/continuous_integration/scripts/test_report.py
@@ -9,7 +9,7 @@ import re
 import shelve
 import sys
 import zipfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Generator, Iterable, Iterator
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any, cast
 
@@ -32,7 +32,7 @@ COLORS = {
 
 
 @contextlib.contextmanager
-def get_session() -> Iterator[requests.Session]:
+def get_session() -> Generator[requests.Session]:
     retry_strategy = Retry(
         status_forcelist=[429, 500, 502, 503, 504],
         backoff_factor=0.2,

--- a/distributed/diagnostics/memory_sampler.py
+++ b/distributed/diagnostics/memory_sampler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
@@ -96,7 +96,7 @@ class MemorySampler:
     @contextmanager
     def _sample_sync(
         self, label: str | None, client: Client, measure: str, interval: float
-    ) -> Iterator[None]:
+    ) -> Generator[None]:
         key = client.sync(
             client.scheduler.memory_sampler_start,
             client=client.id,

--- a/distributed/diagnostics/memray.py
+++ b/distributed/diagnostics/memray.py
@@ -6,7 +6,7 @@ import pathlib
 import subprocess
 import time
 import uuid
-from collections.abc import Iterator, Sequence
+from collections.abc import Generator, Sequence
 from typing import Any, Literal
 from urllib.parse import quote
 
@@ -78,7 +78,7 @@ def memray_workers(
     ),
     fetch_reports_parallel: bool | int = True,
     **memray_kwargs: Any,
-) -> Iterator[None]:
+) -> Generator[None]:
     """Generate a Memray profile on the workers and download the generated report.
 
     Example::
@@ -192,7 +192,7 @@ def memray_scheduler(
         "--leaks",
     ),
     **memray_kwargs: Any,
-) -> Iterator[None]:
+) -> Generator[None]:
     """Generate a Memray profile on the Scheduler and download the generated report.
 
     Example::

--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -5,7 +5,7 @@ import collections
 import sys
 import threading
 import time as timemod
-from collections.abc import Callable, Hashable, Iterator
+from collections.abc import Callable, Generator, Hashable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -125,7 +125,7 @@ class MeterOutput:
 def meter(
     func: Callable[[], float] = timemod.perf_counter,
     floor: float | Literal[False] = 0.0,
-) -> Iterator[MeterOutput]:
+) -> Generator[MeterOutput]:
     """Convenience context manager which calls func() before and after the wrapped
     code and calculates the delta.
 
@@ -214,7 +214,7 @@ class ContextMeter:
         *,
         key: Hashable | None = None,
         allow_offload: bool = False,
-    ) -> Iterator[None]:
+    ) -> Generator[None]:
         """Add a callback when entering the context and remove it when exiting it.
         The callback must accept the same parameters as :meth:`digest_metric`.
 
@@ -256,7 +256,7 @@ class ContextMeter:
             tok.var.reset(tok)
 
     @contextmanager
-    def clear_callbacks(self) -> Iterator[None]:
+    def clear_callbacks(self) -> Generator[None]:
         """Do not trigger any callbacks set outside of this context"""
         tok = self._callbacks.set({})
         try:
@@ -279,7 +279,7 @@ class ContextMeter:
         unit: str = "seconds",
         func: Callable[[], float] = timemod.perf_counter,
         floor: float | Literal[False] = 0.0,
-    ) -> Iterator[MeterOutput]:
+    ) -> Generator[MeterOutput]:
         """Convenience context manager or decorator which calls func() before and after
         the wrapped code, calculates the delta, and finally calls :meth:`digest_metric`.
 
@@ -378,7 +378,7 @@ class DelayedMetricsLedger:
         self.metrics.append((label, value, unit))
 
     @contextmanager
-    def record(self, *, key: Hashable | None = None) -> Iterator[None]:
+    def record(self, *, key: Hashable | None = None) -> Generator[None]:
         """Ingest metrics logged with :meth:`ContextMeter.digest_metric` or
         :meth:`ContextMeter.meter` and temporarily store them in :ivar:`metrics`.
 

--- a/distributed/shuffle/_core.py
+++ b/distributed/shuffle/_core.py
@@ -12,7 +12,6 @@ from collections.abc import (
     Generator,
     Hashable,
     Iterable,
-    Iterator,
     Sequence,
 )
 from concurrent.futures import ThreadPoolExecutor
@@ -174,7 +173,7 @@ class ShuffleRun(Generic[_T_partition_id, _T_partition_type]):
         return self.run_id
 
     @contextlib.contextmanager
-    def _capture_metrics(self, where: str) -> Iterator[None]:
+    def _capture_metrics(self, where: str) -> Generator[None]:
         """Capture context_meter metrics as
 
             {('p2p', <span id>, 'foreground|background...', label, unit): value}
@@ -519,7 +518,7 @@ class SchedulerShuffleState(Generic[_T_partition_id]):
 
 
 @contextlib.contextmanager
-def handle_transfer_errors(id: ShuffleId) -> Iterator[None]:
+def handle_transfer_errors(id: ShuffleId) -> Generator[None]:
     try:
         yield
     except ShuffleClosedError:
@@ -533,7 +532,7 @@ def handle_transfer_errors(id: ShuffleId) -> Iterator[None]:
 
 
 @contextlib.contextmanager
-def handle_unpack_errors(id: ShuffleId) -> Iterator[None]:
+def handle_unpack_errors(id: ShuffleId) -> Generator[None]:
     try:
         yield
     except Reschedule as e:

--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -4,7 +4,7 @@ import copy
 import uuid
 import weakref
 from collections import defaultdict
-from collections.abc import Hashable, Iterable, Iterator, Mapping
+from collections.abc import Generator, Hashable, Iterable, Iterator, Mapping
 from contextlib import contextmanager
 from itertools import islice
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -34,7 +34,7 @@ class SpanMetadata(TypedDict):
 
 
 @contextmanager
-def span(*tags: str) -> Iterator[str]:
+def span(*tags: str) -> Generator[str]:
     """Tag group of tasks to be part of a certain group, called a span.
 
     This context manager can be nested, thus creating sub-spans. If you close and

--- a/distributed/spill.py
+++ b/distributed/spill.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from collections.abc import Callable, Hashable, Iterator, Mapping, MutableMapping, Sized
+from collections.abc import (
+    Callable,
+    Generator,
+    Hashable,
+    Mapping,
+    MutableMapping,
+    Sized,
+)
 from contextlib import contextmanager
 from functools import partial
 from typing import Literal, NamedTuple, Protocol, cast
@@ -101,7 +108,7 @@ class SpillBuffer(zict.Buffer[Key, object]):
         self.cumulative_metrics = defaultdict(float)
 
     @contextmanager
-    def _capture_metrics(self) -> Iterator[None]:
+    def _capture_metrics(self) -> Generator[None]:
         """Capture metrics re. disk read/write, serialize/deserialize, and
         compress/decompress.
 
@@ -119,7 +126,7 @@ class SpillBuffer(zict.Buffer[Key, object]):
             yield
 
     @contextmanager
-    def _handle_errors(self, key: Key | None) -> Iterator[None]:
+    def _handle_errors(self, key: Key | None) -> Generator[None]:
         try:
             yield
         except MaxSpillExceeded as e:

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import random
 import warnings
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any, Literal
 
@@ -37,7 +37,7 @@ from distributed.worker_state_machine import AcquireReplicasEvent
 
 
 @contextmanager
-def assert_amm_log(expect: list[str]) -> Iterator[None]:
+def assert_amm_log(expect: list[str]) -> Generator[None]:
     with captured_logger(
         "distributed.active_memory_manager", level=logging.DEBUG
     ) as logger:

--- a/distributed/utils.py
+++ b/distributed/utils.py
@@ -29,7 +29,6 @@ from collections.abc import (
     Collection,
     Container,
     Generator,
-    Iterator,
     KeysView,
     ValuesView,
 )
@@ -1311,7 +1310,7 @@ def iscoroutinefunction(f):
 
 
 @contextlib.contextmanager
-def warn_on_duration(duration: str | float | timedelta, msg: str) -> Iterator[None]:
+def warn_on_duration(duration: str | float | timedelta, msg: str) -> Generator[None]:
     """Generate a UserWarning if the operation in this context takes longer than
     *duration* and print *msg*
 

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -23,7 +23,7 @@ import threading
 import warnings
 import weakref
 from collections import defaultdict
-from collections.abc import Callable, Collection, Generator, Hashable, Iterator, Mapping
+from collections.abc import Callable, Collection, Generator, Hashable, Mapping
 from contextlib import contextmanager, nullcontext, suppress
 from itertools import count
 from time import sleep
@@ -1144,7 +1144,7 @@ def popen(
     terminate_timeout: float = 10,
     kill_timeout: float = 5,
     **kwargs: Any,
-) -> Iterator[subprocess.Popen[bytes]]:
+) -> Generator[subprocess.Popen[bytes]]:
     """Start a shell command in a subprocess.
     Yields a subprocess.Popen object.
 
@@ -1478,7 +1478,7 @@ def new_config(new_config):
 
 
 @contextmanager
-def new_config_file(c: dict[str, Any]) -> Iterator[None]:
+def new_config_file(c: dict[str, Any]) -> Generator[None]:
     """
     Temporarily change configuration file to match dictionary *c*.
     """
@@ -1694,7 +1694,7 @@ def term_or_kill_active_children(timeout: float) -> None:
 @contextmanager
 def check_process_leak(
     check: bool = True, check_timeout: float = 40, term_timeout: float = 3
-) -> Iterator[None]:
+) -> Generator[None]:
     """Terminate any currently-running subprocesses at both the beginning and end of this context
 
     Parameters
@@ -2271,7 +2271,7 @@ class BarrierGetData(Worker):
 
 
 @contextmanager
-def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[None]:
+def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Generator[None]:
     """Prevent any task from transitioning from fetch to flight on the worker while
     inside the context, simulating a situation where the worker's network comms are
     saturated.
@@ -2302,7 +2302,7 @@ def freeze_data_fetching(w: Worker, *, jump_start: bool = False) -> Iterator[Non
 
 
 @contextmanager
-def freeze_batched_send(bcomm: BatchedSend) -> Iterator[LockedComm]:
+def freeze_batched_send(bcomm: BatchedSend) -> Generator[LockedComm]:
     """
     Contextmanager blocking writes to a `BatchedSend` from sending over the network.
 


### PR DESCRIPTION
Change return type of functions decorated by `@contextmanager` from `Iterator[T]` to `Generator[T]`
(as suggested by PyLance)