### PR TITLE
Fix Nanny race conditions when worker fails to start (flaky `test_failure_during_worker_initialization`)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -114,7 +114,7 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} distributed/tests/test_nanny.py::test_failure_during_worker_initialization --count 100 \
+          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} distributed/tests/test_nanny.py::test_failure_during_worker_initialization --count 400 \
           | tee pytest-stdout.log
 
       - name: Generate or post-process coverage.xml and pytest.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,29 +38,65 @@ jobs:
         environment: [py310, py311, py312, py313, py314]
         task: [test-ci]
         # Cherry-pick test modules to split the overall runtime roughly in half
-        partition: [ci1]
+        partition: [ci1, not ci1]
         include:
           # MacOS CI does not have many hosts available; run it on 3.14 only
           - os: macos-latest
             environment: py314
             task: test-ci
             partition: ci1
+          - os: macos-latest
+            environment: py314
+            task: test-ci
+            partition: not ci1
 
           # Minimum dependencies
           - os: ubuntu-latest
             environment: mindeps
             task: test-ci
             partition: ci1
+          - os: ubuntu-latest
+            environment: mindeps
+            task: test-ci
+            partition: not ci1
 
           - os: ubuntu-latest
             environment: mindeps-array
             task: test-ci
             partition: ci1
+          - os: ubuntu-latest
+            environment: mindeps-array
+            task: test-ci
+            partition: not ci1
 
           - os: ubuntu-latest
             environment: mindeps-dataframe
             task: test-ci
             partition: ci1
+          - os: ubuntu-latest
+            environment: mindeps-dataframe
+            task: test-ci
+            partition: not ci1
+
+          # Set distributed.scheduler.worker-saturation: .inf
+          - os: ubuntu-latest
+            environment: py310
+            task: test-noqueue
+            partition: ci1
+          - os: ubuntu-latest
+            environment: py310
+            task: test-noqueue
+            partition: not ci1
+
+          # Free-threading (WIP - tests don't pass yet)
+          # - os: ubuntu-latest
+          #   environment: py314t
+          #   task: test-ci
+          #   partition: ci1
+          # - os: ubuntu-latest
+          #   environment: py314t
+          #   task: test-ci
+          #   partition: not ci1
 
     steps:
       - name: Checkout source
@@ -114,7 +150,8 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} distributed/tests/test_nanny.py::test_failure_during_worker_initialization --count 400 \
+          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} \
+            -m "${{ matrix.partition }}" \
           | tee pytest-stdout.log
 
       - name: Generate or post-process coverage.xml and pytest.xml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,65 +38,29 @@ jobs:
         environment: [py310, py311, py312, py313, py314]
         task: [test-ci]
         # Cherry-pick test modules to split the overall runtime roughly in half
-        partition: [ci1, not ci1]
+        partition: [ci1]
         include:
           # MacOS CI does not have many hosts available; run it on 3.14 only
           - os: macos-latest
             environment: py314
             task: test-ci
             partition: ci1
-          - os: macos-latest
-            environment: py314
-            task: test-ci
-            partition: not ci1
 
           # Minimum dependencies
           - os: ubuntu-latest
             environment: mindeps
             task: test-ci
             partition: ci1
-          - os: ubuntu-latest
-            environment: mindeps
-            task: test-ci
-            partition: not ci1
 
           - os: ubuntu-latest
             environment: mindeps-array
             task: test-ci
             partition: ci1
-          - os: ubuntu-latest
-            environment: mindeps-array
-            task: test-ci
-            partition: not ci1
 
           - os: ubuntu-latest
             environment: mindeps-dataframe
             task: test-ci
             partition: ci1
-          - os: ubuntu-latest
-            environment: mindeps-dataframe
-            task: test-ci
-            partition: not ci1
-
-          # Set distributed.scheduler.worker-saturation: .inf
-          - os: ubuntu-latest
-            environment: py310
-            task: test-noqueue
-            partition: ci1
-          - os: ubuntu-latest
-            environment: py310
-            task: test-noqueue
-            partition: not ci1
-
-          # Free-threading (WIP - tests don't pass yet)
-          # - os: ubuntu-latest
-          #   environment: py314t
-          #   task: test-ci
-          #   partition: ci1
-          # - os: ubuntu-latest
-          #   environment: py314t
-          #   task: test-ci
-          #   partition: not ci1
 
     steps:
       - name: Checkout source
@@ -150,8 +114,7 @@ jobs:
           set -o pipefail
           mkdir reports
 
-          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} \
-            -m "${{ matrix.partition }}" \
+          pixi run -e ${{ matrix.environment }} ${{ matrix.task }} distributed/tests/test_nanny.py::test_failure_during_worker_initialization --count 100 \
           | tee pytest-stdout.log
 
       - name: Generate or post-process coverage.xml and pytest.xml

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -433,7 +433,7 @@ class Nanny(ServerNode):
             try:
                 result = await self.process.start()
             except Exception:
