### PR TITLE
[unsupervised AI] Isolate CPU-time GC logging from RSS diagnostics

### DIFF
--- a/distributed/tests/test_gc.py
+++ b/distributed/tests/test_gc.py
@@ -91,7 +91,7 @@ def enable_gc_diagnosis_and_log(diag, level="INFO"):
 
 # @pytest.mark.slow
 def test_gc_diagnosis_cpu_time():
-    diag = GCDiagnosis(info_over_frac=0.75)
+    diag = GCDiagnosis(info_over_frac=0.75, info_over_rss_win=float("inf"))
     diag.N_SAMPLES = 3  # shorten tests
 
     with enable_gc_diagnosis_and_log(diag, level="INFO") as sio:


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

`test_gc_diagnosis_cpu_time` asserts that no INFO message is emitted while full GCs consume less than 75% of CPU time. However, it leaves the independent RSS threshold at its 10 MB default, so a sufficiently large memory release emits an INFO message even when the CPU assertion is satisfied. A [Windows Python 3.11 run](https://github.com/dask/distributed/actions/runs/33932941750/job/101215478977) failed this assertion after a GC released 12.86 MiB, exceeding the 9.54 MiB RSS threshold.

Set the RSS threshold to infinity for this CPU-specific test. Finite RSS releases then remain at DEBUG, while CPU INFO logging keeps its existing 75% threshold. Production defaults and the separate RSS test are unchanged.

Validation on macOS ARM64 with Python 3.12:

- `pytest -q distributed/tests/test_gc.py`: 2 passed, 1 xfailed (the existing flaky RSS test).
- CPU test in five separate pytest processes: all passed.
- A controlled callback probe with a 20 MB RSS release reproduced the unwanted RSS INFO at 50% CPU under the default threshold, produced no INFO with the infinite RSS threshold, and still emitted CPU INFO at 90% CPU.
- Pre-commit hooks for `distributed/tests/test_gc.py`: Ruff check/format and Mypy passed; `git diff --check` passed.
