### PR TITLE
Standardize and increase async_poll_for timeout

### DIFF
--- a/distributed/deploy/tests/test_adaptive.py
+++ b/distributed/deploy/tests/test_adaptive.py
@@ -479,7 +479,7 @@ async def test_scale_needs_to_be_awaited():
             await client.gather(futures)
 
             del futures
-            await async_poll_for(lambda: not cluster.workers, 10)
+            await async_poll_for(lambda: not cluster.workers)
 
 
 @gen_test()
@@ -492,11 +492,11 @@ async def test_adaptive_stopped():
         n_workers=0, asynchronous=True, dashboard_address=":0"
     ) as cluster:
         instance = cluster.adapt(interval="10ms")
-        await async_poll_for(lambda: instance.state == "running", timeout=5)
+        await async_poll_for(lambda: instance.state == "running")
         assert instance.periodic_callback is not None
         assert instance.periodic_callback.is_running()
         pc = instance.periodic_callback
-    await async_poll_for(lambda: instance.state == "stopped", timeout=5)
+    await async_poll_for(lambda: instance.state == "stopped")
     assert not pc.is_running()
 
 
@@ -585,7 +585,7 @@ async def test_adaptive_stops_on_cluster_status_change():
     ) as cluster:
         adapt = Adaptive(cluster, interval="100 ms")
         assert adapt.state == "starting"
-        await async_poll_for(lambda: adapt.state == "running", timeout=5)
+        await async_poll_for(lambda: adapt.state == "running")
 
         assert adapt.periodic_callback
         assert adapt.periodic_callback.is_running()
@@ -593,7 +593,7 @@ async def test_adaptive_stops_on_cluster_status_change():
         try:
             cluster.status = Status.closing
 
-            await async_poll_for(lambda: adapt.state != "running", timeout=5)
+            await async_poll_for(lambda: adapt.state != "running")
             assert adapt.state == "stopped"
             assert not adapt.periodic_callback
         finally:
@@ -674,7 +674,7 @@ async def test_adapt_callback_logs_error_in_scale_down():
             Adaptive=BadAdaptive, minimum=1, maximum=4, wait_count=0, interval="10ms"
         )
         adapt._target = 2
-        await async_poll_for(lambda: adapt.state == "running", timeout=5)
+        await async_poll_for(lambda: adapt.state == "running")
         assert adapt.periodic_callback.is_running()
         await adapt.adapt()
         assert len(adapt.plan) == 2
@@ -703,7 +703,7 @@ async def test_adaptive_logs_stopping_once(wait_until_running):
         with captured_logger("distributed.deploy.adaptive") as log:
             adapt = cluster.adapt(Adaptive=MyAdaptive, interval="100ms")
             if wait_until_running:
-                await async_poll_for(lambda: adapt.state == "running", timeout=5)
+                await async_poll_for(lambda: adapt.state == "running")
                 assert adapt.periodic_callback
                 assert adapt.periodic_callback.is_running()
                 pc = adapt.periodic_callback
@@ -731,9 +731,9 @@ async def test_adapt_stop_del():
     ) as cluster:
         adapt = cluster.adapt(Adaptive=MyAdaptive, interval="100ms")
         pc = adapt.periodic_callback
-        await async_poll_for(lambda: adapt.state == "running", timeout=5)  # noqa: F821
+        await async_poll_for(lambda: adapt.state == "running")  # noqa: F821
 
         # Remove reference of adaptive object from cluster
         cluster._adaptive = None
         del adapt
-        await async_poll_for(lambda: not pc.is_running(), timeout=5)
+        await async_poll_for(lambda: not pc.is_running())

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -770,8 +770,7 @@ async def test_adapt_then_manual():
         def wait_workers(n):
             return async_poll_for(
                 lambda: len(cluster.scheduler.workers) == n
-                and len(cluster.workers) == n,
-                timeout=5,
+                and len(cluster.workers) == n
             )
 
         await wait_workers(8)

--- a/distributed/diagnostics/tests/test_worker_plugin.py
+++ b/distributed/diagnostics/tests/test_worker_plugin.py
@@ -113,7 +113,7 @@ async def test_normal_task_transitions_called(c, s, w):
 
     await c.register_plugin(plugin)
     await c.submit(lambda x: x, 1, key="task")
-    await async_poll_for(lambda: not w.state.tasks, timeout=10)
+    await async_poll_for(lambda: not w.state.tasks)
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
@@ -159,7 +159,7 @@ async def test_superseding_task_transitions_called(c, s, w):
 
     await c.register_plugin(plugin)
     await c.submit(lambda x: x, 1, key="task", resources={"X": 1})
-    await async_poll_for(lambda: not w.state.tasks, timeout=10)
+    await async_poll_for(lambda: not w.state.tasks)
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)
@@ -185,7 +185,7 @@ async def test_dependent_tasks(c, s, w):
 
     await c.register_plugin(plugin)
     await c.get(dsk, "task", sync=False)
-    await async_poll_for(lambda: not w.state.tasks, timeout=10)
+    await async_poll_for(lambda: not w.state.tasks)
 
 
 @gen_cluster(nthreads=[("127.0.0.1", 1)], client=True)

--- a/distributed/http/scheduler/tests/test_scheduler_http.py
+++ b/distributed/http/scheduler/tests/test_scheduler_http.py
@@ -507,7 +507,7 @@ async def test_prometheus_collect_worker_states(c, s, a, b):
 
     a.monitor.get_process_memory = lambda: 2**40
     sa = s.workers[a.address]