-                logger.error("Failed to start process", exc_info=True)
+                logger.exception("Failed to start process")
                 await self.close(reason="nanny-instantiate-failed")
                 raise
         return result
@@ -529,9 +529,7 @@ class Nanny(ServerNode):
             try:
                 await self._unregister()
             except OSError:
-                logger.exception(
-                    "Failed to unregister (status=%s)", self.status, exc_info=True
-                )
+                logger.exception("Failed to unregister (status=%s)", self.status)
                 if not self.reconnect:
                     await self.close(reason="nanny-unregister-failed")
                     return
@@ -551,9 +549,7 @@ class Nanny(ServerNode):
                 await self.close(reason="nanny-close-gracefully")
 
         except Exception:
-            logger.error(
-                "Failed to restart worker after its process exited", exc_info=True
-            )
+            logger.exception("Failed to restart worker after its process exited")
 
     @property
     def pid(self):
@@ -732,20 +728,18 @@ class WorkerProcess:
                 # This can only happen if the actual process creation failed, e.g.
                 # multiprocessing.Process.start failed. This is not tested!
                 logger.exception(
-                    "Nanny failed to start process (status=%s)",
-                    self.status,
-                    exc_info=True,
+                    "Nanny failed to start process (status=%s)", self.status
                 )
-                # NOTE: doesn't wait for process to terminate, just for terminate signal to be sent
+                # NOTE: doesn't wait for process to terminate, just for terminate signal
+                # to be sent
                 await self.process.terminate()
                 self.status = Status.failed
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
-                logger.exception(
-                    "Worker failed to connect (status=%s)", self.status, exc_info=True
-                )
-                # NOTE: doesn't wait for process to terminate, just for terminate signal to be sent
+                logger.exception("Worker failed to connect (status=%s)", self.status)
+                # NOTE: doesn't wait for process to terminate, just for terminate signal
+                # to be sent
                 await self.process.terminate()
                 self.status = Status.failed
                 raise
@@ -926,7 +920,7 @@ class WorkerProcess:
             try:
                 msg = child_stop_q.get()
             except (TypeError, OSError, EOFError):
-                logger.error("Worker process died unexpectedly")
+                logger.exception("Worker process died unexpectedly")
                 msg = {"op": "stop"}
             finally:
                 child_stop_q.close()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -734,6 +734,7 @@ class WorkerProcess:
                 # to be sent
                 await self.process.terminate()
                 self.status = Status.failed
+
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
@@ -743,14 +744,15 @@ class WorkerProcess:
                 await self.process.terminate()
                 self.status = Status.failed
                 raise
+
         finally:
             self.running.set()
-        if not msg:
-            return self.status
-        self.worker_address = msg["address"]
-        self.worker_dir = msg["dir"]
-        assert self.worker_address
-        self.status = Status.running
+
+        if msg:
+            self.worker_address = msg["address"]
+            self.worker_dir = msg["dir"]
+            assert self.worker_address
+            self.status = Status.running
 
         return self.status
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -525,10 +525,13 @@ class Nanny(ServerNode):
             Status.closing_gracefully,
             Status.failed,
         ):
+            logger.info("Unregistering worker (status=%s)", self.status)
             try:
                 await self._unregister()
             except OSError:
-                logger.exception("Failed to unregister")
+                logger.exception(
+                    "Failed to unregister (status=%s)", self.status, exc_info=True
+                )
                 if not self.reconnect:
                     await self.close(reason="nanny-unregister-failed")
                     return
@@ -542,7 +545,7 @@ class Nanny(ServerNode):
                 Status.closing_gracefully,
                 Status.failed,
             ):
-                logger.warning("Restarting worker")
+                logger.warning("Restarting worker (status=%s)", self.status)
                 await self.instantiate()
             elif self.status == Status.closing_gracefully:
                 await self.close(reason="nanny-close-gracefully")
@@ -728,13 +731,20 @@ class WorkerProcess:
             except OSError:
                 # This can only happen if the actual process creation failed, e.g.
                 # multiprocessing.Process.start failed. This is not tested!
