### PR TITLE
XFAIL `test_scheduler_bokeh.py::test_simple` in Windows

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -78,6 +78,9 @@ blocklist_apps = {
 }
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32", reason="Very flaky on Windows CI", strict=False
+)
 @gen_cluster(client=True, scheduler_kwargs={"dashboard": True})
 async def test_simple(c, s, a, b):
     port = s.http_server.port


### PR DESCRIPTION
This is extremely flaky in Windows CI.
The log shows the event loop stopping for 20+ seconds which makes me think it is an issue with the VM.