-    await async_poll_for(lambda: sa.status == Status.paused, timeout=2)
+    await async_poll_for(lambda: sa.status == Status.paused)
     assert await fetch_metrics() == {
         "idle": 1,
         "partially_saturated": 0,

--- a/distributed/http/worker/tests/test_worker_http.py
+++ b/distributed/http/worker/tests/test_worker_http.py
@@ -119,7 +119,7 @@ async def test_prometheus_collect_task_states(c, s, a):
 
     # submit a task which should show up in the prometheus scraping
     fut1 = c.submit(ev.wait)
-    await async_poll_for(lambda: a.state.executing, timeout=5)
+    await async_poll_for(lambda: a.state.executing)
 
     await assert_metrics(executing=1)
 
@@ -140,7 +140,7 @@ async def test_prometheus_collect_task_states(c, s, a):
     fut1.release()
     fut2.release()
 
-    await async_poll_for(lambda: not a.state.tasks, timeout=5)
+    await async_poll_for(lambda: not a.state.tasks)
     await assert_metrics()
 
 

--- a/distributed/shuffle/tests/test_rechunk.py
+++ b/distributed/shuffle/tests/test_rechunk.py
@@ -1371,8 +1371,7 @@ async def test_partial_rechunk_taskgroups(c, s):
         lambda: any(
             isinstance(task, str) and task.startswith("shuffle-barrier")
             for task in s.tasks
-        ),
-        timeout=5,
+        )
     )
     assert len(s.task_groups) < 7
 

--- a/distributed/shuffle/tests/test_shuffle.py
+++ b/distributed/shuffle/tests/test_shuffle.py
@@ -468,7 +468,7 @@ async def test_erred_task_before_p2p_does_not_log_event(c, s, a, b):
         out = df.shuffle("x", force=True)
         shuffle_ext = s.plugins["shuffle"]
     out = c.compute(out)
-    await async_poll_for(lambda: shuffle_ext.active_shuffles, timeout=5)
+    await async_poll_for(lambda: shuffle_ext.active_shuffles)
     await event.set()
     with pytest.raises(RuntimeError, match="test error"):
         await out
@@ -539,17 +539,15 @@ async def test_get_or_create_from_dangling_transfer(c, s, a, b):
 
     await shuffle_extA.shuffle_runs.in_get_or_create.wait()
     await assert_worker_cleanup(b, close=True)
-    await async_poll_for(
-        lambda: not any(ws.processing for ws in s.workers.values()), timeout=5
-    )
+    await async_poll_for(lambda: not any(ws.processing for ws in s.workers.values()))
 
     with pytest.raises(KilledWorker):
         await out
 
-    await async_poll_for(lambda: not s.plugins["shuffle"].active_shuffles, timeout=5)
+    await async_poll_for(lambda: not s.plugins["shuffle"].active_shuffles)
     assert a.state.tasks
     shuffle_extA.shuffle_runs.block_get_or_create.set()
-    await async_poll_for(lambda: not a.state.tasks, timeout=10)
+    await async_poll_for(lambda: not a.state.tasks)
 
     assert not s.plugins["shuffle"].active_shuffles
     await assert_worker_cleanup(a)
@@ -613,13 +611,13 @@ async def test_restarting_does_not_deadlock(c, s):
             while not s.extensions["shuffle"].active_shuffles:
                 await asyncio.sleep(0)
             a.status = Status.paused
-            await async_poll_for(lambda: len(s.running) == 1, timeout=5)
+            await async_poll_for(lambda: len(s.running) == 1)
             b.batched_stream.close()
-            await async_poll_for(lambda: not s.running, timeout=5)
+            await async_poll_for(lambda: not s.running)
 
             a.status = Status.running
 
-            await async_poll_for(lambda: s.running, timeout=5)
+            await async_poll_for(lambda: s.running)
             result = await result
             assert dd.assert_eq(result, expected)
 
@@ -806,10 +804,7 @@ async def test_closed_worker_during_barrier(c, s, a, b):
         except KeyError:
             return False
 
-    await async_poll_for(
-        shuffle_restarted,
-        timeout=5,
-    )
+    await async_poll_for(shuffle_restarted)
     restarted_shuffle = alive_shuffles[shuffle_id]
     restarted_shuffle.block_inputs_done.set()
 
@@ -915,10 +910,7 @@ async def test_closed_other_worker_during_barrier(c, s, a, b):
         except KeyError:
             return False
 
-    await async_poll_for(
-        shuffle_restarted,
-        timeout=5,
-    )
+    await async_poll_for(shuffle_restarted)
     restarted_shuffle = alive_shuffles[shuffle_id]
     restarted_shuffle.block_inputs_done.set()
 
@@ -964,10 +956,7 @@ async def test_crashed_other_worker_during_barrier(c, s, a):
             except KeyError:
                 return False
 
-        await async_poll_for(
-            shuffle_restarted,
-            timeout=5,
-        )
+        await async_poll_for(shuffle_restarted)
         restarted_shuffle = get_active_shuffle_run(shuffle_id, a)
         restarted_shuffle.block_inputs_done.set()
 

--- a/distributed/tests/test_active_memory_manager.py
+++ b/distributed/tests/test_active_memory_manager.py
@@ -741,7 +741,7 @@ async def test_ReduceReplicas(c, s, *workers):
         ],
     ):
         s.extensions["amm"].run_once()