-                logger.exception("Nanny failed to start process", exc_info=True)
+                logger.exception(
+                    "Nanny failed to start process (status=%s)",
+                    self.status,
+                    exc_info=True,
+                )
                 # NOTE: doesn't wait for process to terminate, just for terminate signal to be sent
                 await self.process.terminate()
                 self.status = Status.failed
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
+                logger.exception(
+                    "Worker failed to connect (status=%s)", self.status, exc_info=True
+                )
                 # NOTE: doesn't wait for process to terminate, just for terminate signal to be sent
                 await self.process.terminate()
                 self.status = Status.failed

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -535,6 +535,7 @@ class Nanny(ServerNode):
 
         try:
             if self.status not in (
+                Status.init,
                 Status.closing,
                 Status.closed,
                 Status.closing_gracefully,
@@ -733,9 +734,17 @@ class WorkerProcess:
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
-                # NOTE: doesn't wait for process to terminate, just for terminate signal to be sent
-                await self.process.terminate()
-                self.status = Status.failed
+                # The worker subprocess is already shutting down on its own after
+                # reporting the failure. Don't send it a SIGTERM: doing so races
+                # against its graceful exit and, if it is killed while holding a
+                # multiprocessing queue lock, deadlocks the parent-side queue
+                # feeder thread. Any lingering process is reaped by the following
+                # Nanny.close() -> WorkerProcess.kill().
+                # Guard the status transition: a concurrent mark_stopped() (fired
+                # by the process-exit callback) may already have moved us to
+                # Status.stopped and released resources; don't clobber that.
+                if self.status == Status.starting:
+                    self.status = Status.failed
                 raise
         finally:
             self.running.set()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -738,7 +738,7 @@ class WorkerProcess:
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
-                logger.exception("Worker failed to connect (status=%s)", self.status)
+                logger.error("Worker failed to connect (status=%s)", self.status)
                 # NOTE: doesn't wait for process to terminate, just for terminate signal
                 # to be sent
                 await self.process.terminate()

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -727,9 +727,7 @@ class WorkerProcess:
             except OSError:
                 # This can only happen if the actual process creation failed, e.g.
                 # multiprocessing.Process.start failed. This is not tested!
-                logger.exception(
-                    "Nanny failed to start process (status=%s)", self.status
-                )
+                logger.exception("Nanny failed to start process")
                 # NOTE: doesn't wait for process to terminate, just for terminate signal
                 # to be sent
                 await self.process.terminate()
@@ -738,7 +736,7 @@ class WorkerProcess:
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
-                logger.error("Worker failed to connect (status=%s)", self.status)
+                logger.error("Worker failed to connect")
                 # The process may have already exited and been released by
                 # mark_stopped() (fired by the process exit callback), in which
                 # case there's nothing left to terminate.

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -739,10 +739,22 @@ class WorkerProcess:
                 msg = await self._wait_until_connected(uid)
             except Exception:
                 logger.error("Worker failed to connect (status=%s)", self.status)
-                # NOTE: doesn't wait for process to terminate, just for terminate signal
-                # to be sent
-                await self.process.terminate()
-                self.status = Status.failed
+                # The process may have already exited and been released by
+                # mark_stopped() (fired by the process exit callback), in which
+                # case there's nothing left to terminate.
+                if self.process is not None:
+                    # NOTE: doesn't wait for process to terminate, just for terminate
+                    # signal to be sent
+                    await self.process.terminate()
+                # mark_stopped() may have run while we were awaiting terminate();
+                # it set the status to Status.stopped and released init_result_q,
+                # child_stop_q and process. Don't overwrite it with Status.failed:
+                # the following Nanny.close() -> WorkerProcess.kill() would skip
+                # its Status.stopped early exit, crash on the released queues, and
+                # leave the Nanny stuck in Status.closing, hanging every later
+                # close() call forever.
+                if self.status == Status.starting:
+                    self.status = Status.failed
                 raise
 
         finally:

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -536,6 +536,7 @@ class Nanny(ServerNode):
         try:
             if self.status not in (
                 Status.init,
+                Status.starting,
                 Status.closing,
                 Status.closed,
                 Status.closing_gracefully,
@@ -734,17 +735,9 @@ class WorkerProcess:
             try:
                 msg = await self._wait_until_connected(uid)
             except Exception:
-                # The worker subprocess is already shutting down on its own after
-                # reporting the failure. Don't send it a SIGTERM: doing so races
-                # against its graceful exit and, if it is killed while holding a
-                # multiprocessing queue lock, deadlocks the parent-side queue
-                # feeder thread. Any lingering process is reaped by the following
-                # Nanny.close() -> WorkerProcess.kill().
-                # Guard the status transition: a concurrent mark_stopped() (fired
-                # by the process-exit callback) may already have moved us to
-                # Status.stopped and released resources; don't clobber that.
-                if self.status == Status.starting:
-                    self.status = Status.failed
+                # NOTE: doesn't wait for process to terminate, just for terminate signal to be sent
+                await self.process.terminate()
+                self.status = Status.failed
                 raise
         finally:
             self.running.set()


### PR DESCRIPTION
Fix race conditions triggered when the worker fails to start (eg. in the test, due to a bad kwarg) and:

- the nanny would sometimes restart it, whereas a failure to start at all should never be retried; or
- the nanny would occasionally hang.