### PR TITLE
[unsupervised AI] fix: propagate task annotations during worker execution

### DIFF
--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -16,6 +16,7 @@ from distributed import (
     as_completed,
     get_client,
     get_worker,
+    span,
     wait,
     worker_client,
 )
@@ -327,6 +328,29 @@ async def test_compute_within_worker_client(c, s, a, b):
 
     result = await c.compute(f())
     assert result == 1
+
+
+@gen_cluster(client=True)
+async def test_nested_compute_inherits_task_annotations(c, s, a, b):
+    @dask.delayed
+    def read_annotations():
+        return dask.get_annotations()
+
+    @dask.delayed
+    async def read_annotations_async():
+        return dask.get_annotations()
+
+    def outer(value):
+        with span(str(value)), dask.annotate(custom=value):
+            expected = dask.get_annotations()
+            actual_sync = read_annotations().compute(optimize_graph=False)
+            actual_async = read_annotations_async().compute(optimize_graph=False)
+            return expected, actual_sync, actual_async
+
+    for value in (1, 2):
+        expected, actual_sync, actual_async = await c.submit(outer, value, pure=False)
+        assert actual_sync == expected
+        assert actual_async == expected
 
 
 @gen_cluster(client=True)

--- a/distributed/tests/test_worker_client.py
+++ b/distributed/tests/test_worker_client.py
@@ -332,6 +332,9 @@ async def test_compute_within_worker_client(c, s, a, b):
 
 @gen_cluster(client=True)
 async def test_nested_compute_inherits_task_annotations(c, s, a, b):
+    def read_task_annotations():
+        return dask.get_annotations()
+
     @dask.delayed
     def read_annotations():
         return dask.get_annotations()
@@ -348,6 +351,17 @@ async def test_nested_compute_inherits_task_annotations(c, s, a, b):
             return expected, actual_sync, actual_async
 
     for value in (1, 2):
+        with dask.annotate(custom=value):
+            task_annotations = await c.submit(
+                read_task_annotations,
+                pure=False,
+                workers=[a.address],
+                allow_other_workers=True,
+                priority=10,
+                retries=1,
+            )
+        assert task_annotations == {"custom": value}
+
         expected, actual_sync, actual_async = await c.submit(outer, value, pure=False)
         assert actual_sync == expected
         assert actual_async == expected

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -154,6 +154,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+_TASK_CONTROL_ANNOTATIONS = frozenset(
+    {
+        "allow_other_workers",
+        "executor",
+        "loose_restrictions",
+        "priority",
+        "resources",
+        "restrictions",
+        "retries",
+        "shuffle_original_restrictions",
+        "workers",
+    }
+)
+
 LOG_PDB = dask.config.get("distributed.admin.pdb-on-err")
 
 DEFAULT_EXTENSIONS: dict[str, type] = {
@@ -2164,10 +2179,16 @@ class Worker(BaseWorker, ServerNode):
                 )
 
             self.active_keys.add(key)
-            # Make resolved task annotations visible to user code and nested tasks.
+            # Propagate user annotations without applying the parent task's
+            # scheduling and execution controls to nested tasks.
+            annotations = {
+                key: value
+                for key, value in ts.annotations.items()
+                if key not in _TASK_CONTROL_ANNOTATIONS
+            }
             annotations_ctx = (
-                dask.annotate(**ts.annotations)
-                if ts.annotations
+                dask.annotate(**annotations)
+                if annotations
                 else contextlib.nullcontext()
             )
             annotations_ctx.__enter__()

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -2164,14 +2164,13 @@ class Worker(BaseWorker, ServerNode):
                 )
 
             self.active_keys.add(key)
-            # Propagate span (see distributed.spans). This is useful when spawning
-            # more tasks using worker_client() and for logging.
-            span_ctx = (
-                dask.annotate(span=ts.annotations["span"])
-                if "span" in ts.annotations
+            # Make resolved task annotations visible to user code and nested tasks.
+            annotations_ctx = (
+                dask.annotate(**ts.annotations)
+                if ts.annotations
                 else contextlib.nullcontext()
             )
-            span_ctx.__enter__()
+            annotations_ctx.__enter__()
             run_spec = ts.run_spec
             try:
                 ts.start_time = time()
@@ -2219,7 +2218,7 @@ class Worker(BaseWorker, ServerNode):
                         )
             finally:
                 self.active_keys.discard(key)
-                span_ctx.__exit__(None, None, None)
+                annotations_ctx.__exit__(None, None, None)
 
             self.threads[key] = result["thread"]
 


### PR DESCRIPTION
Fixes #9138

## What changed

- Enter resolved user annotation context while worker user code executes, instead of propagating only the span annotation.
- Keep scheduler and execution controls such as worker restrictions, resources, retries, and executor selection scoped to the parent task.
- Add regression coverage for nested synchronous and asynchronous delayed computations, sequential spans, and control-annotation isolation.

This lets nested distributed computations inherit user annotations without accidentally constraining child scheduling to the parent task.

## Verification

- `.venv/bin/python -m pytest -q distributed/tests/test_worker_client.py distributed/tests/test_spans.py`
  - 51 passed, 1 skipped (optional pandas dependency), 1 xpassed
- `.venv/bin/python -m pytest -q distributed/tests/test_actor.py::test_serialize_with_pickle`
  - 1 passed
- `.venv/bin/python -m pytest -q -o addopts='' -W default::pytest.PytestUnknownMarkWarning distributed/tests/test_client.py::test_secede_balances distributed/tests/test_worker.py::test_get_client`
  - 2 passed; local environment lacks the optional flaky-marker plugin
- `.venv/bin/python -m ruff check distributed/worker.py distributed/tests/test_worker_client.py`
- `.venv/bin/python -m ruff format --check distributed/worker.py distributed/tests/test_worker_client.py`
- `git diff --check`