### PR TITLE
Don't lose worker startup exception when its process exit is observed first (flaky `test_local_cluster_redundant_kwarg`)

### DIFF
--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -721,6 +721,11 @@ class WorkerProcess:
         # See note in Nanny docstring.
         os.environ.update(self.pre_spawn_env)
 
+        # If the process dies, mark_stopped() (fired by the process exit callback)
+        # releases self.init_result_q. Hold a reference so that we can read the
+        # exception message that the process may have sent just before dying.
+        init_result_q = self.init_result_q
+
         try:
             try:
                 await self.process.start()
@@ -734,7 +739,7 @@ class WorkerProcess:
                 self.status = Status.failed
 
             try:
-                msg = await self._wait_until_connected(uid)
+                msg = await self._wait_until_connected(uid, init_result_q)
             except Exception:
                 logger.error("Worker failed to connect")
                 # The process may have already exited and been released by
@@ -758,7 +763,11 @@ class WorkerProcess:
         finally:
             self.running.set()
 
-        if msg:
+        # Don't set Status.running if the process already died: mark_stopped() set
+        # the status to Status.stopped and released the queues, and overwriting it
+        # would make the next kill() crash on the released queues, leaving the
+        # Nanny stuck in Status.closing (see comment above).
+        if msg and self.status == Status.starting:
             self.worker_address = msg["address"]
             self.worker_dir = msg["dir"]
             assert self.worker_address
@@ -879,15 +888,23 @@ class WorkerProcess:
                 return
             raise
 
-    async def _wait_until_connected(self, uid):
+    async def _wait_until_connected(self, uid, init_result_q):
         while True:
-            if self.status != Status.starting:
-                return
+            # Read the status *before* polling the queue: if the process failed to
+            # start a worker, it sends the exception through init_result_q, flushes
+            # the queue, and terminates. If mark_stopped() (fired by the process
+            # exit callback) flipped the status away from Status.starting, the
+            # message the process may have sent while dying is guaranteed to be
+            # readable now, so one last get_nowait() will not lose it.
+            stopped = self.status != Status.starting
+
             # This is a multiprocessing queue and we'd block the event loop if
             # we simply called get
             try:
-                msg = self.init_result_q.get_nowait()
+                msg = init_result_q.get_nowait()
             except Empty:
+                if stopped:
+                    return None
                 await asyncio.sleep(self._init_msg_interval)
                 continue
 

--- a/distributed/nanny.py
+++ b/distributed/nanny.py
@@ -763,10 +763,6 @@ class WorkerProcess:
         finally:
             self.running.set()
 
-        # Don't set Status.running if the process already died: mark_stopped() set
-        # the status to Status.stopped and released the queues, and overwriting it
-        # would make the next kill() crash on the released queues, leaving the
-        # Nanny stuck in Status.closing (see comment above).
         if msg and self.status == Status.starting:
             self.worker_address = msg["address"]
             self.worker_dir = msg["dir"]

--- a/distributed/tests/test_nanny.py
+++ b/distributed/tests/test_nanny.py
@@ -26,6 +26,7 @@ from distributed.core import CommClosedError, Status
 from distributed.diagnostics import SchedulerPlugin
 from distributed.diagnostics.plugin import NannyPlugin, WorkerPlugin
 from distributed.metrics import time
+from distributed.nanny import WorkerProcess
 from distributed.protocol.pickle import dumps
 from distributed.utils import TimeoutError, get_mp_context, parse_ports
 from distributed.utils_test import (
@@ -636,6 +637,33 @@ async def test_failure_during_worker_initialization(s):
         with pytest.raises(RuntimeError):
             await Nanny(s.address, foo="bar")
     assert "Restarting worker" not in logs.getvalue()
+
+
+@gen_cluster(nthreads=[])
+async def test_worker_start_exception_after_process_exit(s, monkeypatch):
+    """If the worker fails to start, the process sends the exception to the nanny
+    through init_result_q and terminates. The exception must not be lost if the
+    nanny observes the process exit before it reads the message from the queue
+    (flaky test_local_cluster_redundant_kwarg).
+    """
+    orig_wait_until_connected = WorkerProcess._wait_until_connected
+
+    async def wait_until_connected(self, *args, **kwargs):
+        # Force mark_stopped(), fired by the process exit callback, to win the
+        # race against the polling of init_result_q
+        await self.stopped.wait()
+        return await orig_wait_until_connected(self, *args, **kwargs)
+
+    monkeypatch.setattr(WorkerProcess, "_wait_until_connected", wait_until_connected)
+
+    with raises_with_cause(
+        RuntimeError,
+        "Nanny failed to start",
+        TypeError,
+        "unexpected keyword argument",
+    ):
+        async with Nanny(s.address, foo="bar"):
+            pass
 
 
 @gen_cluster(client=True, Worker=Nanny)


### PR DESCRIPTION
Fix race condition in `Nanny` when a worker fails to start.

Follow-up to #9313; fixes the remaining flakiness in `test_local_cluster_redundant_kwarg` ([example failure](https://github.com/dask/distributed/actions/runs/29014065862/job/86104523936?pr=9324)).

# In-depth commentary (AI-generated)
## Root cause

When the worker process fails to start, the child sends the startup exception to the Nanny through `init_result_q`, flushes the queue, and terminates. `WorkerProcess._wait_until_connected` polls that queue every 50ms and, in each iteration, first bails out with `None` if the status is no longer `Status.starting`. If `mark_stopped()` (fired by the process exit callback) flipped the status during one of the 50ms sleeps, before the poll picked up the message, the exception was lost: `instantiate()` returned `Status.stopped` and `Nanny.start_unsafe` raised a bare `RuntimeError("Nanny failed to start worker process")` instead of chaining from the worker's original exception, breaking the test's `raises_with_cause(RuntimeError, None, TypeError, "unexpected keyword argument")` expectation.

## Fix

- Poll `init_result_q` one last time after observing that the process stopped. The child always flushes the queue before exiting (`close()` + `join_thread()`), so by the time the exit callback has run, the message — if any — is guaranteed to be readable.
- Hold a local reference to `init_result_q` in `WorkerProcess.start()`, since `mark_stopped()` releases `self.init_result_q`.
- Don't overwrite the status with `Status.running` if the process already died: `mark_stopped()` set it to `Status.stopped` and released the queues, and overwriting it would make the next `kill()` crash on the released queues, leaving the Nanny stuck in `Status.closing` (same failure mode described in #9313).