-    await async_poll_for(lambda: len(s.tasks["x"].who_has) == 1, timeout=5)
+    await async_poll_for(lambda: len(s.tasks["x"].who_has) == 1)
 
 
 @pytest.mark.parametrize(
@@ -795,7 +795,7 @@ async def test_ReduceReplicas_with_waiters(
         for i in range(nwaiters_nonproc)
     ]
     nwaiters = nwaiters_w1 + nwaiters_w2 + nwaiters_nonproc
-    await async_poll_for(lambda: len(s.tasks) == nwaiters + 2, timeout=5)
+    await async_poll_for(lambda: len(s.tasks) == nwaiters + 2)
     for fut in waiters_w1:
         assert s.tasks[fut.key].processing_on == s.workers[w1.address]
     for fut in waiters_w2:
@@ -805,7 +805,7 @@ async def test_ReduceReplicas_with_waiters(
 
     s.extensions["amm"].run_once()
     await asyncio.sleep(0.2)  # Test no excessive drops
-    await async_poll_for(lambda: len(s.tasks["x"].who_has) == nreplicas, timeout=5)
+    await async_poll_for(lambda: len(s.tasks["x"].who_has) == nreplicas)
     await ev.set()
 
 
@@ -1297,7 +1297,7 @@ async def tensordot_stress(c, s):
     else:
         raise RuntimeError("Expected 'update_graph' event not found")
     # Test that we didn't recompute any tasks during the stress test
-    await async_poll_for(lambda: not s.tasks, timeout=5)
+    await async_poll_for(lambda: not s.tasks)
     assert sum(t.start == "memory" for t in s.transition_log) == expected_tasks
 
 

--- a/distributed/tests/test_cancelled_state.py
+++ b/distributed/tests/test_cancelled_state.py
@@ -300,7 +300,7 @@ async def test_in_flight_lost_after_resumed(c, s, b):
         fut1.release()
         fut2.release()
 
-        await async_poll_for(lambda: not b.state.tasks, timeout=5)
+        await async_poll_for(lambda: not b.state.tasks)
 
 
 @gen_cluster(client=True)
@@ -500,7 +500,7 @@ async def test_resumed_cancelled_handle_compute(
         await lock_compute.release()
         await exit_compute.wait()
 
-        await async_poll_for(lambda: f3.key not in b.state.tasks, timeout=5)
+        await async_poll_for(lambda: f3.key not in b.state.tasks)
 
     f1 = c.submit(inc, 1, key="f1", workers=[a.address])
     f2 = c.submit(inc, f1, key="f2", workers=[a.address])
@@ -1357,7 +1357,7 @@ async def test_secede_racing_cancellation_and_scheduling_on_other_worker(c, s, a
 
             # Cancel x while the scheduler does not know that it seceded
             x.release()
-            await async_poll_for(lambda: not s.tasks, timeout=5)
+            await async_poll_for(lambda: not s.tasks)
             assert not wsA.processing
             assert not wsA.long_running
 
@@ -1475,7 +1475,7 @@ async def test_secede_racing_resuming_on_same_worker(c, s, a):
 
             # Cancel x while the scheduler does not know that it seceded
             x.release()
-            await async_poll_for(lambda: not s.tasks, timeout=5)
+            await async_poll_for(lambda: not s.tasks)
             assert not wsA.processing
             assert not wsA.long_running
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -463,18 +463,18 @@ def test_Future_release_sync(c):
     x = c.submit(div, 1, 1)
     x.result()
     x.release()
-    poll_for(lambda: not c.futures, timeout=5)
+    poll_for(lambda: not c.futures)
 
     ev = Event()
     x = c.submit(lambda ev: ev.wait(), ev)
     x.release()
-    poll_for(lambda: not c.futures, timeout=5)
+    poll_for(lambda: not c.futures)
     ev.set()
 
     x = c.submit(div, 1, 0)
     x.exception()
     x.release()
-    poll_for(lambda: not c.futures, timeout=5)
+    poll_for(lambda: not c.futures)
 
 
 @pytest.mark.parametrize("method", ["result", "gather"])
@@ -566,9 +566,7 @@ async def test_gc(s, a, b):
         await x
         assert s.tasks[x.key].who_has
         x.__del__()
-        await async_poll_for(
-            lambda: x.key not in s.tasks or not s.tasks[x.key].who_has, timeout=0.3
-        )
+        await async_poll_for(lambda: x.key not in s.tasks or not s.tasks[x.key].who_has)
 
 
 def test_thread(c):
@@ -3624,9 +3622,9 @@ def test_get_returns_early(c):
         result = c.get({"x": (throws, 1), "y": (block, event)}, ["x", "y"])
 
     # Futures should be released and forgotten
-    poll_for(lambda: not c.futures, timeout=1)
+    poll_for(lambda: not c.futures)
     event.set()
-    poll_for(lambda: not any(c.processing().values()), timeout=3)
+    poll_for(lambda: not any(c.processing().values()))
 
     x = c.submit(inc, 1)
     x.result()
@@ -3767,11 +3765,7 @@ async def test_reconnect():
         assert (await x) == 2
         stack.close()
 
-        start = time()
-        while c.status != "connecting":
-            assert time() < start + 10
-            await asyncio.sleep(0.01)
-
+        await async_poll_for(lambda: c.status == "connecting")
         assert x.status == "cancelled"
         with pytest.raises(CancelledError):
             await x
@@ -3786,12 +3780,9 @@ async def test_reconnect():
                 f"--port={port}",
             ]
         ):
-            start = time()
-            while c.status != "running":
-                await asyncio.sleep(0.1)
-                assert time() < start + 10
-
+            await async_poll_for(lambda: c.status == "running")
             await w.finished()
+
             async with Worker(f"127.0.0.1:{port}"):
                 start = time()
                 while len(await c.nthreads()) != 1:
@@ -3906,13 +3897,8 @@ def test_open_close_many_workers(loop, worker, count, repeat):
                 if not running:
                     break
 
-            start = time()
-            while c.nthreads():
-                sleep(0.2)
-                assert time() < start + 10
-
-            while len(workers) < count * repeat:
-                sleep(0.2)
+            poll_for(lambda: not c.nthreads(), period=0.2)
+            poll_for(len(workers) == count * repeat, timeout=300)
 
             status = False
 
@@ -8172,9 +8158,9 @@ async def test_gather_race_vs_AMM(c, s, a, direct):
         # Can't use s.request_acquire_replicas as it would get stuck on b.block_get_data
         a.update_data({"x": 3})
         a.batched_send({"op": "add-keys", "keys": ["x"]})
-        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 2, timeout=5)
+        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 2)
         s.request_remove_replicas(b.address, ["x"], stimulus_id="remove")
