### PR TITLE
Document that start is run as soon as SchedulerPlugin is registered

### DIFF
--- a/distributed/diagnostics/plugin.py
+++ b/distributed/diagnostics/plugin.py
@@ -78,7 +78,8 @@ class SchedulerPlugin:
     async def start(self, scheduler: Scheduler) -> None:
         """Run when the scheduler starts up
 
-        This runs at the end of the Scheduler startup process
+        This runs at the end of the Scheduler startup process,
+        or immediately upon registering the plugin, if Scheduler has already started.
         """
 
     async def before_close(self) -> None:


### PR DESCRIPTION
I was confused as to how SchedulerPlugin's `start` method would be run.
Since module some advanced stuff like `preload` scripts, most of the time by the time you have access to a `Client` object to call `register_plugin` on, the `Scheduler` has already started.
Then i checked the code and saw that `start` is also run when a plugin is registered.
https://github.com/dask/distributed/blob/dc182bda54af488d029f2c40db0893d5f48e69d5/distributed/scheduler.py#L6261


- [x] Tests added / passed
(N/A docs only)
- [x] Passes `pixi run lint`
