### PR TITLE
Ignore SciPy sparse matrix deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ filterwarnings = [
     # https://github.com/dask/dask-expr/issues/945
     '''ignore:dask_expr does not support the DataFrameIOFunction''',
     '''ignore:Please use `dok_matrix` from the `scipy\.sparse` namespace, the `scipy\.sparse\.dok` namespace is deprecated.:DeprecationWarning''',
+    '''ignore:\w+_matrix is being replaced by \w+_array\.:DeprecationWarning''',
     '''ignore:elementwise comparison failed. this will raise an error in the future:DeprecationWarning''',
     '''ignore:unclosed <socket\.socket.*:ResourceWarning''',
     '''ignore:unclosed context <zmq\.asyncio\.Context\(\).*:ResourceWarning''',


### PR DESCRIPTION
Relates to #9353.

SciPy 2.0 nightly warns whenever a sparse matrix class is instantiated, while Distributed promotes warnings to errors during testing. This patch adds a narrowly matched warning filter so the existing serializer test can continue covering all seven sparse matrix classes until SciPy removes them.

The filter only matches the `*_matrix is being replaced by *_array.` warning; unrelated deprecation warnings remain errors.

## Verification

- SciPy 2.0.0.dev0 / NumPy 2.6.0.dev0: 14 serializer cases failed before the change and 14 passed afterward.
- SciPy 1.18.1 / NumPy 2.5.2: all 14 serializer cases passed.
- A matching warning was filtered while an unrelated `DeprecationWarning` still failed as expected.
- `pyproject.toml` parses successfully and `git diff --check` passes.