-        await async_poll_for(lambda: "x" not in b.data, timeout=5)
+        await async_poll_for(lambda: "x" not in b.data)
 
         b.block_get_data.set()
 

--- a/distributed/tests/test_computations.py
+++ b/distributed/tests/test_computations.py
@@ -83,7 +83,7 @@ async def test_computations_long_running(c, s, a):
 
     x = c.submit(func, ev, key="x")
     await wait_for_state("x", "long-running", a)
-    await async_poll_for(lambda: s.total_occupancy == 0, timeout=5)
+    await async_poll_for(lambda: s.total_occupancy == 0)
     y = c.submit(inc, 1, key="y")
     assert await y == 2
     await ev.set()

--- a/distributed/tests/test_failed_workers.py
+++ b/distributed/tests/test_failed_workers.py
@@ -73,7 +73,7 @@ async def test_submit_after_failed_worker_async(
 
     if when == "closed":
         await b.close()
-        await async_poll_for(lambda: b.address not in s.workers, timeout=5)
+        await async_poll_for(lambda: b.address not in s.workers)
     elif when == "closing":
         orig_remove_worker = s.remove_worker
         in_remove_worker = asyncio.Event()
@@ -96,7 +96,7 @@ async def test_submit_after_failed_worker_async(
         workers=[b.address if y_on_failed else a.address],
         allow_other_workers=True,
     )
-    await async_poll_for(lambda: "y" in s.tasks, timeout=5)
+    await async_poll_for(lambda: "y" in s.tasks)
 
     if when == "closing":
         wait_remove_worker.set()
@@ -250,7 +250,7 @@ async def test_multiple_clients_restart(s, a, b):
         assert await y2 == 3
 
         del x2, y2
-        await async_poll_for(lambda: not s.tasks, timeout=5)
+        await async_poll_for(lambda: not s.tasks)
 
 
 @gen_cluster(Worker=Nanny, timeout=60)
@@ -380,8 +380,7 @@ async def test_worker_who_has_clears_after_failed_connection(c, s, a, b):
         result_fut = c.submit(sink, futures, workers=a.address)
 
         await n.kill(timeout=1)
-        while len(s.workers) > 2:
-            await asyncio.sleep(0.01)
+        await async_poll_for(lambda: len(s.workers) <= 2)
 
         await result_fut
 

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -61,15 +61,14 @@ async def test_nanny_process_failure(c, s):
             await c.run(os._exit, 0, workers=[n.worker_address])
 
         # Wait while process dies
-        await async_poll_for(lambda: n.pid != pid, timeout=5)
+        await async_poll_for(lambda: n.pid != pid)
         # Wait while process comes back
-        await async_poll_for(lambda: n.is_alive(), timeout=5)
+        await async_poll_for(lambda: n.is_alive())
 
         # assert n.worker_address != original_address  # most likely
 
         await async_poll_for(
-            lambda: n.worker_address in s.workers and n.worker_dir is not None,
-            timeout=5,
+            lambda: n.worker_address in s.workers and n.worker_dir is not None
         )
 
         second_dir = n.worker_dir
@@ -802,7 +801,7 @@ async def test_malloc_trim_threshold(c, s, a):
     arr = c.persist(arr)
     await wait(arr)
     # Wait for heartbeat
-    await async_poll_for(lambda: s.memory.process > 2**29, timeout=5)
+    await async_poll_for(lambda: s.memory.process > 2**29)
     del arr
 
     # This is the delicate bit, as it relies on
@@ -815,7 +814,7 @@ async def test_malloc_trim_threshold(c, s, a):
     # - 156~210[1] MiB at the end of this test, with MALLOC_TRIM_THRESHOLD_=65536
     # - 620~670[1] MiB at the end of this test, without MALLOC_TRIM_THRESHOLD_
     # [1] depends on distributed.scheduler.worker-saturation
-    await async_poll_for(lambda: s.memory.process < 300 * 2**20, timeout=5)
+    await async_poll_for(lambda: s.memory.process < 300 * 2**20)
 
 
 @gen_cluster(client=True, nthreads=[])

--- a/distributed/tests/test_scheduler.py
+++ b/distributed/tests/test_scheduler.py
@@ -449,7 +449,7 @@ async def test_queued_release_multiple_workers(c, s, *workers):
             range(rootish_threshold),
             key=[f"first-{i}" for i in range(rootish_threshold)],
         )
-        await async_poll_for(lambda: s.queued, 5)
+        await async_poll_for(lambda: s.queued)
 
         second_batch = c2.map(
             lambda i: event.wait(),
@@ -457,7 +457,7 @@ async def test_queued_release_multiple_workers(c, s, *workers):
             key=[f"second-{i}" for i in range(rootish_threshold)],
             fifo_timeout=0,
         )
