### PR TITLE
Fix memray CI; move back from mamba to conda

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -25,15 +25,14 @@ jobs:
         with:
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
-          use-mamba: true
           environment-file: continuous_integration/scripts/test-report-environment.yml
           activate-environment: dask-distributed
 
       - name: Show conda options
         run: conda config --show
 
-      - name: mamba list
-        run: mamba list
+      - name: conda list
+        run: conda list
 
       - uses: actions/cache@v5
         id: cache

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -122,7 +122,6 @@ jobs:
         with:
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
-          use-mamba: true
           activate-environment: dask-distributed
 
       - name: Show conda options
@@ -160,7 +159,7 @@ jobs:
         id: cache
 
       - name: Update environment
-        run: mamba env update -n dask-distributed -f ${{ env.CONDA_FILE }}
+        run: conda env update -n dask-distributed -f ${{ env.CONDA_FILE }}
         if: |
           (
             steps.skip-caching.outputs.trigger-found == 'true'
@@ -179,22 +178,22 @@ jobs:
             || steps.cache.outputs.cache-hit != 'true'
           )
         shell: bash -l {0}
-        run: mamba install -y ${{ join(matrix.extra_packages, ' ') }}
+        run: conda install -y ${{ join(matrix.extra_packages, ' ') }}
 
       - name: Install
         shell: bash -l {0}
         run: |
           python -m pip install --no-deps -e .
 
-      - name: mamba list
+      - name: conda list
         shell: bash -l {0}
-        run: mamba list
+        run: conda list
 
-      - name: mamba env export
+      - name: conda env export
         shell: bash -l {0}
         run: |
-          echo -e "--\n--Conda Environment (re-create this with \`mamba env create --name <name> -f <output_file>\`)\n--"
-          mamba env export | grep -E -v '^prefix:.*$'
+          echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
+          conda env export | grep -E -v '^prefix:.*$'
 
       - name: Setup SSH
         shell: bash -l {0}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,35 +53,35 @@ jobs:
           - os: ubuntu-latest
             environment: "3.10"
             label: no_queue
-            partition: "ci1"
+            partition: ci1
           - os: ubuntu-latest
             environment: "3.10"
             label: no_queue
-            partition: "not ci1"
+            partition: not ci1
 
           # dask.array P2P shuffle
           - os: ubuntu-latest
             environment: mindeps
             label: numpy
             extra_packages: [numpy=1.24]
-            partition: "ci1"
+            partition: ci1
           - os: ubuntu-latest
             environment: mindeps
             label: numpy
             extra_packages: [numpy=1.24]
-            partition: "not ci1"
+            partition: not ci1
 
           # dask.dataframe P2P shuffle
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
             extra_packages: [numpy=1.24, pandas=2.0, pyarrow=16.0]
-            partition: "ci1"
+            partition: ci1
           - os: ubuntu-latest
             environment: mindeps
             label: pandas
             extra_packages: [numpy=1.24, pandas=2.0, pyarrow=16.0]
-            partition: "not ci1"
+            partition: not ci1
 
           - os: ubuntu-latest
             environment: "3.10"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,10 +84,10 @@ jobs:
             partition: "not ci1"
 
           - os: ubuntu-latest
-            environment: mindeps
+            environment: "3.10"
             label: memray
-            extra_packages: [memray]
-            partition: "extra_packages"
+            extra_packages: [memray]  # Not available on Windows
+            partition: memray
 
         # Uncomment to stress-test the test suite for random failures.
         # Must also change `export TEST_ID` in first step below.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,7 +84,8 @@ jobs:
             partition: not ci1
 
           - os: ubuntu-latest
-            environment: "3.10"
+            # Don't disturb the various GPU-only deps in the 3.10 environment
+            environment: "3.11"
             label: memray
             extra_packages: [memray]  # Not available on Windows
             partition: memray

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.CONDA }}/envs
-          key: conda-${{ matrix.os }}-${{ matrix.environment }}-${{ matrix.label }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(env.CONDA_FILE) }}-${{ env.CACHE_NUMBER }}
+          key: conda-${{ matrix.os }}-${{ matrix.environment }}-${{ matrix.label }}-${{ matrix.extra_packages }}-${{ steps.get-date.outputs.today }}-${{ hashFiles(env.CONDA_FILE) }}-${{ env.CACHE_NUMBER }}
         env:
           # Increase this value to reset cache if
           # continuous_integration/environment-${{ matrix.environment }}.yaml has not
@@ -168,15 +168,22 @@ jobs:
             || steps.cache.outputs.cache-hit != 'true'
           )
 
+      - name: Extra Installs
+        if: |
+          matrix.extra_packages
+          && (
+            steps.skip-caching.outputs.trigger-found == 'true'
+            || (github.event_name == 'pull_request'
+                && contains(github.event.pull_request.labels.*.name, 'skip-caching'))
+            || steps.cache.outputs.cache-hit != 'true'
+          )
+        shell: bash -l {0}
+        run: mamba install -y ${{ join(matrix.extra_packages, ' ') }}
+
       - name: Install
         shell: bash -l {0}
         run: |
           python -m pip install --no-deps -e .
-
-      - name: Extra Installs
-        if: ${{ matrix.extra_packages }}
-        shell: bash -l {0}
-        run: mamba install -y ${{ join(matrix.extra_packages, ' ') }}
 
       - name: mamba list
         shell: bash -l {0}

--- a/distributed/diagnostics/tests/test_memray.py
+++ b/distributed/diagnostics/tests/test_memray.py
@@ -4,7 +4,7 @@ import pytest
 
 memray = pytest.importorskip("memray")
 
-pytestmark = pytest.mark.extra_packages
+pytestmark = pytest.mark.memray
 
 from distributed import Client, LocalCluster
 from distributed.diagnostics.memray import memray_scheduler, memray_workers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,12 +184,12 @@ filterwarnings = [
 minversion = "6"
 markers = [
     "ci1: marks tests as belonging to 1 out of 2 partitions to run on CI ('-m \"not ci1\"' for second partition)",
-    "extra_packages: marks tests that require a special dependency to run.",
-    "slow: marks tests as slow (deselected by default",                                                                            # select with '--runslow')
+    "memray: marks tests that require memray to run (available on Linux/MacOS only)",
+    "slow: marks tests as slow (deselected by default; select with '--runslow')",
     "avoid_ci: marks tests as flaky or broken on CI on all OSs",
     "ipython: marks tests as exercising IPython",
     "gpu: marks tests we want to run on GPUs",
-    "leaking: ignore leaked resources",                                                                                            # see pytest_resourceleaks.py for usage
+    "leaking: ignore leaked resources",  # see pytest_resourceleaks.py for usage
     "workerstate: deterministic test for the worker state machine. Automatically applied to all tests that use the 'ws' fixture.",
 ]
 # pytest-timeout settings


### PR DESCRIPTION
memray (which is singled out in CI as there are no windows packages for it) hangs in CI upon install.
This is because it upgrades a bunch of packages that are pinned in the mindeps environment. Move it to the unpinned 3.11 (3.10 is not a great choice, as it includes a wealth of extra GPU-specific stack).

This PR also 
- adds caching to extra dependencies installation (memray, mindeps-numpy, mindeps-pandas)
- moves back from mamba to conda, as conda now internally uses the mamba engine