### PR TITLE
Don't dedupe span metadata by id() (fix flaky `test_collections_metadata`)

### DIFF
--- a/distributed/spans.py
+++ b/distributed/spans.py
@@ -134,7 +134,6 @@ class Span:
     __weakref__: Any
 
     __slots__ = tuple(__annotations__)
-    _metadata_seen: set[int] = set()
 
     def __init__(
         self,
@@ -171,11 +170,7 @@ class Span:
         return None
 
     def add_metadata(self, metadata: SpanMetadata) -> None:
-        """Add metadata to the span, e.g. code snippets"""
-        id_ = id(metadata)
-        if id_ in self._metadata_seen:
-            return
-        self._metadata_seen.add(id_)
+        """Add metadata to the span, e.g. computed collections"""
         if self._metadata is None:
             self._metadata = copy.deepcopy(metadata)
         else:
@@ -522,6 +517,9 @@ class SpansSchedulerExtension:
         """
         out = {}
         default_span = None
+        # All tasks of the same graph submission share the same metadata object.
+        # Add it only once per span.
+        metadata_added: set[Span] = set()
 
         for ts in tss:
             if ts.annotations is None:
@@ -546,7 +544,8 @@ class SpansSchedulerExtension:
 
             if code:
                 span._code[code] = None
-            if span_metadata:
+            if span_metadata and span not in metadata_added:
+                metadata_added.add(span)
                 span.add_metadata(span_metadata)
 
             # The span may be completely different from the one referenced by the


### PR DESCRIPTION
`Span.add_metadata` used a class-level id-based de-duplication system that was tracking the id of already seen metadata. However, `id` is volatile and can be reused by the CPython interpreter as soon as the original object with that id is dereferenced. This caused legitimate new metadata to be occasionally dropped.
This deduplication also grew unboundedly over the lifetime of the scheduler.

The only deduplication actually needed is within a single `observe_tasks` call, where all tasks of one graph submission share the same metadata object.