-        await async_poll_for(lambda: second_batch[0].key in s.tasks, 5)
+        await async_poll_for(lambda: second_batch[0].key in s.tasks)
 
         # All of the second batch should be queued after the first batch
         assert [ts.key for ts in s.queued.sorted()] == [
@@ -472,7 +472,7 @@ async def test_queued_release_multiple_workers(c, s, *workers):
         await c.close()
         del c, first_batch
 
-        await async_poll_for(lambda: len(s.tasks) == len(second_batch), 5)
+        await async_poll_for(lambda: len(s.tasks) == len(second_batch))
 
         # Second batch should move up the queue and start processing
         assert len(s.queued) == len(second_batch) - s.total_nthreads, list(
@@ -586,13 +586,13 @@ async def test_queued_remove_add_worker(c, s, a, b):
     event = Event()
     fs = c.map(lambda i: event.wait(), range(10))
 
-    await async_poll_for(lambda: len(s.queued) == 6, timeout=5)
+    await async_poll_for(lambda: len(s.queued) == 6)
     await s.remove_worker(a.address, stimulus_id="fake")
     assert len(s.queued) == 8
 
     # Add a new worker
     async with Worker(s.address, nthreads=2) as w:
-        await async_poll_for(lambda: len(s.queued) == 6, timeout=5)
+        await async_poll_for(lambda: len(s.queued) == 6)
 
         await event.set()
         await wait(fs)
@@ -609,10 +609,10 @@ async def test_secede_opens_slot(c, s, a):
         second.wait()
 
     fs = c.map(func, [first] * 5, [second] * 5, key=[f"x{i}" for i in range(5)])
-    await async_poll_for(lambda: a.state.executing, timeout=5)
+    await async_poll_for(lambda: a.state.executing)
 
     await first.set()
-    await async_poll_for(lambda: len(a.state.long_running) == len(fs), timeout=5)
+    await async_poll_for(lambda: len(a.state.long_running) == len(fs))
 
     await second.set()
     await c.gather(fs)
@@ -2358,7 +2358,7 @@ async def test_resources_reset_after_cancelled_task(c, s, a):
     assert a.state.available_resources == {"A": 0}
 
     await lock.release()
-    await async_poll_for(lambda: not a.state.tasks, timeout=5)
+    await async_poll_for(lambda: not a.state.tasks)
     assert s.workers[a.address].used_resources == {"A": 0}
     assert a.state.available_resources == {"A": 1}
 
@@ -2587,7 +2587,7 @@ async def test_no_workers_timeout_queued(c, s, a):
     """Don't trip no-workers-timeout when there are queued tasks AND processing tasks"""
     ev = Event()
     futures = [c.submit(lambda ev: ev.wait(), ev, pure=False) for _ in range(3)]
-    await async_poll_for(lambda: len(s.tasks) == 3 and a.state.tasks, timeout=5)
+    await async_poll_for(lambda: len(s.tasks) == 3 and a.state.tasks)
     assert s.queued or math.isinf(s.WORKER_SATURATION)
 
     s._check_no_workers()
@@ -2766,14 +2766,14 @@ async def test_adaptive_target_empty_cluster(c, s, queue):
     assert s.adaptive_target() == 0
 
     f = c.submit(inc, -1)
-    await async_poll_for(lambda: s.tasks, timeout=5)
+    await async_poll_for(lambda: s.tasks)
     assert s.adaptive_target() == 1
     del f
 
     if queue:
         # only queuing supports fast scale-up for empty clusters https://github.com/dask/distributed/issues/6962
         fs = c.map(inc, range(100))
-        await async_poll_for(lambda: len(s.tasks) == len(fs), timeout=5)
+        await async_poll_for(lambda: len(s.tasks) == len(fs))
         assert s.adaptive_target() > 1
 
 
@@ -3075,7 +3075,7 @@ async def test_task_group_done(c, s, a, b):
 
     await wait([x0, x1, x2, y])
     del x2  # forgotten
-    await async_poll_for(lambda: ("x", 2) not in s.tasks, timeout=5)
+    await async_poll_for(lambda: ("x", 2) not in s.tasks)
 
     tg = s.task_groups["x"]
     assert tg.states == {
@@ -4052,7 +4052,7 @@ async def test_gather_on_worker_bad_recipient(c, s, a, b):
     """The recipient is missing"""
     x = await c.scatter("x")
     await b.close()
-    await async_poll_for(lambda: s.workers.keys() == {a.address}, timeout=5)
+    await async_poll_for(lambda: s.workers.keys() == {a.address})
     out = await s.gather_on_worker(b.address, {x.key: [a.address]})
     assert out == {x.key}
 
@@ -4250,7 +4250,7 @@ async def test_transition_counter_max_worker(c, s, a):
     a.state.transition_counter_max = 1
     fut = c.submit(inc, 2)
     with captured_logger("distributed.worker") as logger:
-        await async_poll_for(lambda: a.state.transition_counter > 0, timeout=5)
+        await async_poll_for(lambda: a.state.transition_counter > 0)
 
     assert "TransitionCounterMaxExceeded" in logger.getvalue()
     # Worker state is corrupted. Avoid test failure on gen_cluster teardown.
@@ -4639,7 +4639,7 @@ async def test_transition_waiting_memory(c, s, a, b):
             assert s.tasks["y"].state == "waiting"
             await wait_for_state("y", "memory", b)
 
-    await async_poll_for(lambda: not b.state.tasks, timeout=5)
+    await async_poll_for(lambda: not b.state.tasks)
 
     assert s.tasks["x"].state == "no-worker"
     assert s.tasks["y"].state == "waiting"
@@ -4769,8 +4769,7 @@ async def test_transition_failure_triggers_log_event():
                 event["action"] == "scheduler-transition-failed"
                 for _, event in s.get_events("transitions")
             )
-            == 1,
-            timeout=5,
+            == 1
         )
 
 
@@ -4852,8 +4851,7 @@ async def test_deadlock_dependency_of_queued_released_when_worker_removed(
     with freeze_batched_send(b.batched_stream):
         await async_poll_for(
             lambda: b.state.tasks.get(dep.key) is not None
-            and b.state.tasks.get(dep.key).state == "memory",
-            timeout=5,
+            and b.state.tasks.get(dep.key).state == "memory"
         )
         assert s.queued
         await s.remove_worker(address=a.address, stimulus_id="test")
@@ -5050,7 +5048,7 @@ async def test_fan_out_pattern_deadlock(c, s, a):
             await in_f.clear()
 
             # Make sure that the scheduler knows that both workers hold 'g' in memory
-            await async_poll_for(lambda: len(s.tasks["g"].who_has) == 2, timeout=5)
+            await async_poll_for(lambda: len(s.tasks["g"].who_has) == 2)
             # Remove worker 'b' while it's processing h1
             await s.remove_worker(b.address, stimulus_id="remove_b1")
             await block_hb.set()
@@ -5073,7 +5071,7 @@ async def test_fan_out_pattern_deadlock(c, s, a):
 
         del ha, hb
         # Make sure that h2 gets forgotten on worker 'a'
-        await async_poll_for(lambda: not a.state.tasks, timeout=5)
+        await async_poll_for(lambda: not a.state.tasks)
     # Ensure that no other errors including transition failures were logged
     assert (
         logger.getvalue()
@@ -5133,12 +5131,12 @@ async def test_stimulus_from_erred_task(c, s, a):
         ) as wrapped_stimulus:
             frozen_stream_from_a_ctx.__exit__(None, None, None)
             # Make sure the `stimulus_task_finished` gets processed
-            await async_poll_for(lambda: wrapped_stimulus.call_count == 1, timeout=5)
+            await async_poll_for(lambda: wrapped_stimulus.call_count == 1)
 
         # Allow the scheduler to talk to the worker again
         frozen_stream_to_a_ctx.__exit__(None, None, None)
         # Make sure all data gets forgotten on worker 'a'
-        await async_poll_for(lambda: not a.state.tasks, timeout=5)
+        await async_poll_for(lambda: not a.state.tasks)
 
     # Ensure that no other errors including transition failures were logged
     assert (
@@ -5216,7 +5214,7 @@ async def test_data_producers(c, s, a):
 
     arr = MyArray()
     x = c.compute(arr)
-    await async_poll_for(lambda: s.tasks, 5)
+    await async_poll_for(lambda: s.tasks)
     assert (
         sum([s.is_rootish(v) and v.run_spec.data_producer for v in s.tasks.values()])
         == 2

--- a/distributed/tests/test_spans.py
+++ b/distributed/tests/test_spans.py
@@ -97,7 +97,7 @@ async def test_spans(c, s, a):
     # Test that spans survive their tasks
     prev_span_ids = set(ext.spans)
     del zp
-    await async_poll_for(lambda: not s.tasks, timeout=5)
+    await async_poll_for(lambda: not s.tasks)
     assert ext.spans.keys() == prev_span_ids
 
 
@@ -233,7 +233,7 @@ async def test_task_groups(c, s, a, b, release, no_time_resync):
     if release:
         # Test that the information in the Spans survives the tasks
         finalizer.release()
-        await async_poll_for(lambda: not s.tasks, timeout=5)
+        await async_poll_for(lambda: not s.tasks)
         assert not s.task_groups
 
     sbn = s.extensions["spans"].spans_search_by_name
@@ -316,7 +316,7 @@ async def test_duplicate_task_group(c, s, a, b):
     with span("foo"):
         for _ in range(2):
             await c.submit(inc, 1, key="x")
-            await async_poll_for(lambda: not s.tasks, timeout=5)
+            await async_poll_for(lambda: not s.tasks)
     sp = s.extensions["spans"].spans_search_by_name["foo",][-1]
     assert len(sp.groups) == 2
     tg0, tg1 = sp.groups
@@ -457,7 +457,7 @@ async def test_worker_metrics(c, s, a, b):
 
             # Cleanup
             del x0, x1, x2, x3
-            await async_poll_for(lambda: not s.tasks, timeout=5)
+            await async_poll_for(lambda: not s.tasks)
 
             # Have metrics with 'y' task prefix in foo too
             await c.submit(inc, 1, key=("y", 1))
@@ -549,15 +549,15 @@ async def test_merge_by_tags(c, s, a, b):
 async def test_merge_by_tags_metrics(c, s, a, b):
     with span("foo") as foo1:
         await c.submit(slowinc, 1, delay=0.05, key="x-1")
-    await async_poll_for(lambda: not s.task_groups, timeout=5)
+    await async_poll_for(lambda: not s.task_groups)
 
     with span("foo") as foo2:
         await c.submit(slowinc, 2, delay=0.06, key="x-2")
-    await async_poll_for(lambda: not s.task_groups, timeout=5)
+    await async_poll_for(lambda: not s.task_groups)
 
     with span("bar") as bar1:
         await c.submit(slowinc, 3, delay=0.07, key="x-3")
-    await async_poll_for(lambda: not s.task_groups, timeout=5)
+    await async_poll_for(lambda: not s.task_groups)
 
     await a.heartbeat()
     await b.heartbeat()

--- a/distributed/tests/test_steal.py
+++ b/distributed/tests/test_steal.py
@@ -1971,7 +1971,7 @@ async def test_stealing_objective_accounts_for_in_flight(c, s, a):
 
         async with Worker(s.address, nthreads=1) as b:
             try:
-                await async_poll_for(lambda: s.idle, timeout=5)
+                await async_poll_for(lambda: s.idle)
                 wsA = s.workers[a.address]
                 wsB = s.workers[b.address]
                 ts = next(iter(wsA.processing))
@@ -1995,7 +1995,7 @@ async def test_stealing_objective_accounts_for_in_flight(c, s, a):
                     ts, wsB, occupancies=occupancies
                 ) > s.worker_objective(ts, wsB)
 
-                await async_poll_for(lambda: not extension.in_flight, timeout=5)
+                await async_poll_for(lambda: not extension.in_flight)
                 occupancies = {ws: ws.occupancy for ws in s.workers.values()}
                 # No in-flight requests, so both match
                 assert extension.stealing_objective(
@@ -2042,13 +2042,13 @@ async def test_do_not_ping_pong(c, s, a):
 
         async with Worker(s.address, nthreads=1) as b:
             try:
-                await async_poll_for(lambda: s.idle, timeout=5)
+                await async_poll_for(lambda: s.idle)
 
                 wsB = s.workers[b.address]
 
                 extension.balance()
                 assert 10 >= len(extension.in_flight) >= 5
-                await async_poll_for(lambda: not extension.in_flight, timeout=5)
+                await async_poll_for(lambda: not extension.in_flight)
                 # On first try, we may try to balance the task executing on a
                 assert 10 >= len(wsB.processing) >= 5 - 1
 
@@ -2056,7 +2056,7 @@ async def test_do_not_ping_pong(c, s, a):
                 # On second try we may want to rebalance a single task if we failed to
                 # rebalance the task executing on a
                 assert len(extension.in_flight) <= 1
-                await async_poll_for(lambda: not extension.in_flight, timeout=5)
+                await async_poll_for(lambda: not extension.in_flight)
                 assert 10 >= len(wsB.processing) >= 5
 
                 # On third try, the balancing should be stable

--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -659,7 +659,7 @@ async def test_Executor(c, s):
 @gen_cluster(nthreads=[("127.0.0.1", 1)])
 async def test_close_on_disconnect(s, w):
     await s.close()
-    await async_poll_for(lambda: w.status == Status.closed, timeout=5)
+    await async_poll_for(lambda: w.status == Status.closed)
 
 
 @gen_cluster(nthreads=[])
@@ -737,7 +737,7 @@ async def test_types(c, s, a, b):
 
     await c._cancel(y)
 
-    await async_poll_for(lambda: y.key not in b.data, timeout=5)
+    await async_poll_for(lambda: y.key not in b.data)
     assert y.key not in b.state.tasks
 
 
@@ -933,7 +933,7 @@ async def test_stop_doing_unnecessary_work(c, s, a, b):
     await asyncio.sleep(0.1)
 
     del futures
-    await async_poll_for(lambda: a.state.executing_count == 0, timeout=0.5)
+    await async_poll_for(lambda: a.state.executing_count == 0)
 
 
 @gen_cluster(client=True, nthreads=[("127.0.0.1", 1)])
@@ -1554,7 +1554,7 @@ async def test_close_gracefully_no_suspicious_tasks(c, s, a, b):
         await c.run(close_gracefully, workers=[to_close])
     except CommClosedError:
         pass
-    await async_poll_for(lambda: to_close not in s.workers, 5)
+    await async_poll_for(lambda: to_close not in s.workers)
 
     assert b.address not in s.workers
     assert s.tasks[fut.key].suspicious == 0
@@ -3749,7 +3749,7 @@ async def test_suppress_keyerror_for_cancelled_tasks(c, s, a, state):
             y = c.submit(inc, x, key="y", workers=[b.address])
             await b.in_execute.wait()
             del x, y
-            await async_poll_for(lambda: "x" not in b.data, timeout=5)
+            await async_poll_for(lambda: "x" not in b.data)
 
             if state == "resumed":
                 y = c.submit(inc, 1, key="y", workers=[a.address])
@@ -3763,7 +3763,7 @@ async def test_suppress_keyerror_for_cancelled_tasks(c, s, a, state):
                 assert await z == 3
                 del y, z
 
-            await async_poll_for(lambda: not b.state.tasks, timeout=5)
+            await async_poll_for(lambda: not b.state.tasks)
 
     assert not log.getvalue()
 
@@ -3785,6 +3785,6 @@ async def test_suppress_compute_failure_for_cancelled_tasks(c, s, a):
 
         await wait_for_state("x", "cancelled", a)
         await block_event.set()
-        await async_poll_for(lambda: not a.state.tasks, timeout=5)
+        await async_poll_for(lambda: not a.state.tasks)
 
     assert not log.getvalue()

--- a/distributed/tests/test_worker_memory.py
+++ b/distributed/tests/test_worker_memory.py
@@ -975,7 +975,7 @@ async def test_pause_while_spilling(c, s, a):
 
     futs = [c.submit(SlowSpill, pure=False) for _ in range(N_TOTAL)]
 
-    await async_poll_for(lambda: len(a.data.slow) >= N_PAUSE, timeout=5, period=0)
+    await async_poll_for(lambda: len(a.data.slow) >= N_PAUSE, period=0)
     assert a.status == Status.paused
     # Worker should have become paused after the first `SlowSpill` was evicted, because
     # the spill to disk took longer than the memory monitor interval.
@@ -1098,12 +1098,12 @@ async def test_pause_while_idle(s, a, b):
     assert sa in s.running
 
     a.monitor.get_process_memory = lambda: 2**40
-    await async_poll_for(lambda: sa.status == Status.paused, timeout=5)
+    await async_poll_for(lambda: sa.status == Status.paused)
     assert a.address not in s.idle
     assert sa not in s.running
 
     a.monitor.get_process_memory = lambda: 0
-    await async_poll_for(lambda: sa.status == Status.running, timeout=5)
+    await async_poll_for(lambda: sa.status == Status.running)
     assert a.address in s.idle
     assert sa in s.running
 
@@ -1113,17 +1113,17 @@ async def test_pause_while_saturated(c, s, a, b):
     sa = s.workers[a.address]
     ev = Event()
     futs = c.map(lambda i, ev: ev.wait(), range(3), ev=ev, workers=[a.address])
-    await async_poll_for(lambda: len(a.state.tasks) == 3, timeout=5)
+    await async_poll_for(lambda: len(a.state.tasks) == 3)
     assert sa in s.saturated
     assert sa in s.running
 
     a.monitor.get_process_memory = lambda: 2**40
-    await async_poll_for(lambda: sa.status == Status.paused, timeout=5)
+    await async_poll_for(lambda: sa.status == Status.paused)
     assert sa not in s.saturated
     assert sa not in s.running
 
     a.monitor.get_process_memory = lambda: 0
-    await async_poll_for(lambda: sa.status == Status.running, timeout=5)
+    await async_poll_for(lambda: sa.status == Status.running)
     assert sa in s.saturated
     assert sa in s.running
 
@@ -1173,5 +1173,5 @@ async def test_delete_spilled_keys(c, s, a):
         a.data["x"]
 
     x.release()
-    await async_poll_for(lambda: not a.data, timeout=2)
+    await async_poll_for(lambda: not a.data)
     assert not a.state.tasks

--- a/distributed/tests/test_worker_metrics.py
+++ b/distributed/tests/test_worker_metrics.py
@@ -61,11 +61,11 @@ async def test_task_lifecycle(c, s, a, b):
         assert (await z) == "x" * 20_000 + "y" * 20_000
         # The call to Worker.get_data will terminate after the fetch of z returns
         await async_poll_for(
-            lambda: ("get-data", "network", "seconds") in a.digests_total, timeout=5
+            lambda: ("get-data", "network", "seconds") in a.digests_total
         )
 
     del x, y, z
-    await async_poll_for(lambda: not a.state.tasks, timeout=5)  # For hygiene only
+    await async_poll_for(lambda: not a.state.tasks)  # For hygiene only
 
     # Note: use set instead of list to account for rare, but harmless, race conditions
     expect = {
@@ -194,7 +194,7 @@ async def test_cancelled_execute(c, s, a):
     del x
     await wait_for_state("x", "cancelled", a)
     await ev.set()
-    await async_poll_for(lambda: not a.state.tasks, timeout=5)
+    await async_poll_for(lambda: not a.state.tasks)
 
     assert list(get_digests(a)) == [
         ("execute", span_id(s), "x", "cancelled", "seconds")
@@ -253,9 +253,9 @@ async def test_gather_dep_no_task(c, s, w1):
 
         # Move x from w1 to w2
         s.request_acquire_replicas(w2.address, ["x"], stimulus_id="ar")
-        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 2, timeout=5)
+        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 2)
         s.request_remove_replicas(w1.address, ["x"], stimulus_id="rr")
-        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 1, timeout=5)
+        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 1)
 
         w3.block_gather_dep.set()
         # 1. w1 will now answer that it does not have the key
@@ -330,7 +330,7 @@ async def test_gather_dep_network_error(c, s, a):
 async def test_memory_monitor(c, s, a):
     a.monitor.get_process_memory = lambda: 800_000_000_000 if a.data.fast else 0
     x = c.submit(inc, 1, key="x")
-    await async_poll_for(lambda: a.data.disk, timeout=5)
+    await async_poll_for(lambda: a.data.disk)
 
     assert list(get_digests(a, "memory-monitor")) == [
         ("memory-monitor", "serialize", "seconds"),

--- a/distributed/tests/test_worker_state_machine.py
+++ b/distributed/tests/test_worker_state_machine.py
@@ -665,16 +665,14 @@ async def test_lose_replica_during_fetch(c, s, w1, w2, w3, as_deps):
 
         assert len(s.tasks["x"].who_has) == 2
         await w2.close()
-        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 1, timeout=5)
+        await async_poll_for(lambda: len(s.tasks["x"].who_has) == 1)
 
         if as_deps:
             y2 = c.submit(inc, x, key="y2", workers=[w1.address])
         else:
             s.request_acquire_replicas(w1.address, ["x"], stimulus_id="test")
 
-        await async_poll_for(
-            lambda: w1.state.tasks["x"].who_has == {w3.address}, timeout=5
-        )
+        await async_poll_for(lambda: w1.state.tasks["x"].who_has == {w3.address})
 
     await wait_for_state("x", "memory", w1)
     assert_story(

--- a/distributed/utils_test.py
+++ b/distributed/utils_test.py
@@ -55,7 +55,7 @@ from distributed.core import (
 )
 from distributed.deploy import SpecCluster
 from distributed.diagnostics.plugin import WorkerPlugin
-from distributed.metrics import _WindowsTime, context_meter, time
+from distributed.metrics import _WindowsTime, context_meter, monotonic, time
 from distributed.nanny import Nanny
 from distributed.node import ServerNode
 from distributed.proctitle import enable_proctitle_on_children
@@ -1237,24 +1237,34 @@ def popen(
                     print(err.decode() if isinstance(err, bytes) else err)
 
 
-def poll_for(predicate, timeout, fail_func=None, period=0.05):
-    deadline = time() + timeout
+def poll_for(
+    predicate: Callable[[], bool],
+    timeout: float = 15,
+    fail_func: Callable[[], None] | None = None,
+    period: float = 0.05,
+) -> None:
+    deadline = monotonic() + timeout
     while not predicate():
         sleep(period)
-        if time() > deadline:
+        if monotonic() > deadline:
             if fail_func is not None:
                 fail_func()
-            pytest.fail(f"condition not reached until {timeout} seconds")
+            pytest.fail(f"condition not reached after {timeout} seconds")
 
 
-async def async_poll_for(predicate, timeout, fail_func=None, period=0.05):
-    deadline = time() + timeout
+async def async_poll_for(
+    predicate: Callable[[], bool],
+    timeout: float = 15,
+    fail_func: Callable[[], None] | None = None,
+    period: float = 0.05,
+) -> None:
+    deadline = monotonic() + timeout
     while not predicate():
         await asyncio.sleep(period)
-        if time() > deadline:
+        if monotonic() > deadline:
             if fail_func is not None:
                 fail_func()
-            pytest.fail(f"condition not reached until {timeout} seconds")
+            pytest.fail(f"condition not reached after {timeout} seconds")
 
 
 def wait_for(*args, **kwargs):


### PR DESCRIPTION
async_for_poll asked for explicit timeout. This was typically 5 or 10s; sometimes less.

Standardize it as 15s and set it as default. We really don't care to have tests fail 5s faster in CI if they're broken - whereas a timeout too short may cause flakiness due to the github actions hypervisor chocking the VM for several seconds.

Also change from the wall clock to the monotonic clock, as the former could cause random test failures in case of  system clock updates via NTP or simiilar.