### PR TITLE
Use `@dataclass(slots=True)` (with constraints from Python <3.14)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v0.15.2
     hooks:
       - id: ruff-check
+        # args: [--fix]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.3.1
     hooks:

--- a/distributed/actor.py
+++ b/distributed/actor.py
@@ -245,6 +245,8 @@ class BaseActorFuture(abc.ABC, Awaitable[_T]):
     Actor
     """
 
+    __slots__ = ()
+
     @abc.abstractmethod
     def result(self, timeout: str | timedelta | float | None = None) -> _T: ...
 
@@ -255,7 +257,7 @@ class BaseActorFuture(abc.ABC, Awaitable[_T]):
         return "<ActorFuture>"
 
 
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, slots=True)
 class EagerActorFuture(BaseActorFuture[_T]):
     """Future to an actor's method call when an actor calls another actor on the same worker"""
 
@@ -272,7 +274,7 @@ class EagerActorFuture(BaseActorFuture[_T]):
         return True
 
 
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, slots=True)
 class _OK(Generic[_T]):
     _v: _T
 
@@ -280,7 +282,7 @@ class _OK(Generic[_T]):
         return self._v
 
 
-@dataclass(frozen=True, eq=False)
+@dataclass(frozen=True, eq=False, slots=True)
 class _Error:
     _e: Exception
 
@@ -289,10 +291,16 @@ class _Error:
 
 
 class ActorFuture(BaseActorFuture[_T]):
+    _io_loop: IOLoop
+    _event: LateLoopEvent
+    _out: _Error | _OK[_T] | None
+
+    __slots__ = tuple(__annotations__)
+
     def __init__(self, io_loop: IOLoop):
         self._io_loop = io_loop
         self._event = LateLoopEvent()
-        self._out: _Error | _OK[_T] | None = None
+        self._out = None
 
     def __await__(self) -> Generator[object, None, _T]:
         return self._result().__await__()

--- a/distributed/metrics.py
+++ b/distributed/metrics.py
@@ -113,12 +113,11 @@ except (AttributeError, OSError):  # pragma: no cover
     thread_time = process_time
 
 
-@dataclass
+@dataclass(slots=True)
 class MeterOutput:
     start: float
     stop: float
     delta: float
-    __slots__ = tuple(__annotations__)
 
 
 @contextmanager

--- a/distributed/scheduler.py
+++ b/distributed/scheduler.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import dataclasses
 import heapq
 import inspect
 import itertools
@@ -31,6 +30,7 @@ from collections.abc import (
     Set,
 )
 from contextlib import suppress
+from dataclasses import dataclass
 from functools import partial
 from typing import (
     TYPE_CHECKING,
@@ -858,7 +858,7 @@ class WorkerState:
         )
 
 
-@dataclasses.dataclass
+@dataclass(slots=True)
 class ErredTask:
     """Lightweight representation of an erred task without any dependency information
     or runspec.
@@ -868,7 +868,7 @@ class ErredTask:
     TaskState
     """
 
-    key: Hashable
+    key: Key
     timestamp: float
     erred_on: set[str]
     exception_text: str

--- a/distributed/worker_state_machine.py
+++ b/distributed/worker_state_machine.py
@@ -382,6 +382,8 @@ class _InstructionMatch:
     cls: type[Instruction]
     kwargs: dict[str, Any]
 
+    __slots__ = ("cls", "kwargs")
+
     def __init__(self, cls: type[Instruction], **kwargs: Any):
         self.cls = cls
         self.kwargs = kwargs


### PR DESCRIPTION
Salvage from #9254.
Follow-up to #8793 and #8824.

Python 3.10 introduces `@dataclass(slots=True)`, which however is broken in Python<3.14 when such classes have subclasses.
This PR uses the functionality only when subclassing is not involved.