### PR TITLE
Support pixi in dask/dask CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ test_short_report.html
 
 # Test failures will dump the cluster state in here
 test_cluster_dump/
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 # This file is used by pixi-build in other projects (namely, dask/dask) 
 # to generate a conda package of distributed from git tip
 [workspace]
-channels = ["conda-forge"]
+channels = ["https://prefix.dev/conda-forge"]
 platforms = ["linux-64", "osx-arm64", "win-64"]
 preview = ["pixi-build"]
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,34 @@
+# This file is used by pixi-build in other projects (namely, dask/dask) 
+# to generate a conda package of distributed from git tip
+[workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-arm64", "win-64"]
+preview = ["pixi-build"]
+
+[package]
+name = "distributed"
+# FIXME work around poor pixi-build support for SCM versioning
+version = "2099.0.0"
+
+[package.build]
+backend = { name = "pixi-build-python", version = "*" }
+source.path = "."
+
+[package.host-dependencies]
+setuptools = "*"
+setuptools-scm = "*"
+
+[package.run-dependencies]
+# Don't pin dask/dask here to avoid headaches 
+# when installing from git tip with pixi-build
+dask-core = "*"
+# Skip dependencies redundant with dask-core
+jinja2 = ">=2.10.3"
+locket = ">=1.0.0"
+msgpack-python = ">=1.0.2"
+psutil = ">=5.8.0"
+sortedcontainers = ">=2.0.5"
+tblib = ">=1.6.0,!=3.2.0,!=3.2.1"
+tornado = ">=6.2.0"
+urllib3 = ">=1.26.5"
+zict = ">=3.0.0"


### PR DESCRIPTION
Allows pixi-build to create a conda package of distributed from git tip.
Blocks https://github.com/dask/dask/pull/12389.

A PR that properly migrates distributed CI to pixi will follow.