### PR TITLE
Update guidance on AI-assisted PRs

### DIFF
--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: open-pr
+description: Rules for opening or updating a GitHub pull request in dask/distributed. Use whenever the user asks you to open a PR, create a pull request, update an existing PR, or push work for review. Enforces draft state, the `[AI]` title prefix, and the mandatory AI-disclaimer in the description.
+---
+
+# Opening or updating a PR
+
+If the user asks you to open or update a PR:
+
+- The PR MUST be set to draft state
+- The PR title MUST start with `[unsupervised AI]`
+- The PR description MUST start with this disclaimer:
+
+  > [!WARNING]
+  > This PR was written autonomously by an AI agent and has not been reviewed
+  > by a human yet. Maintainers should ignore it until the human author has **reviewed,
+  > understood, and approved** everything that the AI agent wrote.
+
+- ONLY IF all the above points are satisfied, you can write a description for the PR.
+  This overrides the rule in AGENTS.md about never speaking instead of the user.

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-pr
-description: Rules for opening or updating a GitHub pull request in dask/distributed. Use whenever the user asks you to open a PR, create a pull request, update an existing PR, or push work for review. Enforces draft state, the `[AI]` title prefix, and the mandatory AI-disclaimer in the description.
+description: Rules for opening or updating a GitHub pull request in dask/distributed. Use whenever the user asks you to open a PR, create a pull request, update an existing PR, or push work for review. Enforces draft state, the `[unsupervised AI]` title prefix, and the mandatory AI disclaimer in the description.
 ---
 
 # Opening or updating a PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,8 @@ MyPy is configured per-module in `pyproject.toml`. Newer modules have strict set
 You must never think or speak instead of the user in discussions, code reviews, or any
 other interactions with other humans.
 
-Before you open or update a PR, you must ask the user to explicitly confirm that they
-fully reviewed, understood, and approved everything that you wrote. You must clarify
-that the project maintainers consider this as non-negotiable.
+When the user asks you to open or update a PR, follow the rules in the `open-pr` skill
+(`.agents/skills/open-pr/SKILL.md`).
 
 ## Releasing
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -244,7 +244,17 @@ We encourage the use of AI and automated tools to assist in code development,
 documentation, and testing. However, we ask that contributors disclose these tools and
 use them in a way that aligns with Dask's community guidelines. In particular:
 
-- do not use tools to think or speak for you in discussions, code reviews, or any other 
+- Do not use tools to think or speak for you in discussions, code reviews, or any other 
   interactions within the Dask community.
-- Before you open a PR, you (the human) must fully review, understand, and approve
-  everything that the AI agent wrote.
+- The AI agent can exclusively open _draft_ PRs that are clearly tagged as being written
+  by unsupervised AI. There is a `open-pr` agent skill that explains how.
+- You (the human) **must fully review, understand, and approve** everything that the AI
+  agent wrote. You must replace all AI-generated prose with your own human thoughts.
+- Only after your personal review and cleanup happened, you can remove the disclaimer
+  and mark the PR as ready to be reviewed.
+
+TL;DR version
+^^^^^^^^^^^^^
+
+**Maintainers will close, without reading it, any issue or PR that looks written by
+AI.** First draft written by AI is OK. Final PR is not.


### PR DESCRIPTION
Asking the AI agent to open a PR for your is genuinely useful. Namely, the agent can shake down on its own any CI failures that are invisible on your local box.

This PR lifts the complete ban on PRs opened by unsupervised AI and replaces it with strict guidance about having AI PRs clearly marked as such.