### PR TITLE
Add explicit check for name not None

### DIFF
--- a/distributed/tests/test_worker.py
+++ b/distributed/tests/test_worker.py
@@ -2160,6 +2160,16 @@ async def test_executor_inherit_threadname_from_worker(c, s):
         result = await c.gather(c.submit(get_thread_name, pure=False))
         assert "WorkerName-Dask-Default-Threads" in result
 
+    # LocalCluster by default assigns numbers starting from zero
+    # as the worker names
+    async with Worker(
+        s.address,
+        nthreads=1,
+        name=0,
+    ):
+        result = await c.gather(c.submit(get_thread_name, pure=False))
+        assert "0-Dask-Default-Threads" in result
+
     async with Worker(
         s.address,
         nthreads=1,

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -648,7 +648,7 @@ class Worker(BaseWorker, ServerNode):
 
         self.name = name
 
-        executor_pool_prefix = f"{self.name}-" if self.name else ""
+        executor_pool_prefix = f"{self.name}-" if self.name is not None else ""
         # Common executors always available
         self.executors = {
             "offload": utils._offload_executor,


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

With #9120 , I had added dask worker's name as a prefix into the default executor.

The `LocalCluster` by default names the workers as numbers, starting from 0.
Assuming the LocalCluster spawns 3 workers, 1 thread each, the names of the dask workers are allocated like this:
```
Dask-Default-Threads-2770614-0
1-Dask-Default-Threads-2770626-0
2-Dask-Default-Threads-2770614-0
```

The prefix `0-` is missing from the first worker's name.

This PR fixes this, explictly checking for `name is not None`.