### PR TITLE
Improve CLI error message for unknown options to dask worker (#9094)

### DIFF
--- a/distributed/cli/tests/test_dask_worker.py
+++ b/distributed/cli/tests/test_dask_worker.py
@@ -612,6 +612,29 @@ def test_version_option():
     assert result.exit_code == 0
 
 
+def test_unknown_option_reports_no_such_option():
+    # Regression: dash-prefixed unknown tokens should still surface as
+    # click's "No such option" error rather than the catch-all preload
+    # message (see GH#9094).
+    runner = CliRunner()
+    result = runner.invoke(main, ["tcp://127.0.0.1:8786", "--nprocs", "1"])
+    assert result.exit_code == 2
+    assert "No such option" in result.output
+    assert "--nprocs" in result.output
+
+
+def test_stray_positional_hints_at_help_and_preload():
+    # GH#9094: stray positional arguments (which Click otherwise lets
+    # leak through into preload_argv) should produce a message that
+    # points the user at --help and explains the --preload ordering rule.
+    runner = CliRunner()
+    result = runner.invoke(main, ["tcp://127.0.0.1:8786", "foo", "bar"])
+    assert result.exit_code == 2
+    assert "unexpected extra argument" in result.output
+    assert "--help" in result.output
+    assert "--preload" in result.output
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("no_nanny", [True, False])
 def test_worker_timeout(no_nanny):

--- a/distributed/preloading.py
+++ b/distributed/preloading.py
@@ -40,7 +40,9 @@ def validate_preload_argv(ctx, param, value):
         for a in unexpected_args:
             raise click.NoSuchOption(a)
         raise click.UsageError(
-            "Got unexpected extra argument{}: ({})".format(
+            "Got unexpected extra argument{}: ({}). If you intended these as "
+            "values for a --preload module, list --preload before them. "
+            "Otherwise check spelling -- see '--help' for valid options.".format(
                 "s" if len(value) > 1 else "", " ".join(value)
             )
         )


### PR DESCRIPTION
## Summary

Improves the error message users see when they pass an unknown option or stray positional argument to `dask worker` (and `dask scheduler`). Fixes #9094.

## Motivation

`dask_worker`'s click group is configured with `ignore_unknown_options=True`, so any unrecognized token gets passed through into `preload_argv` and is then caught in `validate_preload_argv` (`distributed/preloading.py`).

For dash-prefixed tokens the existing code already raises `click.NoSuchOption`, which produces a helpful "No such option: --foo" message. But for any non-dash stray value the user just got:

```
Error: Got unexpected extra arguments: (foo bar)
```

with no hint that `--help` lists the valid options or that `--preload` consumes everything to its right. After #9240 removed the deprecated `--nprocs`, the original MCVE in #9094 now hits the dash-prefixed branch and produces a good message — but the catch-all message remained the same misleading wall.

## Changes

- **`distributed/preloading.py`** — extended the `click.UsageError` message in `validate_preload_argv` to point users at `--help` and explain the `--preload` ordering rule. No structural changes; the `NoSuchOption` branch is untouched.
- **`distributed/cli/tests/test_dask_worker.py`** — two new `CliRunner` tests:
  - `test_unknown_option_reports_no_such_option` — regression guard for the dash-prefixed branch.
  - `test_stray_positional_hints_at_help_and_preload` — asserts the improved message mentions `--help` and `--preload`.

Net diff: +26 / -1 across two files.

## Testing

Repro on `main` after #9240:

```
$ dask worker tcp://127.0.0.1:8786 foo bar
Error: Got unexpected extra arguments: (foo bar)
```

After this PR:

```
$ dask worker tcp://127.0.0.1:8786 foo bar
Error: Got unexpected extra arguments: (foo bar). If you intended these as
values for a --preload module, list --preload before them. Otherwise check
spelling -- see '--help' for valid options.
```

Dash-prefixed unknowns still produce the click-native message:

```
$ dask worker tcp://127.0.0.1:8786 --nprocs 1
Error: No such option: --nprocs
```

Local runs:

- `pytest distributed/cli/tests/test_dask_worker.py -m "not slow"` — 31 passed, 2 skipped (uvloop missing), 0 failed.
- New tests pass.
- `pre-commit run --files distributed/preloading.py distributed/cli/tests/test_dask_worker.py` — ruff, black, mypy all clean.

Notes:

- `validate_preload_argv` is also imported by `distributed/cli/dask_scheduler.py`, so the improved message benefits both entry points. Behavior is unchanged.
- No touching of `ignore_unknown_options=True` in `cli/dask_worker.py` — that's a deeper refactor and out of scope for the message fix requested in #9094.

Fixes #9094.
