### PR TITLE
Handle empty MultiProgressWidget shutdown

### DIFF
--- a/distributed/diagnostics/progressbar.py
+++ b/distributed/diagnostics/progressbar.py
@@ -337,8 +337,9 @@ class MultiProgressWidget(MultiProgressBar):
         **kwargs,
     ):
         super().__init__(keys, scheduler, **kwargs)
-        from ipywidgets import VBox
+        from ipywidgets import HTML, VBox
 
+        self.elapsed_time = HTML("")
         self.widget = VBox([])
 
     def make_widget(self, all):

--- a/distributed/diagnostics/tests/test_progress_widgets.py
+++ b/distributed/diagnostics/tests/test_progress_widgets.py
@@ -92,6 +92,12 @@ def test_values(client):
     assert p.status == "error"
 
 
+def test_multi_progressbar_widget_empty_keys_does_not_error():
+    p = MultiProgressWidget([])
+    p._draw_stop(remaining={}, status="finished")
+    assert "Finished" in p.elapsed_time.value
+
+
 def test_progressbar_done(client):
     L = [client.submit(inc, i) for i in range(5)]
     wait(L)

--- a/distributed/diagnostics/tests/test_progress_widgets.py
+++ b/distributed/diagnostics/tests/test_progress_widgets.py
@@ -93,7 +93,7 @@ def test_values(client):
 
 
 def test_multi_progressbar_widget_empty_keys_does_not_error():
-    p = MultiProgressWidget([])
+    p = MultiProgressWidget([], scheduler="tcp://127.0.0.1:1")
     p._draw_stop(remaining={}, status="finished")
     assert "Finished" in p.elapsed_time.value
 


### PR DESCRIPTION
Closes #3007

MultiProgressWidget only initialized lapsed_time inside make_widget(). When progress tracking finished without ever creating any bars, _draw_stop() could still run and access self.elapsed_time, raising AttributeError.

This change initializes lapsed_time during widget construction so shutdown paths stay safe even when there are no task groups to render.

It also adds a focused regression test covering the empty-keys shutdown path.

Validation:
- python -m py_compile distributed/diagnostics/progressbar.py distributed/diagnostics/tests/test_progress_widgets.py
- python -m black --check distributed/diagnostics/progressbar.py distributed/diagnostics/tests/test_progress_widgets.py
- Local pytest could not run in this environment because dask is not installed and pytest fails during initial config import
