### PR TITLE
Reinstate no-queue tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -149,7 +149,7 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pixi run -e ${{ matrix.environment }} test-ci \
+          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} \
             -m "${{ matrix.partition }}" \
           | tee pytest-stdout.log
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -222,7 +222,7 @@ post-test-ci = "bash continuous_integration/scripts/post_test_ci.sh"
 
 [feature.test.tasks.test-noqueue]
 env = { DASK_DISTRIBUTED__SCHEDULER__WORKER_SATURATION = "inf" }
-cmd = "coverage run pytest --runslow --junit-xml=pytest.xml --leaks=fds,processes,threads"
+cmd = "coverage run -m pytest --junit-xml=pytest.xml --runslow --leaks=fds,processes,threads"
 
 [feature.lint.dependencies]
 python = "=3.14"


### PR DESCRIPTION
Fix regression from #9276 which accidentally disabled the no-queue use case in CI