### PR TITLE
SubprocessCluster: fix random crash on start

### DIFF
--- a/distributed/deploy/subprocess.py
+++ b/distributed/deploy/subprocess.py
@@ -100,24 +100,30 @@ class SubprocessScheduler(Subprocess):
         )
 
         scheduler_file = Path(self.scheduler_kwargs["scheduler_file"])
-        while not (
-            deadline.expired
-            or scheduler_file.exists()
-            or self.process.returncode is not None
-        ):
-            await asyncio.sleep(0.1)
-        if deadline.expired or self.process.returncode is not None:
+
+        while not deadline.expired and self.process.returncode is None:
+            try:
+                with scheduler_file.open(mode="r") as f:
+                    identity = json.load(f)
+                self.address = identity["address"]
+                break
+            # The scheduler_file may not yet exist or may not have
+            # finished writing to disk.
+            # Use OSError defensively instead of FileNotFounderror
+            # to cover potential concurrent access failures on Windows
+            except (OSError, json.JSONDecodeError):
+                await asyncio.sleep(0.1)
+
+        else:
             assert self.process.stderr
             logger.error((await self.process.stderr.read()).decode())
             if deadline.expired:
                 raise RuntimeError(f"Scheduler failed to start within {self.timeout}s")
             raise RuntimeError(
-                f"Scheduler failed to start and exited with code {self.process.returncode}"
+                "Scheduler failed to start and exited with code "
+                f"{self.process.returncode}"
             )
 
-        with scheduler_file.open(mode="r") as f:
-            identity = json.load(f)
-            self.address = identity["address"]
         logger.info("Scheduler at %r", self.address)
 
 


### PR DESCRIPTION
Fix a race condition where SubprocessCluster would crash on start with

> RuntimeError: Cluster failed to start: Expecting value: line 1 column 1 (char 0)

e.g. https://github.com/dask/distributed/actions/runs/27200027227/job/80301891998?pr=9282

this was due to a race condition where the scheduler_file already exists on disk, but it has not been written to yet.