### PR TITLE
Remove `avoid_ci` mark

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -239,7 +239,7 @@ jobs:
           mkdir reports
 
           python -m pytest distributed \
-            -m "not avoid_ci and ${{ matrix.partition }}" --runslow \
+            -m "${{ matrix.partition }}" --runslow \
             --leaks=fds,processes,threads \
             --junitxml reports/pytest.xml -o junit_suite_name=$TEST_ID \
             --cov=distributed --cov-report=xml \

--- a/distributed/deploy/tests/test_old_ssh.py
+++ b/distributed/deploy/tests/test_old_ssh.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.avoid_ci
+@pytest.mark.skip
 def test_cluster(loop):
     with SSHCluster(
         scheduler_addr="127.0.0.1",

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -105,6 +105,7 @@ async def test_keywords():
             assert all(v["nthreads"] == 2 for v in d.values())
 
 
+@pytest.mark.xfail(reason="Very flaky (leaks resources)", strict=False)
 def test_defer_to_old(loop):
     with pytest.warns(
         UserWarning,

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -105,7 +105,6 @@ async def test_keywords():
             assert all(v["nthreads"] == 2 for v in d.values())
 
 
-@pytest.mark.avoid_ci
 def test_defer_to_old(loop):
     with pytest.warns(
         UserWarning,
@@ -124,7 +123,7 @@ def test_defer_to_old(loop):
         assert isinstance(c, OldSSHCluster)
 
 
-@pytest.mark.avoid_ci
+@pytest.mark.skip
 def test_old_ssh_with_local_dir(loop):
     from distributed.deploy.old_ssh import SSHCluster as OldSSHCluster
 

--- a/distributed/tests/test_client.py
+++ b/distributed/tests/test_client.py
@@ -7950,7 +7950,7 @@ class TestClientSecurityLoader:
                     pass
 
 
-@pytest.mark.avoid_ci(reason="This is slow and probably not worth the cost")
+@pytest.mark.skip(reason="This is very slow and probably not worth the cost")
 @pytest.mark.slow
 @gen_cluster(client=True)
 async def test_benchmark_hardware(c, s, a, b):

--- a/distributed/tests/test_stress.py
+++ b/distributed/tests/test_stress.py
@@ -175,7 +175,6 @@ def vsum(*args):
 
 
 @pytest.mark.skip(reason="times out")
-@pytest.mark.avoid_ci
 @pytest.mark.slow
 @gen_cluster(
     client=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,6 @@ markers = [
     "ci1: marks tests as belonging to 1 out of 2 partitions to run on CI ('-m \"not ci1\"' for second partition)",
     "memray: marks tests that require memray to run (available on Linux/MacOS only)",
     "slow: marks tests as slow (deselected by default; select with '--runslow')",
-    "avoid_ci: marks tests as flaky or broken on CI on all OSs",
     "ipython: marks tests as exercising IPython",
     "gpu: marks tests we want to run on GPUs",
     "leaking: ignore leaked resources",  # see pytest_resourceleaks.py for usage


### PR DESCRIPTION
This mark just confuses infrequent contributors, who will be left wasting time trying to figure out why a test fails on their box (the answer it's that's been broken for a while and nobody noticed).