### PR TITLE
Avoid external IP lookup for inproc addresses

### DIFF
--- a/distributed/comm/inproc.py
+++ b/distributed/comm/inproc.py
@@ -15,7 +15,6 @@ from tornado.ioloop import IOLoop
 from distributed.comm.core import BaseListener, Comm, CommClosedError, Connector
 from distributed.comm.registry import Backend, backends
 from distributed.protocol.serialize import _nested_deserialize
-from distributed.utils import get_ip
 
 logger = logging.getLogger(__name__)
 
@@ -38,10 +37,7 @@ class Manager:
     @property
     def ip(self):
         if not self._ip:
-            try:
-                self._ip = get_ip()
-            except OSError:
-                self._ip = "127.0.0.1"
+            self._ip = "127.0.0.1"
         return self._ip
 
     def add_listener(self, addr, listener):

--- a/distributed/comm/tests/test_comms.py
+++ b/distributed/comm/tests/test_comms.py
@@ -170,7 +170,7 @@ def test_get_address_host(tcp):
     f = get_address_host
 
     assert f("tcp://127.0.0.1:123") == "127.0.0.1"
-    assert f("inproc://%s/%d/123" % (get_ip(), os.getpid())) == get_ip()
+    assert f("inproc://127.0.0.1/%d/123" % os.getpid()) == "127.0.0.1"
 
 
 def test_resolve_address(tcp):
@@ -201,7 +201,7 @@ def test_get_local_address_for(tcp):
     if has_ipv6():
         assert f("tcp://[::1]:123") == "tcp://[::1]"
 
-    inproc_arg = "inproc://%s/%d/444" % (get_ip(), os.getpid())
+    inproc_arg = "inproc://127.0.0.1/%d/444" % os.getpid()
     inproc_res = f(inproc_arg)
     assert inproc_res.startswith("inproc://")
     assert inproc_res != inproc_arg
@@ -586,12 +586,11 @@ tls_eq = tcp_eq
 
 
 def inproc_check():
-    expected_ip = get_ip()
     expected_pid = os.getpid()
 
     def checker(loc):
         ip, pid, suffix = loc.split("/")
-        assert ip == expected_ip
+        assert ip == "127.0.0.1"
         assert int(pid) == expected_pid
 
     return checker

--- a/distributed/deploy/tests/test_local.py
+++ b/distributed/deploy/tests/test_local.py
@@ -151,6 +151,28 @@ def test_transports_inproc(loop):
             assert e.submit(inc, 4).result() == 5
 
 
+def test_transports_inproc_does_not_discover_external_ip(loop):
+    import distributed.comm.inproc
+
+    distributed.comm.inproc.global_manager._ip = None
+    with (
+        mock.patch(
+            "distributed.comm.inproc.get_ip",
+            side_effect=AssertionError("inproc should not discover an external IP"),
+            create=True,
+        ),
+        LocalCluster(
+            n_workers=1,
+            processes=False,
+            silence_logs=False,
+            dashboard_address=":0",
+            loop=loop,
+        ) as c,
+    ):
+        assert c.scheduler_address.startswith("inproc://127.0.0.1/")
+        assert c.workers[0].address.startswith("inproc://127.0.0.1/")
+
+
 def test_transports_tcp(loop):
     # Have nannies => need TCP
     with LocalCluster(

--- a/distributed/tests/test_core.py
+++ b/distributed/tests/test_core.py
@@ -281,12 +281,12 @@ async def test_server_listen():
 
     async with listen_on(Server, "inproc://") as server:
         inproc_addr1 = server.address
-        assert inproc_addr1.startswith("inproc://%s/%d/" % (get_ip(), os.getpid()))
+        assert inproc_addr1.startswith("inproc://127.0.0.1/%d/" % os.getpid())
         await assert_can_connect(inproc_addr1)
 
         async with listen_on(Server, "inproc://") as server2:
             inproc_addr2 = server2.address
-            assert inproc_addr2.startswith("inproc://%s/%d/" % (get_ip(), os.getpid()))
+            assert inproc_addr2.startswith("inproc://127.0.0.1/%d/" % os.getpid())
             await assert_can_connect(inproc_addr2)
 
         await assert_can_connect(inproc_addr1)


### PR DESCRIPTION
Fixes #8559.

This changes the inproc communication manager to use the loopback address as its local process identifier instead of calling get_ip(), which may try to discover a route to 8.8.8.8 and warn on offline machines. Since inproc addresses are only valid within the current process, no external IP discovery is needed.

Tests:
- python -m pytest distributed/deploy/tests/test_local.py::test_transports_inproc_does_not_discover_external_ip distributed/deploy/tests/test_local.py::test_transports_inproc distributed/deploy/tests/test_local.py::test_move_unserializable_data
- python -m pytest distributed/comm/tests/test_comms.py::test_get_address_host distributed/comm/tests/test_comms.py::test_get_local_address_for distributed/comm/tests/test_comms.py::test_inproc_client_server distributed/comm/tests/test_comms.py::test_inproc_addresses
- python -m ruff check distributed/comm/inproc.py