### PR TITLE
Keep draining remote stdout and stderr in SSHCluster

### DIFF
--- a/distributed/deploy/ssh.py
+++ b/distributed/deploy/ssh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import logging
 import sys
@@ -28,6 +29,7 @@ class Process(ProcessInterface):
     def __init__(self, **kwargs):
         self.connection = None
         self.proc = None
+        self._logger_tasks: list[asyncio.Task] = []
         super().__init__(**kwargs)
 
     async def start(self):
@@ -35,9 +37,42 @@ class Process(ProcessInterface):
         weakref.finalize(
             self, self.proc.kill
         )  # https://github.com/ronf/asyncssh/issues/112
+        self._start_forwarding_output()
         await super().start()
 
+    def _start_forwarding_output(self) -> None:
+        """Keep draining the remote process' stdout and stderr.
+
+        Subclasses read stderr only until the remote process announces its address,
+        and never read stdout at all. Once that startup handshake is over nothing
+        consumes the SSH channel any more, so the receive window fills up and the
+        remote process blocks forever the next time it writes a log line.
+        """
+        assert self.proc
+        self._logger_tasks = [
+            asyncio.create_task(self._forward_output(stream))
+            for stream in (self.proc.stdout, self.proc.stderr)
+        ]
+
+    @staticmethod
+    async def _forward_output(stream: Any) -> None:
+        try:
+            while True:
+                line = await stream.readline()
+                if not line:  # EOF; the remote process exited
+                    break
+                logger.info(line.strip())
+        except Exception:
+            # The connection dropping is an expected way for this to end, and it is
+            # already reported through other channels; never let it surface here.
+            logger.debug("Stopped forwarding output from %r", stream, exc_info=True)
+
     async def close(self):
+        if self._logger_tasks:
+            for task in self._logger_tasks:
+                task.cancel()
+            await asyncio.gather(*self._logger_tasks, return_exceptions=True)
+            self._logger_tasks.clear()
         if self.proc:
             self.proc.kill()  # https://github.com/ronf/asyncssh/issues/112
         if self.connection:

--- a/distributed/deploy/tests/test_ssh.py
+++ b/distributed/deploy/tests/test_ssh.py
@@ -4,19 +4,87 @@ import pytest
 
 pytest.importorskip("asyncssh")
 
+import asyncio
 import sys
 
 import dask
 
 from distributed import Client
 from distributed.compatibility import MACOS, WINDOWS
-from distributed.deploy.ssh import SSHCluster
+from distributed.deploy.ssh import Scheduler, SSHCluster
 from distributed.utils_test import gen_test
 
 pytestmark = [
     pytest.mark.xfail(MACOS, reason="very high flakiness; see distributed/issues/4543"),
     pytest.mark.skipif(WINDOWS, reason="no CI support; see distributed/issues/4509"),
 ]
+
+
+# asyncssh.create_server leaks 2 fds on its own, independently of anything under test
+@pytest.mark.leaking("fds")
+@gen_test()
+async def test_remote_process_not_blocked_by_unread_output():
+    """The remote process must keep running once its startup banner has been read.
+
+    ``Scheduler.start`` reads stderr only until the remote announces its address and
+    never reads stdout at all. If nothing drains those streams afterwards, the SSH
+    receive window fills up and the remote process blocks forever the next time it
+    logs. See https://github.com/dask/distributed/issues/9033.
+
+    This drives the real ``ssh.Scheduler`` against an in-process asyncssh server, so
+    it exercises genuine SSH flow control without needing a reachable sshd.
+    """
+    import asyncssh
+
+    # Enough to overflow asyncssh's 2 MiB default channel window several times over.
+    chunk = "distributed.core - INFO - " + "x" * 4000 + "\n"
+    n_chunks = 1500
+    finished = asyncio.Event()
+
+    async def handle_process(process):
+        if process.command == "uname":
+            process.stdout.write("Linux\n")
+            process.exit(0)
+            return
+        process.stderr.write(
+            "distributed.scheduler - INFO - Scheduler at: tcp://127.0.0.1:8786\n"
+        )
+        await process.stderr.drain()
+        for _ in range(n_chunks):
+            process.stderr.write(chunk)
+            await process.stderr.drain()  # blocks once the peer window is exhausted
+        finished.set()
+        process.exit(0)
+
+    class _Server(asyncssh.SSHServer):
+        def begin_auth(self, username):
+            return False  # the test server does not authenticate
+
+    server = await asyncssh.create_server(
+        _Server,
+        "127.0.0.1",
+        0,
+        server_host_keys=[asyncssh.generate_private_key("ssh-ed25519")],
+        process_factory=handle_process,
+    )
+    try:
+        port = next(iter(server.sockets)).getsockname()[1]
+        scheduler = Scheduler(
+            address="127.0.0.1",
+            connect_options={"port": port, "known_hosts": None, "username": "test"},
+            kwargs={},
+        )
+        await scheduler.start()
+        connection = scheduler.connection
+        try:
+            assert scheduler.address == "tcp://127.0.0.1:8786"
+            await asyncio.wait_for(finished.wait(), timeout=30)
+        finally:
+            await scheduler.close()
+            await connection.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
 
 
 def test_ssh_hosts_None():


### PR DESCRIPTION
`SSHCluster` can deadlock after running for a while because the scheduler stops reading the remote process’s `stderr` once startup is complete. Eventually the pipe fills up, which blocks the remote process the next time it tries to write a log message.

This fix keeps draining both output streams for the entire lifetime of the process. I also added a regression test that hangs without the fix.

Closes #9033

### Behaviour note

Remote log lines are now forwarded for the whole life of the cluster at `logger.info`, matching what the existing startup loop already does. That surfaces remote logs that were previously lost after startup, but it is a visible change in log volume.

### Tests

The new test drives `ssh.Scheduler` against an in-process `asyncssh` server, so it exercises real SSH flow control without needing a reachable sshd. It writes past the 2 MiB default channel window after the startup banner and asserts the remote still finishes.

- Without the fix: `FAILED ... TimeoutError` after 30s
- With the fix: `1 passed in 0.72s`

Run locally on macOS:

- `pytest distributed/deploy/tests/test_ssh.py::test_remote_process_not_blocked_by_unread_output --leaks=fds,processes,threads` — 1 passed, no leaks
- `pytest distributed/deploy/tests/test_spec_cluster.py distributed/deploy/tests/test_cluster.py distributed/deploy/tests/test_subprocess.py` — 33 passed, 3 skipped
- `ruff check` / `ruff format --check` on both changed files — clean
- `mypy --warn-unused-configs distributed/deploy/ssh.py` — no new errors versus an unmodified checkout

`test_ssh.py` is `xfail` on macOS, so the tests needing a real sshd could not run locally. CI covered them: on `ubuntu-24.04-arm py312 test-ci not ci1` the new test passed along with `test_basic`, `test_n_workers`, `test_keywords`, `test_config_inherited_by_subprocess`, `test_list_of_connect_options` and `test_remote_python`.

The test carries `@pytest.mark.leaking("fds")` because `asyncssh.create_server` leaks 2 fds on its own, confirmed separately with a server-only test containing no code from this repository.

### Unrelated CI failure

The `pre-commit` job fails on `mypy` in `distributed/shuffle/tests/test_merge.py` and `test_shuffle.py`, which this PR does not touch. It fails identically on #9341 from 2026-08-05; the mypy hook installs `git+https://github.com/dask/dask` unpinned, so upstream drift made two `type: ignore` comments redundant. I have left those files alone to keep this PR in scope.

---

Disclosure: this change was developed with AI assistance.
