### PR TITLE
[unsupervised AI] Use the canonical NumPy inventory URL

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -395,7 +395,7 @@ extlinks = {
 # and the Numpy documentation.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
     "pandas": ("https://pandas.pydata.org/docs", None),
     "dask": ("https://docs.dask.org/en/latest", None),
     "bokeh": ("https://docs.bokeh.org/en/latest", None),


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

Related to #8850.

Point the NumPy intersphinx mapping directly at `https://numpy.org/doc/stable`. The existing `docs.scipy.org/doc/numpy` URL redirects there, adding a dependency on the old host. A [recent Read the Docs build](https://app.readthedocs.org/projects/distributed/builds/34401741/) completed Sphinx rendering but failed because fetching the inventory through that host timed out.

The direct official URL returned HTTP 200 with a valid NumPy Sphinx inventory; following the old redirect returned the same inventory bytes. Changed-file pre-commit hooks passed.

- [x] Tests added / passed (direct inventory verification; configuration-only change)
- [ ] Passes `pixi run lint`

