### PR TITLE
Bump actions/checkout from 4.1.3 to 6.0.2

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     name: pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build (and upload)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Required to get tag history
       - name: Check if release commit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0  # Required to get tag history
       - name: Check if release commit

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -18,7 +18,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v4.1.3
+      - uses: actions/checkout@v6.0.2
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v4.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,7 +112,7 @@ jobs:
         shell: bash
 
       - name: Checkout source
-        uses: actions/checkout@v4.1.3
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Address this warning message and avoid CI disruptions next June:

**Warning:** Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@v4`, `actions/checkout@v4.1.3`. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`. For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

- [ ] Tests added / passed
- [X] Passes `pre-commit run --all-files`
