### PR TITLE
Avoid NumPy 2.5 type stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
           - types-setuptools
           # Typed libraries
           - click
-          - numpy
+          - numpy<2.5  # type stubs for NumPy 2.5 contain Python >=3.12 syntax
           - pytest
           - tornado
           - pyarrow


### PR DESCRIPTION
NumPy 2.5 requires Python >=3.12 - including in its type stubs.
But Dask still supports Python =3.10; as a consequence when checking annotations we must use stubs from an older NumPy version.