### PR TITLE
Extend the fix (#9328)

### DIFF
--- a/distributed/dashboard/tests/test_scheduler_bokeh.py
+++ b/distributed/dashboard/tests/test_scheduler_bokeh.py
@@ -1099,16 +1099,16 @@ async def test_proxy_to_workers(c, s, a, b):
         assert response_direct.code == 200
         assert b"System" in response_direct.body
 
+    dashboard_port = s.http_server.port
+    http_client = AsyncHTTPClient()
+    unsafe_host = "<><><>"  # Some unsafe characters that should be escaped
+    proxy_url = f"http://localhost:{dashboard_port}/proxy/1234/{unsafe_host}/status"
+    response = await http_client.fetch(proxy_url, raise_error=False)
     if proxy_exists:
-        dashboard_port = s.http_server.port
-        http_client = AsyncHTTPClient()
-        unsafe_host = "<><><>"  # Some unsafe characters that should be escaped
-        proxy_url = f"http://localhost:{dashboard_port}/proxy/1234/{unsafe_host}/status"
-        response = await http_client.fetch(proxy_url, raise_error=False)
         assert response.code == 400
-        assert (
-            unsafe_host not in response.body.decode()
-        ), "Unsafe characters should be escaped"
+    assert unsafe_host not in response.body.decode(), (
+        "Unsafe characters should be escaped"
+    )
 
 
 @gen_cluster(

--- a/distributed/http/proxy.py
+++ b/distributed/http/proxy.py
@@ -97,9 +97,9 @@ except ImportError:
             self.extra = extra or {}
 
         def get(self, port, host, proxied_path):
-            worker_url = f"{host}:{port}/{proxied_path}"
+            worker_url = html.escape(f"{host}:{port}/{proxied_path}")
             msg = """
-                <p> Try navigating to <a href=http://{}>{}</a> for your worker dashboard </p>
+                <p> Try navigating to <a href="http://{}">{}</a> for your worker dashboard </p>
 
                 <p>
                 Dask tried to proxy you to that page through your


### PR DESCRIPTION
(cherry picked from commit 40fcd99a8cd41c39071a16a546e93a9298f1b64d)

Adapted to the old `.format` style instead of an f-string.