### PR TITLE
Install keras with conda

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -23,6 +23,7 @@ dependencies:
   - jupyter_events
   - jupyter-server-proxy
   - jupyterlab
+  - keras
   - locket
   - lz4  # Only tested here
   - msgpack-python
@@ -55,4 +56,3 @@ dependencies:
   - pip:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
-      - keras

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -21,6 +21,7 @@ dependencies:
   - jupyter_events
   - jupyter-server-proxy
   - jupyterlab
+  - keras
   - locket
   - msgpack-python
   - netcdf4
@@ -28,7 +29,7 @@ dependencies:
   - pre-commit
   - prometheus_client
   - psutil
-  - pyarrow=16.0
+  - pyarrow
   - pytest
   - pytest-cov
   - pytest-faulthandler
@@ -49,4 +50,3 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
-      - keras

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -21,6 +21,7 @@ dependencies:
   - jupyter_events
   - jupyter-server-proxy
   - jupyterlab
+  - keras
   - locket
   - msgpack-python
   - netcdf4
@@ -49,4 +50,3 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
-      - keras

--- a/continuous_integration/environment-3.13.yaml
+++ b/continuous_integration/environment-3.13.yaml
@@ -1,12 +1,13 @@
 name: dask-distributed
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.13
   - packaging
   - pip
   - asyncssh
-  - bokeh>3
+  - bokeh
   - click
   - cloudpickle
   - coverage
@@ -20,6 +21,7 @@ dependencies:
   - jupyter_events
   - jupyter-server-proxy
   - jupyterlab
+  - keras
   - locket
   - msgpack-python
   - netcdf4
@@ -48,4 +50,3 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
-      - keras

--- a/continuous_integration/environment-3.14.yaml
+++ b/continuous_integration/environment-3.14.yaml
@@ -1,12 +1,13 @@
 name: dask-distributed
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.14
   - packaging
   - pip
   - asyncssh
-  - bokeh>3
+  - bokeh
   - click
   - cloudpickle
   - coverage
@@ -20,6 +21,7 @@ dependencies:
   - jupyter_events
   - jupyter-server-proxy
   - jupyterlab
+  - keras
   - locket
   - msgpack-python
   - netcdf4
@@ -48,4 +50,3 @@ dependencies:
       - git+https://github.com/dask/dask
       - git+https://github.com/dask/zict
       - git+https://github.com/fsspec/filesystem_spec
-      - keras


### PR DESCRIPTION
Historically, keras did not offer a conda package and was thus installed with pip.